### PR TITLE
fix(ci): attach SLSA Provenance bundle to GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,14 +40,38 @@ jobs:
         run: npm run package
         working-directory: extensions/git-id-switcher
 
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/git-id-switcher-v}" >> $GITHUB_OUTPUT
+
+      # SLSA Provenance: Generate attestation via GitHub Attestation API
+      # This creates verifiable build provenance for supply chain security
       - name: Generate SLSA Provenance attestation
+        id: provenance
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
         with:
           subject-path: extensions/git-id-switcher/*.vsix
 
-      - name: Get version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/git-id-switcher-v}" >> $GITHUB_OUTPUT
+      # Copy the provenance bundle to release assets for OpenSSF Scorecard detection
+      # The bundle is also stored in GitHub Attestation API for `gh attestation verify`
+      - name: Prepare provenance for release
+        run: |
+          BUNDLE_PATH="${{ steps.provenance.outputs.bundle-path }}"
+          DEST_PATH="extensions/git-id-switcher/git-id-switcher-${{ steps.version.outputs.version }}.vsix.intoto.jsonl"
+
+          if [ -z "$BUNDLE_PATH" ]; then
+            echo "::error::Provenance bundle path is empty"
+            exit 1
+          fi
+
+          if [ ! -f "$BUNDLE_PATH" ]; then
+            echo "::error::Provenance bundle file not found: $BUNDLE_PATH"
+            exit 1
+          fi
+
+          cp "$BUNDLE_PATH" "$DEST_PATH"
+          echo "Provenance bundle copied to: $DEST_PATH"
+          ls -la "$DEST_PATH"
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -58,7 +82,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          files: extensions/git-id-switcher/*.vsix
+          files: |
+            extensions/git-id-switcher/*.vsix
+            extensions/git-id-switcher/*.intoto.jsonl
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **User description**
## Summary
- Attach `.intoto.jsonl` provenance file to release assets for OpenSSF Scorecard detection
- Provenance is also stored in GitHub Attestation API (`gh attestation verify`)
- Add error handling for bundle-path validation

## Why
OpenSSF Scorecard's Signed-Releases check looks for provenance files in release assets. The current GitHub Attestation API approach isn't reliably detected by Scorecard.

## Changes
- Reorder steps to get version before provenance generation
- Copy provenance bundle to release directory with proper naming
- Include `.intoto.jsonl` in release assets alongside `.vsix`

## Test plan
- [ ] Merge this PR
- [ ] Create tag `git-id-switcher-v0.10.37`
- [ ] Verify release contains both `.vsix` and `.intoto.jsonl` files


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Attach SLSA Provenance bundle (`.intoto.jsonl`) to GitHub release assets

- Add error handling for provenance bundle path validation

- Reorder workflow steps to get version before provenance generation

- Enable OpenSSF Scorecard detection of signed releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Package Extension"] --> B["Get Version from Tag"]
  B --> C["Generate SLSA Provenance"]
  C --> D["Prepare Provenance for Release"]
  D --> E["Validate Bundle Path"]
  E --> F["Copy to Release Assets"]
  F --> G["Create GitHub Release"]
  G --> H["Release with .vsix + .intoto.jsonl"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish.yml</strong><dd><code>Add provenance bundle to release assets with validation</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish.yml

<ul><li>Reordered workflow steps to extract version before provenance <br>generation<br> <li> Added new step to prepare and validate provenance bundle with error <br>handling<br> <li> Implemented validation checks for bundle path existence and non-empty <br>values<br> <li> Updated release file glob pattern to include <code>.intoto.jsonl</code> provenance <br>files<br> <li> Added explanatory comments for SLSA Provenance and Scorecard detection</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/59/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7">+30/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

