### PR TITLE
ci: disable pre-commit.ci autofix commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,12 @@
 # Pre-commit configuration
 # https://pre-commit.com/
-# Bot: pre-commit-ci[bot] will auto-fix and commit changes
+# Bot: pre-commit-ci[bot] reports errors only (no auto-fix commits)
+# Reason: Bot commits are unverified; only GPG-signed commits allowed
 
 ci:
   autofix_commit_msg: |
     [pre-commit.ci] auto fixes from pre-commit hooks
-  autofix_prs: true
+  autofix_prs: false
   autoupdate_branch: ''
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
   autoupdate_schedule: weekly


### PR DESCRIPTION
## Summary

- Disable `autofix_prs` in pre-commit.ci configuration
- Bot commits from pre-commit.ci are unverified (no GPG signature)
- This repository requires all commits to be GPG-signed

## Changes

- Set `autofix_prs: false` in `.pre-commit-config.yaml`
- pre-commit.ci will now only report errors without making commits
- Fixes must be applied manually by contributors with GPG keys

## Rationale

Unverified bot commits cannot be merged into protected branches that require signed commits. By disabling autofix, we ensure all commits in this repository maintain GPG signature verification.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)