### PR TITLE
chore(release): v0.13.7 - Fix documentation hash mismatch

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.7] - 2026-01-19
+
+### Fixed
+
+- **Documentation Hash Mismatch**: Fixed Webview documentation display failing due to outdated hashes
+  - Regenerated SHA-256 hashes for all 32 documentation files
+  - Added automatic hash update script (`scripts/update-doc-hashes.mjs`) for CI/CD
+  - Deploy workflow now auto-updates hashes before CDN deployment
+
 ## [0.13.6] - 2026-01-18
 
 ### Added

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump version to 0.13.7
- Update CHANGELOG with fix description

## Changes in v0.13.7
### Fixed
- **Documentation Hash Mismatch**: Fixed Webview documentation display failing due to outdated hashes
  - Regenerated SHA-256 hashes for all 32 documentation files
  - Added automatic hash update script (`scripts/update-doc-hashes.mjs`) for CI/CD
  - Deploy workflow now auto-updates hashes before CDN deployment

## Release Process
After merge, tag and push to trigger marketplace release:
```bash
git tag git-id-switcher-v0.13.7
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)