### PR TITLE
security: remove unused lodash and minimist dependencies

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-01-17
+
+### Security
+
+- **Security Hardening**: Comprehensive security improvements
+  - **Log Path Validation** (Breaking Change)
+    - Added `isSecureLogPath()` function with symlink detection via `lstat`
+    - Log files now restricted to `globalStorageUri` directory only
+    - `filePath` workspace setting is now ignored for security
+  - **Binary Path Resolution**
+    - Added `binaryResolver.ts` for secure PATH resolution
+    - Commands now execute using absolute paths instead of relying on PATH
+    - Prevents PATH pollution attacks with fake git/ssh binaries
+  - **Audit Logging**
+    - Added `securityLogger.logCommandBlocked()` for allowlist violations
+    - Improved error handling in `gitExec` (no longer silently fails)
+  - **Dependency Cleanup**
+    - Removed unused `lodash` and `minimist` from devDependencies
+    - Reduces attack surface and supply chain risk
+
+### Breaking Changes
+
+- `gitIdSwitcher.logging.filePath` workspace setting is now ignored
+  - Log files are always written to VS Code's `globalStorageUri` for security
+  - This prevents malicious repositories from writing to arbitrary paths via `.vscode/settings.json`
+
 ## [0.12.3] - 2026-01-14
 
 ### Changed
@@ -1193,7 +1219,8 @@ This release includes comprehensive security hardening across multiple areas.
 - `gitIdentitySwitcher.autoSwitchSshKey`: Auto SSH key switching
 - `gitIdentitySwitcher.showNotifications`: Show switch notifications
 
-[Unreleased]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.12.3...HEAD
+[Unreleased]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.13.0...HEAD
+[0.13.0]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.12.3...git-id-switcher-v0.13.0
 [0.12.3]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.12.2...git-id-switcher-v0.12.3
 [0.12.2]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.12.1...git-id-switcher-v0.12.2
 [0.12.1]: https://github.com/nullvariant/nullvariant-vscode-extensions/compare/git-id-switcher-v0.12.0...git-id-switcher-v0.12.1

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "husky": "^9.1.7",
-        "lodash": "4.17.21",
-        "minimist": "1.2.6"
+        "husky": "^9.1.7"
       }
     },
     "node_modules/husky": {
@@ -29,20 +27,6 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "husky": "^9.1.7",
-    "lodash": "4.17.21",
-    "minimist": "1.2.6"
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary

- Remove unused `lodash@4.17.21` from devDependencies
- Remove unused `minimist@1.2.6` from devDependencies  
- Bump git-id-switcher version to 0.13.0

## Security Impact

Reduces attack surface and supply chain risk by removing unused dependencies that could potentially introduce vulnerabilities.

## Verification

- Confirmed no `import`/`require` for lodash or minimist in source code
- `npm install` successful (removed 2 packages)
- `npm run compile` successful
- `npm run test:coverage` passed (94.53% coverage)
- `npm audit` reports 0 vulnerabilities

## Test Plan

- [x] Local build passes
- [x] Local tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)