### PR TITLE
refactor: split pathSecurity.ts into unicode.ts and traversal.ts

### DIFF
--- a/extensions/git-id-switcher/src/path/security/traversal.ts
+++ b/extensions/git-id-switcher/src/path/security/traversal.ts
@@ -1,0 +1,87 @@
+/**
+ * Path Traversal Security Validators
+ *
+ * Provides validators for detecting path traversal attacks:
+ * - Directory traversal patterns (..)
+ * - Double slashes
+ * - Backslashes
+ * - Trailing dots
+ */
+
+import { hasPathTraversalStrict } from '../../validators/common';
+import { Validator } from './unicode';
+
+// ============================================================================
+// Traversal Validators
+// ============================================================================
+
+/**
+ * Validates no path traversal patterns (..)
+ */
+export const validateNoTraversal: Validator = (state) => {
+  if (hasPathTraversalStrict(state.path)) {
+    return { ...state, valid: false, reason: 'Path contains traversal pattern (..)' };
+  }
+  return state;
+};
+
+/**
+ * Validates no double forward slashes (potential path confusion)
+ * Note: Double backslashes (\\) are caught by validateNoBackslash
+ */
+export const validateNoDoubleSlash: Validator = (state) => {
+  if (/\/\//.test(state.path)) {
+    return { ...state, valid: false, reason: 'Path contains double slashes' };
+  }
+  return state;
+};
+
+/**
+ * Validates no backslashes (cross-platform safety)
+ */
+export const validateNoBackslash: Validator = (state) => {
+  if (state.path.includes('\\')) {
+    return {
+      ...state,
+      valid: false,
+      reason: 'Path contains backslash (use forward slashes for cross-platform compatibility)',
+    };
+  }
+  return state;
+};
+
+/**
+ * Validates no trailing dots (cross-platform safety)
+ * Note: '.' itself is valid and allowed
+ */
+export const validateNoTrailingDot: Validator = (state) => {
+  if (state.path !== '.' && state.path.endsWith('.')) {
+    return {
+      ...state,
+      valid: false,
+      reason: 'Path ends with dot (not allowed for cross-platform compatibility)',
+    };
+  }
+  return state;
+};
+
+/**
+ * Validates no trailing /./ or /../ patterns (edge cases)
+ *
+ * Note: This validator is defense-in-depth code. Due to pipeline order:
+ * - /. endings are caught first by validateNoTrailingDot
+ * - /.. endings are caught first by validateNoTraversal
+ * This code exists as a safety net if upstream validators are modified.
+ */
+/* c8 ignore start - Defense-in-depth: unreachable due to prior validators */
+export const validateNoTrailingDotSlash: Validator = (state) => {
+  if (state.path.endsWith('/.') || state.path.endsWith('/..')) {
+    return {
+      ...state,
+      valid: false,
+      reason: 'Path ends with /./ or /../ (not allowed)',
+    };
+  }
+  return state;
+};
+/* c8 ignore stop */

--- a/extensions/git-id-switcher/src/path/security/unicode.ts
+++ b/extensions/git-id-switcher/src/path/security/unicode.ts
@@ -1,0 +1,82 @@
+/**
+ * Unicode Security Validators
+ *
+ * Provides validators for detecting Unicode-based attacks:
+ * - Control characters
+ * - Invisible Unicode characters
+ * - Unicode normalization
+ */
+
+import {
+  CONTROL_CHAR_REGEX_STRICT,
+  hasInvisibleUnicode,
+} from '../../validators/common';
+
+/**
+ * Internal state for validation pipeline
+ */
+export interface ValidationState {
+  valid: boolean;
+  path: string;
+  reason?: string;
+}
+
+/**
+ * Validator function type for pipeline pattern
+ */
+export type Validator = (state: ValidationState) => ValidationState;
+
+// ============================================================================
+// Validator Factories (DRY pattern)
+// ============================================================================
+
+/**
+ * Creates a validator for control characters with custom error message suffix
+ */
+export const createControlCharValidator = (suffix: string = ''): Validator => (state) => {
+  if (CONTROL_CHAR_REGEX_STRICT.test(state.path)) {
+    return { ...state, valid: false, reason: `Path contains control characters${suffix}` };
+  }
+  return state;
+};
+
+/**
+ * Creates a validator for invisible Unicode with custom error message suffix
+ */
+export const createInvisibleUnicodeValidator = (suffix: string = ''): Validator => (state) => {
+  if (hasInvisibleUnicode(state.path)) {
+    return { ...state, valid: false, reason: `Path contains invisible Unicode characters${suffix}` };
+  }
+  return state;
+};
+
+// ============================================================================
+// Pre-built Validators
+// ============================================================================
+
+/** Validates no control characters (pre-normalization) */
+export const validateNoControlChars = createControlCharValidator();
+
+/** Validates no invisible Unicode characters (pre-normalization) */
+export const validateNoInvisibleUnicode = createInvisibleUnicodeValidator();
+
+/**
+ * Normalizes Unicode to NFC for consistent comparison
+ */
+export const normalizeUnicode: Validator = (state) => ({
+  ...state,
+  path: state.path.normalize('NFC'),
+});
+
+/**
+ * Re-validates control characters after normalization.
+ * NFC normalization can theoretically affect character composition,
+ * so we re-check as a security precaution.
+ */
+export const validateNoControlCharsAfterNormalization = createControlCharValidator(' (after normalization)');
+
+/**
+ * Re-validates invisible Unicode after normalization.
+ * Security precaution for edge cases in Unicode normalization.
+ */
+export const validateNoInvisibleUnicodeAfterNormalization = createInvisibleUnicodeValidator(' (after normalization)');


### PR DESCRIPTION
## Summary
- Split `pathSecurity.ts` (688 lines) into specialized modules for better maintainability
- Created `path/security/unicode.ts` (82 lines): Unicode attack detection validators
- Created `path/security/traversal.ts` (87 lines): Path traversal detection validators
- Reduced `pathSecurity.ts` to 591 lines (14% reduction) with re-exports for backward compatibility

## Test plan
- [x] All unit tests pass (`npm run test:unit`)
- [x] All security tests pass (`npm run test:security`)
- [x] 100% test coverage maintained (`npm run test:coverage`)
- [x] ESLint passes with no errors
- [x] c8 ignore comments correctly preserved in new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)