### PR TITLE
chore: fix SonarCloud quality issues and bump version to 0.12.0

### DIFF
--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {


### PR DESCRIPTION
## Summary
- Refactor `generate-root-readme.js` to fix SonarCloud quality gate failure:
  - Replace 6 duplicate transform functions with data-driven TRANSFORMATIONS array
  - Use `node:fs` and `node:path` prefixes (SonarCloud recommendation)
  - Use `replaceAll()` instead of `replace()` with `/g` flag
  - Apply Prettier formatting
- Bump version from 0.11.3 to 0.12.0 for Workspace Trust rollback release

## Test plan
- [x] `npm run generate:readme` works correctly
- [x] `npm run compile` passes
- [x] `npm test` passes
- [ ] SonarCloud Quality Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)