### PR TITLE
fix: set author/committer for verified commits

### DIFF
--- a/.github/workflows/slow-bot.yml
+++ b/.github/workflows/slow-bot.yml
@@ -58,6 +58,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
+          author: nullvariant-slow[bot] <2610174+nullvariant-slow[bot]@users.noreply.github.com>
+          committer: nullvariant-slow[bot] <2610174+nullvariant-slow[bot]@users.noreply.github.com>
           commit-message: |
             🦥 ...zzz... updated wisdom
 


### PR DESCRIPTION
### **User description**
## Summary
- Add explicit `author` and `committer` fields to peter-evans/create-pull-request
- Ensures commits are attributed to nullvariant-slow[bot] and properly verified

## Background
PR #41's commit was unsigned because author/committer defaulted to github-actions[bot].

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Set explicit author and committer for verified commits

- Ensures commits attributed to nullvariant-slow[bot]

- Fixes unsigned commit issue from previous PR


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["create-pull-request action"] -- "add author field" --> B["nullvariant-slow[bot] attribution"]
  A -- "add committer field" --> B
  B -- "ensures" --> C["verified commits"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>slow-bot.yml</strong><dd><code>Add author and committer fields to PR action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/slow-bot.yml

<ul><li>Added explicit <code>author</code> field to peter-evans/create-pull-request action<br> <li> Added explicit <code>committer</code> field to peter-evans/create-pull-request <br>action<br> <li> Both fields set to nullvariant-slow[bot] with proper email format<br> <li> Ensures commits are properly attributed and verified</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/42/files#diff-9c8a5286a78f5e3fbee1586d4642e8210664874b79650ee53eeb02e38ba5036d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

