### PR TITLE
fix(git-id-switcher): use node: prefix for built-in modules

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-01-14
+
+### Internal
+
+- **Code Quality Improvements**: Use `node:` prefix for Node.js built-in modules
+  - `child_process` → `node:child_process` in secureExec.ts
+  - `util` → `node:util` in secureExec.ts
+  - `assert` → `node:assert` in all test files
+
 ## [0.12.0] - 2026-01-14
 
 ### Removed
@@ -1164,7 +1173,9 @@ This release includes comprehensive security hardening across multiple areas.
 - `gitIdentitySwitcher.autoSwitchSshKey`: Auto SSH key switching
 - `gitIdentitySwitcher.showNotifications`: Show switch notifications
 
-[Unreleased]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.11.3...HEAD
+[Unreleased]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.12.1...HEAD
+[0.12.1]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.12.0...git-id-switcher-v0.12.1
+[0.12.0]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.11.3...git-id-switcher-v0.12.0
 [0.11.3]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.11.2...git-id-switcher-v0.11.3
 [0.11.2]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.11.1...git-id-switcher-v0.11.2
 [0.11.1]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.11.0...git-id-switcher-v0.11.1

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/secureExec.ts
+++ b/extensions/git-id-switcher/src/secureExec.ts
@@ -14,8 +14,8 @@
  * @see https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback
  */
 
-import { execFile, ExecFileException } from 'child_process';
-import { promisify } from 'util';
+import { execFile, ExecFileException } from 'node:child_process';
+import { promisify } from 'node:util';
 import { isCommandAllowed } from './commandAllowlist';
 import { securityLogger, type ISecurityLogger } from './securityLogger';
 import { getWorkspace } from './vscodeLoader';

--- a/extensions/git-id-switcher/src/test/combinedFlagValidation.test.ts
+++ b/extensions/git-id-switcher/src/test/combinedFlagValidation.test.ts
@@ -25,7 +25,7 @@
  *   rare in practice. The pre-normalization checks catch virtually all cases.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import { validateCombinedFlags } from '../flagValidator';
 import { isCommandAllowed } from '../commandAllowlist';
 

