### PR TITLE
feat(constants): add field length limit constants

### DIFF
--- a/extensions/git-id-switcher/src/core/constants.ts
+++ b/extensions/git-id-switcher/src/core/constants.ts
@@ -56,6 +56,84 @@ export const MAX_SECRET_LENGTH = 256;
  */
 export const MAX_ID_LENGTH = 64;
 
+// ============================================================================
+// Field Length Limits
+// ============================================================================
+
+/**
+ * Maximum email address length per RFC 5321
+ *
+ * RFC 5321 Section 4.5.3.1 specifies:
+ * - Local part: max 64 octets (4.5.3.1.1)
+ * - Domain: max 255 octets (4.5.3.1.2)
+ * - Total: 64 + 1 (@) + 255 = 320 characters maximum
+ */
+export const MAX_EMAIL_LENGTH = 320;
+
+/**
+ * Maximum SSH host length (DNS maximum)
+ *
+ * RFC 1035 specifies 253 characters maximum for fully qualified domain names.
+ */
+export const MAX_SSH_HOST_LENGTH = 253;
+
+/**
+ * Maximum display name length
+ *
+ * Reasonable limit for git user.name and identity display names.
+ */
+export const MAX_NAME_LENGTH = 256;
+
+/**
+ * Maximum service name length
+ *
+ * Used for service identifiers like "github", "gitlab", etc.
+ */
+export const MAX_SERVICE_LENGTH = 64;
+
+/**
+ * Maximum description length
+ *
+ * Used for identity descriptions and notes.
+ */
+export const MAX_DESCRIPTION_LENGTH = 500;
+
+// ============================================================================
+// Icon Limits
+// ============================================================================
+
+/**
+ * Maximum icon byte length
+ *
+ * Composed emojis (e.g., family emoji with ZWJ sequences) can be up to 32 bytes.
+ */
+export const MAX_ICON_BYTE_LENGTH = 32;
+
+/**
+ * Maximum icon grapheme count
+ *
+ * Icons should be a single visible character (grapheme cluster).
+ */
+export const MAX_ICON_GRAPHEME_COUNT = 1;
+
+// ============================================================================
+// GPG Key Limits
+// ============================================================================
+
+/**
+ * Minimum GPG key ID length
+ *
+ * Short key IDs are 8 hex characters.
+ */
+export const MIN_GPG_KEY_LENGTH = 8;
+
+/**
+ * Maximum GPG key ID length
+ *
+ * Full fingerprints are 40 hex characters.
+ */
+export const MAX_GPG_KEY_LENGTH = 40;
+
 /**
  * Security limits object for backwards compatibility
  *


### PR DESCRIPTION
## Summary
- Add 9 centralized constants for input validation limits in `constants.ts`
- Constants cover email, SSH host, name, service, description, icon, and GPG key length limits
- All values are based on relevant RFCs or reasonable defaults

## Changes
| Constant | Value | Rationale |
|----------|-------|-----------|
| `MAX_EMAIL_LENGTH` | 320 | RFC 5321 |
| `MAX_SSH_HOST_LENGTH` | 253 | RFC 1035 (DNS max) |
| `MAX_NAME_LENGTH` | 256 | git user.name |
| `MAX_SERVICE_LENGTH` | 64 | service identifiers |
| `MAX_DESCRIPTION_LENGTH` | 500 | identity descriptions |
| `MAX_ICON_BYTE_LENGTH` | 32 | composed emoji max |
| `MAX_ICON_GRAPHEME_COUNT` | 1 | single grapheme |
| `MIN_GPG_KEY_LENGTH` | 8 | short key ID |
| `MAX_GPG_KEY_LENGTH` | 40 | full fingerprint |

## Test plan
- [x] `npm run compile` succeeds
- [x] `npm test` all pass
- [x] `npm run lint` no errors (existing warnings only)
- [x] `npm run test:coverage` maintains 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)