### PR TITLE
ci(sonarcloud): skip analysis for Dependabot PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,6 +16,8 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
+    # Skip Dependabot PRs as they don't have access to SONAR_TOKEN secret
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Summary
- Skip SonarCloud analysis for Dependabot PRs

## Background
Dependabot PRs don't have access to `SONAR_TOKEN` secret due to GitHub's security policy, causing "Project not found" errors.

## Changes
- Add `if: github.actor != 'dependabot[bot]'` condition to sonarcloud job

## Test plan
- [ ] Verify SonarCloud workflow is skipped for PR #198 (Dependabot lodash update)
- [ ] Verify SonarCloud workflow still runs on regular PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)