### PR TITLE
security: fix script injection vulnerability in bot workflows

### DIFF
--- a/.github/workflows/blaze-bot.yml
+++ b/.github/workflows/blaze-bot.yml
@@ -43,26 +43,36 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # SECURITY: Use environment variable to prevent script injection
+      # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injection
       - name: 📝 Leave a fired-up message
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         run: |
           mkdir -p docs
-          cat > docs/BLAZE.md << EOF
+          cat > docs/BLAZE.md << 'EOF'
           # 🐗 Blaze's Battle Cry
 
           > "Don't think, just DO IT!"
 
           ## Today's War Cry
 
-          ${{ github.event.inputs.message }}
+          EOF
+          printf '%s\n' "${USER_MESSAGE}" >> docs/BLAZE.md
+          cat >> docs/BLAZE.md << 'EOF'
 
           ---
 
-          *Last charged: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*
+          EOF
+          echo "*Last charged: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*" >> docs/BLAZE.md
+          cat >> docs/BLAZE.md << 'EOF'
 
           > よっしゃ！デプロイしまくるぞ！
           EOF
 
       - name: 📬 Create PR with verified commit
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -72,7 +82,7 @@ jobs:
           commit-message: |
             🐗 CHARGE!!! Updated battle cry
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             NO RETREAT! FULL SPEED AHEAD!
           branch: blaze/charge-${{ github.run_number }}
@@ -81,7 +91,7 @@ jobs:
           body: |
             ## 🐗 LETS GOOOO!!!
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ---
 

--- a/.github/workflows/ciel-bot.yml
+++ b/.github/workflows/ciel-bot.yml
@@ -43,26 +43,36 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # SECURITY: Use environment variable to prevent script injection
+      # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injection
       - name: 📝 Leave a peaceful message
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         run: |
           mkdir -p docs
-          cat > docs/CIEL.md << EOF
+          cat > docs/CIEL.md << 'EOF'
           # 🕊️ Ciel's Sky Notes
 
           > "The sky sees all, judges none."
 
           ## Today's Whisper
 
-          ${{ github.event.inputs.message }}
+          EOF
+          printf '%s\n' "${USER_MESSAGE}" >> docs/CIEL.md
+          cat >> docs/CIEL.md << 'EOF'
 
           ---
 
-          *Last descended: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*
+          EOF
+          echo "*Last descended: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*" >> docs/CIEL.md
+          cat >> docs/CIEL.md << 'EOF'
 
           > まあまあ、ほどほどに。
           EOF
 
       - name: 📬 Create PR with verified commit
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -72,7 +82,7 @@ jobs:
           commit-message: |
             🕊️ A message from above
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ~~ drifting back to the clouds ~~
           branch: ciel/whisper-${{ github.run_number }}
@@ -81,7 +91,7 @@ jobs:
           body: |
             ## 🕊️ *A gentle breeze*
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ---
 

--- a/.github/workflows/justice-bot.yml
+++ b/.github/workflows/justice-bot.yml
@@ -44,17 +44,23 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # SECURITY: Use environment variable to prevent script injection
+      # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injection
       - name: 📝 Leave a verdict
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         run: |
           mkdir -p docs
-          cat > docs/JUSTICE.md << EOF
+          cat > docs/JUSTICE.md << 'EOF'
           # 👮 Justice's Code Review
 
           > "The law applies equally to all code."
 
           ## Today's Verdict
 
-          ${{ github.event.inputs.message }}
+          EOF
+          printf '%s\n' "${USER_MESSAGE}" >> docs/JUSTICE.md
+          cat >> docs/JUSTICE.md << 'EOF'
 
           ### Checklist
           - [ ] Tests written?
@@ -64,12 +70,16 @@ jobs:
 
           ---
 
-          *Last inspected: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*
+          EOF
+          echo "*Last inspected: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*" >> docs/JUSTICE.md
+          cat >> docs/JUSTICE.md << 'EOF'
 
           > テストは？型定義は？エラーハンドリングは？
           EOF
 
       - name: 📬 Create PR with verified commit
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -79,7 +89,7 @@ jobs:
           commit-message: |
             👮 Code inspection complete
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             Remember: Tests? Types? Error handling?
           branch: justice/verdict-${{ github.run_number }}
@@ -88,7 +98,7 @@ jobs:
           body: |
             ## 👮 ⚖️ VERDICT ⚖️
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ---
 

--- a/.github/workflows/luna-bot.yml
+++ b/.github/workflows/luna-bot.yml
@@ -44,17 +44,23 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # SECURITY: Use environment variable to prevent script injection
+      # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injection
       - name: 📝 Leave a discovery note
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         run: |
           mkdir -p docs
-          cat > docs/LUNA.md << EOF
+          cat > docs/LUNA.md << 'EOF'
           # 👧 Luna's Discovery Journal
 
           > "Every bug is just an undocumented feature waiting to be found!"
 
           ## Today's Discovery
 
