### PR TITLE
feat(security): add secure log path validation with symlink detection

### DIFF
--- a/extensions/git-id-switcher/src/extension.ts
+++ b/extensions/git-id-switcher/src/extension.ts
@@ -45,8 +45,10 @@ export async function activate(
 ): Promise<void> {
   console.log('[Git ID Switcher] Activating...');
 
-  // Initialize security logger
-  securityLogger.initialize();
+  // Initialize security logger with context for secure file logging
+  // SECURITY: Pass globalStorageUri to ensure log files are written
+  // only to the extension's secure storage, not arbitrary paths
+  securityLogger.initializeWithContext(context.globalStorageUri.fsPath);
   securityLogger.logActivation();
 
   // Create status bar


### PR DESCRIPTION
## Summary
- Add `isSecureLogPath()` function to validate log file paths
- Detect and reject symbolic links in path (TOCTOU mitigation)
- Validate paths are under allowed directory (`globalStorageUri`)
- Ignore workspace `filePath` setting to prevent arbitrary file write attacks
- Add cross-platform support for Windows/Linux/macOS

## Test plan
- [x] Run existing tests to ensure no regression
- [x] Add unit tests for `isSecureLogPath()` function
- [x] Test symlink detection on macOS (where `/var` and `/tmp` are symlinks)
- [x] Verify cross-platform path handling with `path.join()` and `path.normalize()`
- [ ] CI verification

## Coverage
- Overall: 93.98%
- pathSecurity.ts: 94.91%

🤖 Generated with [Claude Code](https://claude.com/claude-code)