### PR TITLE
fix(ci): enable source maps for accurate Codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,13 +12,12 @@ coverage:
         target: auto
 
 # Fix path mapping for monorepo structure
-# lcov.info contains paths like "out/commandAllowlist.js"
-# Source files are at "extensions/git-id-switcher/src/commandAllowlist.ts"
+# With sourceMap enabled, lcov.info contains paths like "src/commandAllowlist.ts"
+# These need to be mapped to full repository paths
 fixes:
-  - "out/::extensions/git-id-switcher/src/"
+  - "src/::extensions/git-id-switcher/src/"
 
 # Ignore test files from coverage
 ignore:
   - "**/*.test.ts"
   - "**/test/**"
-  - "**/out/test/**"

--- a/extensions/git-id-switcher/tsconfig.json
+++ b/extensions/git-id-switcher/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "sourceMap": true,
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",


### PR DESCRIPTION
### **User description**
## Summary
- Enable TypeScript source maps for accurate coverage reporting
- Fix codecov.yml path mapping to use src/ instead of out/
- Remove redundant ignore pattern

## Problem
Codecov was showing 0% coverage despite actual coverage being ~64%. The root cause:
1. Coverage reports contained compiled JS paths (`out/*.js`)
2. These paths couldn't be mapped to TypeScript source files
3. Codecov couldn't find matching source files in the repository

## Solution
1. Enable `sourceMap: true` in tsconfig.json
   - c8 now reports coverage for TypeScript source files (`src/*.ts`)
   - .js.map files are excluded from git (`out/`) and vsix (`*.map`)
2. Update codecov.yml path mapping: `src/` -> `extensions/git-id-switcher/src/`
3. Remove redundant `**/out/test/**` pattern (covered by `**/test/**`)

## Test plan
- [ ] PR CI passes
- [ ] After merge, check Codecov dashboard shows correct coverage (~64%)

## Verification
Local test confirms lcov.info now contains TypeScript paths:
\`\`\`
SF:src/commandAllowlist.ts
SF:src/validation.ts
...
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Enable TypeScript source maps in tsconfig.json for accurate coverage

- Update codecov.yml path mapping from compiled JS to TypeScript sources

- Remove redundant ignore pattern for test files in coverage config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TypeScript Source Files"] -->|"sourceMap: true"| B["Coverage Reports with TS Paths"]
  B -->|"src/ → extensions/git-id-switcher/src/"| C["Codecov Path Mapping"]
  C -->|"Accurate Coverage"| D["Codecov Dashboard"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tsconfig.json</strong><dd><code>Enable TypeScript source map generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/tsconfig.json

<ul><li>Add <code>sourceMap: true</code> compiler option to enable TypeScript source map <br>generation<br> <li> Allows c8 coverage tool to report coverage for TypeScript source files <br>instead of compiled JavaScript</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/68/files#diff-bf814eebe4a69550d90a878ee73bf94e8291d286043a0b48b388c22c04de79ad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codecov.yml</strong><dd><code>Update codecov path mapping for source files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codecov.yml

<ul><li>Update path mapping from <code>out/</code> (compiled JS) to <code>src/</code> (TypeScript <br>sources)<br> <li> Update comment to reflect new source map-based coverage reporting<br> <li> Remove redundant <code>**/out/test/**</code> ignore pattern already covered by <br><code>**/test/**</code></ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/68/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

