### PR TITLE
chore: release v0.10.37

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.37] - 2026-01-08
+
+### Changed
+
+- **CI/CD: Attach SLSA Provenance to releases**
+  - Provenance bundle (`.intoto.jsonl`) now included in release assets
+  - Enables OpenSSF Scorecard Signed-Releases detection
+  - Provenance also stored in GitHub Attestation API for `gh attestation verify`
+
 ## [0.10.36] - 2026-01-08
 
 ### Added

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.10.36",
+  "version": "0.10.37",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {


### PR DESCRIPTION
### **User description**
## Summary
- Bump version to 0.10.37
- Add CHANGELOG entry for SLSA Provenance release assets

## Test plan
- [ ] Merge this PR
- [ ] Create tag `git-id-switcher-v0.10.37`
- [ ] Verify release contains `.vsix` and `.intoto.jsonl` files


___

### **PR Type**
Other


___

### **Description**
- Bump version from 0.10.36 to 0.10.37

- Add CHANGELOG entry for SLSA Provenance release assets

- Document CI/CD improvements for release security


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version 0.10.36"] -- "bump version" --> B["Version 0.10.37"]
  B -- "add CHANGELOG entry" --> C["SLSA Provenance documentation"]
  C -- "includes" --> D["intoto.jsonl in releases"]
  D -- "enables" --> E["OpenSSF Scorecard detection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump extension version to 0.10.37</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/package.json

- Update version field from 0.10.36 to 0.10.37


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/60/files#diff-df2ff0ced7db6a80bf6b63d774a1d1c816f4c292e9d1d6526bf11e481a2c59b2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document v0.10.37 SLSA Provenance release changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/CHANGELOG.md

<ul><li>Add new section for version 0.10.37 release dated 2026-01-08<br> <li> Document SLSA Provenance attachment to release assets<br> <li> Note inclusion of <code>.intoto.jsonl</code> provenance bundle in releases<br> <li> Highlight OpenSSF Scorecard and GitHub Attestation API integration</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/60/files#diff-b59256585854bdd2d670ae154a3649ccddca95a22825a3aea473bbc1c132f2c6">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

