### PR TITLE
fix(sonarcloud): exclude test files from duplication detection

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.organization=nullvariant
 # Exclude test files and documentation from duplication detection
 # Test code: duplication is acceptable for readability and isolation
 # Documentation: multi-language versions SHOULD have identical structure
-sonar.cpd.exclusions=**/test/**,**/docs/**,**/*.test.ts,**/*.spec.ts,**/README.md
+sonar.cpd.exclusions=**/test/**,**/src/test/**,extensions/**/test/**,**/docs/**,**/*.test.ts,**/*.spec.ts,**/README.md
 
 # Source encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Add specific glob patterns for monorepo test directories to `sonar.cpd.exclusions`
- Fixes Quality Gate failure caused by 3.5% duplication rate from test code
- Test code intentionally has duplication for readability/isolation

## Changes
Added patterns to `sonar-project.properties`:
- `**/src/test/**`
- `extensions/**/test/**`

## Root Cause
The existing `**/test/**` pattern was not matching test files in the monorepo structure (`extensions/git-id-switcher/src/test/`).

## Test plan
- [ ] Verify SonarCloud Quality Gate passes after merge
- [ ] Confirm test folder shows 0% in Duplications after exclusion takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)