### PR TITLE
fix(sonarcloud): add .sonarcloud.properties for automatic analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,20 @@
+# SonarCloud Automatic Analysis Configuration
+# https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/automatic-analysis/
+#
+# NOTE: This file is for automatic analysis (GitHub App).
+# Wildcard patterns are NOT allowed in this file.
+# sonar-project.properties is IGNORED when using automatic analysis.
+
+# Source and test directories (explicit paths, no wildcards)
+sonar.sources=extensions/git-id-switcher/src
+sonar.tests=extensions/git-id-switcher/src/test
+
+# Exclusions from source analysis
+sonar.exclusions=extensions/git-id-switcher/src/test
+
+# Exclude test directory from duplication detection
+# Test code intentionally has duplication for readability and isolation
+sonar.cpd.exclusions=extensions/git-id-switcher/src/test
+
+# Source encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- SonarCloud automatic analysis **ignores** `sonar-project.properties`
- Add `.sonarcloud.properties` with explicit test exclusion from duplication detection
- Fixes Quality Gate failure (3.5% duplication > 3.0% threshold)

## Root Cause
Automatic analysis (GitHub App) uses `.sonarcloud.properties`, not `sonar-project.properties`.
All previous PRs (#155, #156, #157) were modifying the wrong file.

## Changes
Created `.sonarcloud.properties`:
- `sonar.sources=extensions/git-id-switcher/src`
- `sonar.tests=extensions/git-id-switcher/src/test`
- `sonar.exclusions=extensions/git-id-switcher/src/test`
- `sonar.cpd.exclusions=extensions/git-id-switcher/src/test`

Note: Wildcard patterns are NOT allowed in `.sonarcloud.properties`.

## Test plan
- [ ] Verify SonarCloud Quality Gate passes after merge
- [ ] Confirm test folder is excluded from duplication analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)