### PR TITLE
chore: bump version to 0.11.3

### DIFF
--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump version to 0.11.3 in package.json
- Required for Marketplace publish (previous PR only updated CHANGELOG)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)