### PR TITLE
fix(ci): remove CODECOV_TOKEN (org no longer requires tokens)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           directory: extensions/git-id-switcher/coverage
           fail_ci_if_error: false
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,7 +73,6 @@ This section documents all secrets used in CI/CD workflows.
 | RELEASE_PAT | Tag push to trigger publish workflow | auto-tag.yml | 90 days | High |
 | VSCE_PAT | VS Code Marketplace publishing | publish.yml, unpublish.yml | Annual | High |
 | OVSX_PAT | Open VSX publishing | publish.yml, unpublish.yml | Annual | High |
-| CODECOV_TOKEN | Coverage reporting | ci.yml | As needed | Medium |
 | SONAR_TOKEN | SonarCloud code analysis | sonarcloud.yml | As needed | Medium |
 | CLOUDFLARE_API_TOKEN | Cloudflare Pages/R2 deployment | deploy-docs.yml, publish.yml | Annual | High |
 | CLOUDFLARE_ACCOUNT_ID | Cloudflare account identifier (public) | deploy-docs.yml, publish.yml | Never | Low (public ID) |
@@ -121,7 +120,6 @@ Marketplace publishing secrets (VSCE_PAT, OVSX_PAT) are protected by the `produc
 | VSCE_PAT | Azure DevOps | [Azure DevOps Tokens](https://dev.azure.com/nullvariant/_usersSettings/tokens) | 2027-01-08 |
 | OVSX_PAT | Open VSX | [Open VSX Tokens](https://open-vsx.org/user-settings/tokens) | No expiration |
 | CLOUDFLARE_API_TOKEN | Cloudflare | [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens) | No expiration |
-| CODECOV_TOKEN | Codecov | [Codecov Settings](https://app.codecov.io/account/gh/nullvariant/settings) | No expiration |
 | SONAR_TOKEN | SonarCloud | [SonarCloud Security](https://sonarcloud.io/account/security) | No expiration |
 | GitHub App Keys | GitHub | [GitHub Apps](https://github.com/settings/apps) | No expiration |
 | SLACK_WEBHOOK | Slack | [Slack Apps](https://api.slack.com/apps) | No expiration |

--- a/extensions/git-id-switcher/src/documentation.internal.ts
+++ b/extensions/git-id-switcher/src/documentation.internal.ts
@@ -59,7 +59,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'extensions/git-id-switcher/README.md': 'cc8dc766afdd43c1fb9051b5270617382c845ebabd103654f190ce63850e3c6e',
   'LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
   'README.md': 'e6c0c4e5924873eabd0e49973e29457abc5e8171ba4ff9da77700e6a19c28f9d',
-  'SECURITY.md': '72dbadafd9a5caaa4e16f6b1f19a5255f7f84310432bf3c8207c163f5f8088da',
+  'SECURITY.md': '87496fc22c667ebc9911a27ef520d1e2918229f7c44bb0f717151995dfd4893b',
 };
 
 /** Supported locales for documentation */


### PR DESCRIPTION
## Summary
- Remove CODECOV_TOKEN from ci.yml (org no longer requires upload tokens)
- Remove CODECOV_TOKEN from SECURITY.md secrets documentation

Codecov dashboard shows "Your org no longer requires upload tokens". Using token was causing uploads to not be recognized.

## Test plan
- [ ] CI passes
- [ ] Codecov uploads are recognized after merge

🤖 Generated with [Claude Code](https://claude.ai/download)