### PR TITLE
docs: add karesansui-style code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Garden Etiquette
+
+This repository is a karesansui--a garden that expresses the universe through sand and stone.
+
+> For the full philosophy, see [Karesansui Architecture](extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md)
+
+---
+
+## Principles
+
+*In karesansui: the stone is core function, sand patterns are invisible quality, accents are delightful details.*
+
+**Discern the stone** -- Question the essence; do not place a stone that cannot answer
+
+**Rake every sand pattern** -- Invest time in invisible quality
+
+**Appreciate accents** -- Welcome beauty that seems "wasteful"
+
+**Protect empty space** -- Not placing is also a decision
+
+---
+
+## Welcome in This Garden
+
+- Thoughtful dialogue
+- Beautiful code
+- Respect for "excessive" quality
+
+---
+
+## Not Welcome in This Garden
+
+Beyond disruptive behavior (harassment, trolling, personal attacks), the following values do not belong here:
+
+- **"If it works, it's fine"** -- A stone does not shine by merely functioning
+- **"Quick profit"** -- No one questions ROI in a hobby garden
+- **"Eliminate waste"** -- In this garden, sand patterns and accents are not waste
+
+What the world considers right may not be welcome here.
+
+---
+
+## Contact
+
+For questions or concerns: <contact@nullvariant.com>
+
+---
+
+*This garden exists for the satisfaction of its maker.*
+
+---
+
+*This is an original code of conduct based on the [karesansui philosophy](extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md), inspired by but not adapted from the [Contributor Covenant](https://www.contributor-covenant.org/).*


### PR DESCRIPTION
## Summary

Add "Garden Etiquette" - an original code of conduct based on the karesansui architecture philosophy.

## Key Principles

- **Discern the stone** -- Question essence before implementation
- **Rake every sand pattern** -- Invest in invisible quality
- **Appreciate accents** -- Welcome beautiful "waste"
- **Protect empty space** -- Not adding is also a decision

## Notable Aspects

This code of conduct explicitly rejects common "pragmatic" values:

- "If it works, it's fine" -- A stone does not shine by merely functioning
- "Quick profit" -- No one questions ROI in a hobby garden
- "Eliminate waste" -- Sand patterns and accents are not waste here

## Attribution

This is an original document inspired by, but not adapted from, the [Contributor Covenant](https://www.contributor-covenant.org/). It links to [DESIGN_PHILOSOPHY.md](extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md) for full context.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)