### PR TITLE
fix(sonarcloud): properly configure test exclusion

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,10 +4,16 @@
 sonar.projectKey=nullvariant_nullvariant-vscode-extensions
 sonar.organization=nullvariant
 
+# Source and test directories
+sonar.sources=extensions/git-id-switcher/src
+sonar.exclusions=**/test/**,**/node_modules/**,**/out/**,**/coverage/**
+sonar.tests=extensions/git-id-switcher/src/test
+sonar.test.inclusions=**/*.test.ts,**/*.spec.ts
+
 # Exclude test files and documentation from duplication detection
 # Test code: duplication is acceptable for readability and isolation
 # Documentation: multi-language versions SHOULD have identical structure
-sonar.cpd.exclusions=**/test/**,**/src/test/**,extensions/**/test/**,**/docs/**,**/*.test.ts,**/*.spec.ts,**/README.md
+sonar.cpd.exclusions=**/test/**,**/*.test.ts,**/*.spec.ts,**/docs/**,**/README.md
 
 # Source encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Properly configure SonarCloud to separate test code from source analysis
- Previous cpd.exclusions patterns were not working

## Changes
Added to `sonar-project.properties`:
- `sonar.sources=extensions/git-id-switcher/src` - explicit source directory
- `sonar.exclusions=**/test/**,**/node_modules/**,**/out/**,**/coverage/**`
- `sonar.tests=extensions/git-id-switcher/src/test` - mark test directory
- `sonar.test.inclusions=**/*.test.ts,**/*.spec.ts`

## Test plan
- [ ] Verify SonarCloud Quality Gate passes after merge
- [ ] Confirm test folder is excluded from duplication analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)