### PR TITLE
fix(ci): use PAT for auto-tag to trigger publish workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -36,6 +36,9 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          # Use PAT to allow tag push to trigger publish workflow
+          # GITHUB_TOKEN pushes don't trigger other workflows (prevents infinite loops)
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Check if package.json changed
         id: changed


### PR DESCRIPTION
## Summary

- Use `RELEASE_PAT` secret instead of `GITHUB_TOKEN` for tag pushes
- This allows the publish workflow to be triggered automatically

## Background

`GITHUB_TOKEN` pushes don't trigger other workflows (by design, to prevent infinite loops). The v0.13.0 tag was created but the publish workflow was not triggered.

## Required Action

Add `RELEASE_PAT` secret in repository settings:
1. Go to Settings > Secrets and variables > Actions
2. Add new repository secret: `RELEASE_PAT`
3. Value: Personal Access Token with `repo` scope

## Test Plan

- [ ] Add RELEASE_PAT secret
- [ ] Delete and re-push v0.13.0 tag to verify publish workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)