### PR TITLE
chore(husky): auto-regenerate DOCUMENT_HASHES on doc changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,3 +11,20 @@ if git diff --cached --name-only | grep -Fxq "extensions/git-id-switcher/docs/i1
   )
   echo "✅ README.md regenerated and staged"
 fi
+
+# Auto-regenerate DOCUMENT_HASHES when documentation files change
+# Pattern matches: extension .md files, extension LICENSE, monorepo root .md files, monorepo root LICENSE
+if git diff --cached --name-only | grep -qE '^(extensions/git-id-switcher/.*\.md|extensions/git-id-switcher/LICENSE|[^/]+\.md|LICENSE)$'; then
+  echo "🔒 Regenerating DOCUMENT_HASHES..."
+  (
+    cd extensions/git-id-switcher || exit 1
+    node scripts/update-doc-hashes.mjs || exit 1
+    git add src/documentation.internal.ts
+  )
+  # Subshell failure should abort commit
+  if [ $? -ne 0 ]; then
+    echo "❌ Failed to regenerate DOCUMENT_HASHES"
+    exit 1
+  fi
+  echo "✅ DOCUMENT_HASHES regenerated and staged"
+fi


### PR DESCRIPTION
## Summary
- Add pre-commit hook logic to automatically regenerate DOCUMENT_HASHES when documentation files change
- Triggered when staging `.md` files or `LICENSE` (extension or monorepo root)
- Ensures hash consistency without manual intervention
- Prevents CI failures from forgotten hash updates

## Test plan
- [x] Tested locally: modified CHANGELOG.md → hook triggered → hashes regenerated and staged automatically
- [ ] CI passes

## Related
- Follow-up to PR #183 (hash-check.yml)
- Completes the local automation gap identified after PR #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)