### PR TITLE
fix: treat empty string as "not set" for optional fields

### DIFF
--- a/extensions/git-id-switcher/src/configSchema.ts
+++ b/extensions/git-id-switcher/src/configSchema.ts
@@ -129,7 +129,10 @@ function validateProperty(
   errors: SchemaError[]
 ): void {
   // Type check
-  if (value !== undefined && value !== null) {
+  // Empty string is treated as "not set" for optional fields.
+  // This allows default config with "" values to pass validation without errors.
+  // SECURITY: Required fields (id, name, email) are still protected via else-if below.
+  if (value !== undefined && value !== null && value !== '') {
     if (typeof value !== schema.type) {
       errors.push({
         field,


### PR DESCRIPTION
## Summary

- Empty strings in default config (`service`, `sshKeyPath`, `sshHost`, `gpgKeyId`) were causing validation errors on first install
- This change treats empty strings as "not set" for optional fields
- Required fields (id, name, email) remain protected via existing else-if logic

## Test plan

- [x] Existing tests pass (`npm test`)
- [x] Self-review completed (3 rounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)