### PR TITLE
fix: enable sign-commits for verified signatures

### DIFF
--- a/.github/workflows/slow-bot.yml
+++ b/.github/workflows/slow-bot.yml
@@ -58,6 +58,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
           author: nullvariant-slow[bot] <2610174+nullvariant-slow[bot]@users.noreply.github.com>
           committer: nullvariant-slow[bot] <2610174+nullvariant-slow[bot]@users.noreply.github.com>
           commit-message: |


### PR DESCRIPTION
### **User description**
## Summary
- Add `sign-commits: true` to peter-evans/create-pull-request
- Commits will be created via GitHub API and automatically verified

## Background
Previous attempts (PRs #41, #43) had unsigned commits because the action
used git commands instead of the GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Enable GPG commit signing in GitHub Actions workflow

- Commits created via GitHub API are automatically verified

- Resolves previous unsigned commit issues in PRs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Workflow"] -->|"add sign-commits: true"| B["peter-evans/create-pull-request"]
  B -->|"creates commits via API"| C["GPG-verified commits"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>slow-bot.yml</strong><dd><code>Enable GPG signing for automated PR commits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/slow-bot.yml

<ul><li>Added <code>sign-commits: true</code> parameter to create-pull-request action<br> <li> Enables automatic GPG signing of commits created via GitHub API<br> <li> Ensures commits are cryptographically verified and signed</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/44/files#diff-9c8a5286a78f5e3fbee1586d4642e8210664874b79650ee53eeb02e38ba5036d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