-          ${{ github.event.inputs.message }}
+          EOF
+          printf '%s\n' "${USER_MESSAGE}" >> docs/LUNA.md
+          cat >> docs/LUNA.md << 'EOF'
 
           ### Fun Fact
           Did you know? HTTP 418 "I'm a teapot" is a real status code!
@@ -62,12 +68,16 @@ jobs:
 
           ---
 
-          *Last explored: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*
+          EOF
+          echo "*Last explored: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*" >> docs/LUNA.md
+          cat >> docs/LUNA.md << 'EOF'
 
           > Botに418返そうよ！
           EOF
 
       - name: 📬 Create PR with verified commit
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -77,7 +87,7 @@ jobs:
           commit-message: |
             👧 New discovery logged!
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ~Luna was here~ ✨
           branch: luna/discovery-${{ github.run_number }}
@@ -86,7 +96,7 @@ jobs:
           body: |
             ## 👧 ✨ LOOK WHAT I FOUND! ✨
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ---
 

--- a/.github/workflows/mimi-bot.yml
+++ b/.github/workflows/mimi-bot.yml
@@ -44,17 +44,23 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # SECURITY: Use environment variable to prevent script injection
+      # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injection
       - name: 📝 Leave a whispered note
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         run: |
           mkdir -p docs
-          cat > docs/MIMI.md << EOF
+          cat > docs/MIMI.md << 'EOF'
           # 🐰 Mimi's Listening Post
 
           > "These ears don't miss a thing."
 
           ## Today's Whisper
 
-          ${{ github.event.inputs.message }}
+          EOF
+          printf '%s\n' "${USER_MESSAGE}" >> docs/MIMI.md
+          cat >> docs/MIMI.md << 'EOF'
 
           ### Reminder
           Always validate your inputs!
@@ -62,12 +68,16 @@ jobs:
 
           ---
 
-          *Last heard: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*
+          EOF
+          echo "*Last heard: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*" >> docs/MIMI.md
+          cat >> docs/MIMI.md << 'EOF'
 
           > バリデーターを通してくださいね
           EOF
 
       - name: 📬 Create PR with verified commit
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -77,7 +87,7 @@ jobs:
           commit-message: |
             🐰 Heard something important
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             *ears still listening*
           branch: mimi/whisper-${{ github.run_number }}
@@ -86,7 +96,7 @@ jobs:
           body: |
             ## 🐰 *whispers*
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ---
 

--- a/.github/workflows/slow-bot.yml
+++ b/.github/workflows/slow-bot.yml
@@ -44,27 +44,37 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # SECURITY: Use environment variable to prevent script injection
+      # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injection
       - name: 📝 Leave a lazy message
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         run: |
           # Create docs directory and update SLOW.md
           mkdir -p docs
-          cat > docs/SLOW.md << EOF
+          cat > docs/SLOW.md << 'EOF'
           # 🦥 Slow's Corner
 
           > "Why hurry? The code will still be here tomorrow."
 
           ## Today's Wisdom
 
-          ${{ github.event.inputs.message }}
+          EOF
+          printf '%s\n' "${USER_MESSAGE}" >> docs/SLOW.md
+          cat >> docs/SLOW.md << 'EOF'
 
           ---
 
-          *Last yawned: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*
+          EOF
+          echo "*Last yawned: $(date -u +"%Y-%m-%d %H:%M:%S UTC")*" >> docs/SLOW.md
+          cat >> docs/SLOW.md << 'EOF'
 
           > 働きたくないでござる
           EOF
 
       - name: 📬 Create PR with verified commit
+        env:
+          USER_MESSAGE: ${{ github.event.inputs.message }}
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -74,7 +84,7 @@ jobs:
           commit-message: |
             🦥 ...zzz... updated wisdom
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             *yawn* maybe I'll do more tomorrow...
           branch: slow/wisdom-${{ github.run_number }}
@@ -83,7 +93,7 @@ jobs:
           body: |
             ## 🦥 *yawn*
 
-            ${{ github.event.inputs.message }}
+            ${{ env.USER_MESSAGE }}
 
             ---
 


### PR DESCRIPTION
## Summary
- Fix GitHub Actions script injection vulnerability in all 6 bot workflow files (blaze, ciel, justice, luna, mimi, slow)
- SonarCloud flagged these as "Blocker" severity security issues

## Changes
- Add `USER_MESSAGE` environment variable to sanitize `github.event.inputs.message`
- Use quoted heredocs (`<< 'EOF'`) to prevent shell expansion
- Use `printf '%s\n'` to safely output user input
- Replace `${{ github.event.inputs.message }}` with `${{ env.USER_MESSAGE }}` in action parameters

## Security Reference
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injection

## Test plan
- [ ] CI passes
- [ ] Manually trigger one of the bot workflows with test input
- [ ] Verify the markdown file is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)