### PR TITLE
chore(release): v0.13.1 - Fix submodule detection bug

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-01-18
+
+### Fixed
+
+- **Submodule Detection Bug**: Fixed `listSubmodules()` failing to detect the first submodule
+  - Root cause: `gitExec()` applied `stdout.trim()` which removed the leading status character
+  - Added `gitExecRaw()` function that preserves raw stdout without trimming
+  - `git submodule status` output format requires leading character (` `, `-`, `+`) for status
+
+### Added
+
+- **Comprehensive Submodule Tests**: Added tests for submodule detection scenarios
+  - Single submodule detection test
+  - Multiple submodules detection test (3 submodules)
+  - Nested submodules recursive test (3-level hierarchy)
+  - `gitExecRaw()` error handling test
+
+### Changed
+
+- **Improved Test Coverage**: `submodule.ts` coverage increased from 79.78% to 93.53%
+
 ## [0.13.0] - 2026-01-17
 
 ### Security

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {


### PR DESCRIPTION
## Summary

- Bump version to 0.13.1
- Update CHANGELOG with bug fix details

## Changes in v0.13.1

### Fixed
- **Submodule Detection Bug**: Fixed `listSubmodules()` failing to detect the first submodule
  - Root cause: `gitExec()` applied `stdout.trim()` which removed the leading status character
  - Added `gitExecRaw()` function that preserves raw stdout without trimming

### Added
- Comprehensive submodule tests (single, multiple, nested)
- `gitExecRaw()` error handling test

### Changed
- Test coverage improved: `submodule.ts` 79.78% → 93.53%

## Test Plan

- [x] All existing tests pass
- [x] New submodule tests pass
- [x] Coverage meets threshold (≥90%)
- [x] SonarCloud Quality Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)