--- a/extensions/git-id-switcher/src/test/commandAllowlist.test.ts
+++ b/extensions/git-id-switcher/src/test/commandAllowlist.test.ts
@@ -4,7 +4,7 @@
  * Tests the strict validation logic for command allowlisting.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import { isCommandAllowed } from '../commandAllowlist';
 
 export async function runCommandAllowlistTests(): Promise<void> {

--- a/extensions/git-id-switcher/src/test/configChangeDetector.test.ts
+++ b/extensions/git-id-switcher/src/test/configChangeDetector.test.ts
@@ -56,7 +56,7 @@
  * Total: Comprehensive test coverage for all code paths including edge cases and error handling.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   ConfigChangeDetector,
   configChangeDetector,

--- a/extensions/git-id-switcher/src/test/configSchema.test.ts
+++ b/extensions/git-id-switcher/src/test/configSchema.test.ts
@@ -10,7 +10,7 @@
  * - Schema validation edge cases
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   validateIdentitySchema,
   validateIdentitiesSchema,

--- a/extensions/git-id-switcher/src/test/documentation.test.ts
+++ b/extensions/git-id-switcher/src/test/documentation.test.ts
@@ -40,7 +40,7 @@
  *           resolveRelativePath, getDocumentDisplayName, escapeHtmlEntities
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   sanitizeHtml,
   escapeHtmlEntities,

--- a/extensions/git-id-switcher/src/test/e2e/documentation.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/documentation.test.ts
@@ -39,7 +39,7 @@
  * - Test panel lifecycle (creation, close, re-creation)
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 
 const EXTENSION_ID = 'nullvariant.git-id-switcher';

--- a/extensions/git-id-switcher/src/test/e2e/extension.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/extension.test.ts
@@ -16,7 +16,7 @@
  * Note: These tests use the real VS Code API (no mocks) to ensure actual behavior.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 
 const EXTENSION_ID = 'nullvariant.git-id-switcher';

--- a/extensions/git-id-switcher/src/test/e2e/gitConfig.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/gitConfig.test.ts
@@ -23,7 +23,7 @@
  * Each test restores original configuration values after execution.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 import * as path from 'node:path';
 import * as fs from 'node:fs';

--- a/extensions/git-id-switcher/src/test/e2e/identity.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/identity.test.ts
@@ -19,7 +19,7 @@
  * Each test restores original configuration values after execution.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 
 const EXTENSION_ID = 'nullvariant.git-id-switcher';

--- a/extensions/git-id-switcher/src/test/e2e/quickPick.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/quickPick.test.ts
@@ -34,7 +34,7 @@
  * - Test configuration changes affect notification behavior
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 import {
   createQuickPickItems,

--- a/extensions/git-id-switcher/src/test/e2e/statusBar.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/statusBar.test.ts
@@ -27,7 +27,7 @@
  * test-only accessor methods to statusBar.ts in a future phase.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 import { createStatusBar, IdentityStatusBar } from '../../statusBar';
 import { Identity } from '../../identity';

--- a/extensions/git-id-switcher/src/test/errors.test.ts
+++ b/extensions/git-id-switcher/src/test/errors.test.ts
@@ -2,7 +2,7 @@
  * Tests for Security Error Classes
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   SecurityError,
   ErrorCategory,

--- a/extensions/git-id-switcher/src/test/fileLogWriter.test.ts
+++ b/extensions/git-id-switcher/src/test/fileLogWriter.test.ts
@@ -63,7 +63,7 @@
  *   - Requires fs mocking to trigger
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/extensions/git-id-switcher/src/test/i18n.test.ts
+++ b/extensions/git-id-switcher/src/test/i18n.test.ts
@@ -19,7 +19,7 @@
  * Total: 3 test functions
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/extensions/git-id-switcher/src/test/pathSanitizer.test.ts
+++ b/extensions/git-id-switcher/src/test/pathSanitizer.test.ts
@@ -33,7 +33,7 @@
  * Total: 22 test functions covering all code paths.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   containsSensitiveDir,
   matchesSensitivePattern,

--- a/extensions/git-id-switcher/src/test/pathSecurity.test.ts
+++ b/extensions/git-id-switcher/src/test/pathSecurity.test.ts
@@ -10,7 +10,7 @@
  * - PATH_MAX length attacks
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   isSecurePath,
   isPathArgument,

--- a/extensions/git-id-switcher/src/test/pathUtils.test.ts
+++ b/extensions/git-id-switcher/src/test/pathUtils.test.ts
@@ -80,7 +80,7 @@
  *     - Empty code block (just comment) for logging purposes
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {

--- a/extensions/git-id-switcher/src/test/secureExec.test.ts
+++ b/extensions/git-id-switcher/src/test/secureExec.test.ts
@@ -44,7 +44,7 @@
  *     - Creating reliable timeout conditions is non-deterministic
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as os from 'node:os';
 import {
   secureExec,

--- a/extensions/git-id-switcher/src/test/securityLogger.test.ts
+++ b/extensions/git-id-switcher/src/test/securityLogger.test.ts
@@ -12,7 +12,7 @@
  * that methods can be called without errors and console output is correct.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   securityLogger,
   SecurityEventType,

--- a/extensions/git-id-switcher/src/test/sensitiveDataDetector.test.ts
+++ b/extensions/git-id-switcher/src/test/sensitiveDataDetector.test.ts
@@ -36,7 +36,7 @@
  * Total: 20 test functions covering all code paths.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   looksLikeSensitiveData,
   sanitizeValue,

--- a/extensions/git-id-switcher/src/test/sshKeyFile.test.ts
+++ b/extensions/git-id-switcher/src/test/sshKeyFile.test.ts
@@ -8,7 +8,7 @@
  * - File permission checks (Unix)
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/extensions/git-id-switcher/src/test/sshKeyFormat.test.ts
+++ b/extensions/git-id-switcher/src/test/sshKeyFormat.test.ts
@@ -5,7 +5,7 @@
  * These tests do NOT depend on the vscode module and can run standalone.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/extensions/git-id-switcher/src/test/submodule.test.ts
+++ b/extensions/git-id-switcher/src/test/submodule.test.ts
@@ -4,7 +4,7 @@
  * Tests submodule path validation, symlink protection, and depth limiting.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { validateSubmodulePath } from '../pathUtils';

--- a/extensions/git-id-switcher/src/test/validation.fuzz.test.ts
+++ b/extensions/git-id-switcher/src/test/validation.fuzz.test.ts
@@ -15,7 +15,7 @@
  * @see https://github.com/dubzzz/fast-check
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import * as fc from 'fast-check';
 import { validateIdentity, validateIdentities, isPathSafe } from '../validation';
 import { Identity } from '../identity';

--- a/extensions/git-id-switcher/src/test/validation.test.ts
+++ b/extensions/git-id-switcher/src/test/validation.test.ts
@@ -4,7 +4,7 @@
  * Tests that malicious input is properly rejected.
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import { validateIdentity, validateIdentities, isPathSafe } from '../validation';
 import { Identity } from '../identity';
 

--- a/extensions/git-id-switcher/src/test/validatorsCommon.test.ts
+++ b/extensions/git-id-switcher/src/test/validatorsCommon.test.ts
@@ -4,7 +4,7 @@
  * Tests the centralized validation utilities in validators/common.ts
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   hasNullByte,
   hasControlChars,

--- a/extensions/git-id-switcher/src/test/vscodeLoader.test.ts
+++ b/extensions/git-id-switcher/src/test/vscodeLoader.test.ts
@@ -4,7 +4,7 @@
  * Tests the lazy loading mechanism for VS Code APIs
  */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import {
   getVSCode,
   getWorkspace,


### PR DESCRIPTION
## Summary

- Use node: prefix for Node.js built-in modules to improve ESM compatibility
- secureExec.ts: child_process -> node:child_process, util -> node:util
- All 27 test files: assert -> node:assert
- Bump version to 0.12.1

## Test plan

- [x] npm run compile passes
- [x] npm run lint passes (2 pre-existing warnings)
- [ ] SonarCloud Quality Gate passes