### PR TITLE
chore(release): v0.10.43 - Karesansui Architecture

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.43] - 2026-01-10
+
+### Added
+
+- **Karesansui Architecture Documentation**
+  - Added `docs/DESIGN_PHILOSOPHY.md` with full design philosophy poem
+  - Documents the "Karesansui (Zen Garden) Architecture" approach
+  - Explains core concepts: Stone (core), Sand Patterns (quality), Accents (differentiation), and Stones We Don't Place (intentional constraints)
+
+- **Design Philosophy Section in READMEs**
+  - Added Design Philosophy section to all 26 language README files
+  - Each section includes localized summary and link to full philosophy
+
+- **Karesansui Architecture Badge**
+  - Added clickable badge (🪨 Karesansui | Architecture) to header section of all READMEs
+  - Badge links to DESIGN_PHILOSOPHY.md
+  - Multiple badge style samples available in DESIGN_PHILOSOPHY.md
+
 ## [0.10.42] - 2026-01-09
 
 ### Added

--- a/extensions/git-id-switcher/package-lock.json
+++ b/extensions/git-id-switcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-id-switcher",
-  "version": "0.10.39",
+  "version": "0.10.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-id-switcher",
-      "version": "0.10.39",
+      "version": "0.10.43",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.10.42",
+  "version": "0.10.43",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {


### PR DESCRIPTION
### **User description**
## Release v0.10.43

### Added

- **Karesansui Architecture Documentation**
  - Added `docs/DESIGN_PHILOSOPHY.md` with full design philosophy poem
  - Documents the "Karesansui (Zen Garden) Architecture" approach
  - Explains core concepts: Stone (core), Sand Patterns (quality), Accents (differentiation), and Stones We Don't Place (intentional constraints)

- **Design Philosophy Section in READMEs**
  - Added Design Philosophy section to all 26 language README files
  - Each section includes localized summary and link to full philosophy

- **Karesansui Architecture Badge**
  - Added clickable badge (🪨 Karesansui | Architecture) to header section of all READMEs
  - Badge links to DESIGN_PHILOSOPHY.md
  - Multiple badge style samples available in DESIGN_PHILOSOPHY.md

## Checklist
- [x] CHANGELOG.md updated
- [x] package.json version bumped to 0.10.43
- [ ] Merge this PR
- [ ] Create and push tag: `git tag git-id-switcher-v0.10.43 && git push origin git-id-switcher-v0.10.43`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Release v0.10.43 with Karesansui Architecture documentation

- Added DESIGN_PHILOSOPHY.md explaining Zen Garden architecture approach

- Updated all 26 language READMEs with design philosophy sections

- Added Karesansui Architecture badge to README headers

- Bumped package version to 0.10.43


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release v0.10.43"] --> B["DESIGN_PHILOSOPHY.md"]
  A --> C["26 Language READMEs"]
  A --> D["Karesansui Badge"]
  B --> E["Zen Garden Architecture"]
  C --> F["Design Philosophy Sections"]
  D --> G["Links to Philosophy"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Added v0.10.43 release notes to changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/CHANGELOG.md

<ul><li>Added v0.10.43 release entry with date 2026-01-10<br> <li> Documented three main additions: Karesansui Architecture <br>Documentation, Design Philosophy sections in READMEs, and Architecture <br>badge<br> <li> Included detailed descriptions of core concepts and implementation <br>details</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/103/files#diff-b59256585854bdd2d670ae154a3649ccddca95a22825a3aea473bbc1c132f2c6">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Updated package version to 0.10.43</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/package.json

- Bumped version from 0.10.42 to 0.10.43


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/103/files#diff-df2ff0ced7db6a80bf6b63d774a1d1c816f4c292e9d1d6526bf11e481a2c59b2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

