### PR TITLE
test: add operationGuard tests to test runner

### DIFF
--- a/extensions/git-id-switcher/src/test/runTests.ts
+++ b/extensions/git-id-switcher/src/test/runTests.ts
@@ -21,6 +21,7 @@ import { runConfigChangeDetectorTests } from './configChangeDetector.test';
 import { runCommandAllowlistTests } from './commandAllowlist.test';
 import { runDocumentationTests } from './documentation.test';
 import { runWorkspaceTrustTests } from './workspaceTrust.test';
+import { runOperationGuardTests } from './operationGuard.test';
 
 async function main(): Promise<void> {
   console.log('╔════════════════════════════════════════════╗');
@@ -78,6 +79,9 @@ async function main(): Promise<void> {
 
     // Run workspace trust tests
     await runWorkspaceTrustTests();
+
+    // Run operation guard tests
+    await runOperationGuardTests();
 
     console.log('╔════════════════════════════════════════════╗');
     console.log('║   🎉 All Security Tests Passed!            ║');


### PR DESCRIPTION
## Summary
- Add missing `operationGuard.test.ts` import and execution to `runTests.ts`
- Ensures operation guard tests are included in the test suite
- Improves test coverage from 92.82% to 93.15%

## Test plan
- [x] `npm test` passes with all tests including operation guard tests
- [x] `npm run test:coverage` shows 93.15% coverage (above 90% requirement)
- [x] `npm run lint` passes with no errors
- [x] `npm run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)