### PR TITLE
fix(ci): correct codecov path mapping for monorepo

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,9 +12,10 @@ coverage:
         target: auto
 
 # Fix path mapping for monorepo structure
+# lcov.info contains paths like "out/commandAllowlist.js"
+# Source files are at "extensions/git-id-switcher/src/commandAllowlist.ts"
 fixes:
-  - "out/::" # Remove out/ prefix from paths
-  - "extensions/git-id-switcher/out/::extensions/git-id-switcher/src/" # Map compiled to source
+  - "out/::extensions/git-id-switcher/src/"
 
 # Ignore test files from coverage
 ignore:


### PR DESCRIPTION
### **User description**
## Summary
- Fix codecov.yml path mapping to correctly map compiled JS files to source TS files
- Change `out/::` to `out/::extensions/git-id-switcher/src/` for proper repository path

## Problem
Codecov was showing 0% coverage despite actual coverage being ~64%. The path mapping was incorrect:
- lcov.info contains: `out/commandAllowlist.js`
- Source files are at: `extensions/git-id-switcher/src/commandAllowlist.ts`
- Previous mapping only removed prefix, resulting in unmappable paths

## Test plan
- [ ] PR CI passes
- [ ] After merge, check Codecov dashboard shows correct coverage (~64%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix codecov path mapping for monorepo structure

- Map compiled JS files to source TS files correctly

- Simplify path transformation from two rules to one

- Add clarifying comments about path mapping logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["lcov.info paths<br/>out/commandAllowlist.js"] -->|"old mapping<br/>two rules"| B["unmapped paths"]
  A -->|"new mapping<br/>single rule"| C["extensions/git-id-switcher/src/<br/>commandAllowlist.js"]
  C --> D["correct coverage<br/>detection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codecov.yml</strong><dd><code>Simplify and fix codecov path mapping rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codecov.yml

<ul><li>Consolidated two path mapping rules into single rule: <br><code>out/::extensions/git-id-switcher/src/</code><br> <li> Removed incorrect prefix-only removal rule that left paths unmappable<br> <li> Added clarifying comments explaining lcov.info paths and source file <br>locations<br> <li> Maintains existing coverage thresholds and test file ignore patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/67/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

