### PR TITLE
fix: exclude tests and docs from SonarCloud duplication detection

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+# SonarCloud Configuration
+# https://docs.sonarcloud.io/advanced-setup/analysis-parameters/
+
+sonar.projectKey=nullvariant_nullvariant-vscode-extensions
+sonar.organization=nullvariant
+
+# Exclude test files and documentation from duplication detection
+# Test code: duplication is acceptable for readability and isolation
+# Documentation: multi-language versions SHOULD have identical structure
+sonar.cpd.exclusions=**/test/**,**/docs/**,**/*.test.ts,**/*.spec.ts,**/README.md
+
+# Source encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Add `sonar-project.properties` to configure SonarCloud analysis
- Exclude test files and documentation from duplication detection

## Rationale
Test code and documentation follow different best practices than production code:
- **Test files**: Duplication is acceptable for readability and test isolation
- **Documentation**: Multi-language READMEs SHOULD have identical structure (that's the point of translations)

## Changes
- Created `sonar-project.properties` with `sonar.cpd.exclusions` for:
  - `**/test/**`
  - `**/docs/**`
  - `**/*.test.ts`
  - `**/*.spec.ts`
  - `**/README.md`

## Related
- Fixes Quality Gate failure from PR #130 (14.4% duplication on new code)