### PR TITLE
fix: add parent directory exclusion to .vscodeignore

### DIFF
--- a/extensions/git-id-switcher/.vscodeignore
+++ b/extensions/git-id-switcher/.vscodeignore
@@ -1,3 +1,4 @@
+../**
 .vscode/**
 .vscode-test/**
 .vscode-test.mjs

--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-01-23
+
+### Fixed
+
+- **VSIX Packaging Fix**: Added `../**` to `.vscodeignore` to exclude parent directory files
+  - Fixes "invalid relative path" error during `vsce publish`
+  - Prevents monorepo root files (e.g., `sonar-project.properties`) from being included in VSIX
+
 ## [0.14.1] - 2026-01-23
 
 ### Security

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/documentation.internal.ts
+++ b/extensions/git-id-switcher/src/documentation.internal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': '54f16b767e57686b3eb46a2b4aa02b378554cc492c32c49ed96588f6d184b6b8',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '4e1a449caa6b873fdc5af7134d9738a5b6d9815e5e5f47e5454761acb983702f',
+  'extensions/git-id-switcher/CHANGELOG.md': '864fa5cd55227ade6c688cfcfe373473c9c564d89d17332ad46ceadc396986a9',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',
   'extensions/git-id-switcher/docs/i18n/ain/README.md': '4d309165e22a943b2a1791914db02bc2762d5fb643f5350a2426558ac7b3ae19',


### PR DESCRIPTION
## Summary

- Add `../**` pattern to `.vscodeignore` to exclude parent directory files from VSIX
- Fixes "invalid relative path: extension/../../sonar-project.properties" error during `vsce publish`
- Bump version to 0.14.2

## Context

v0.14.1 publish failed because monorepo root files were being included in the VSIX package.

## Test plan

- [ ] CI passes (build, lint, unit tests, E2E tests)
- [ ] Publish workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)