### PR TITLE
feat(i18n): add localization keys for delete identity command

### DIFF
--- a/extensions/git-id-switcher/l10n/bundle.l10n.bg.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.bg.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Отказ",
   "Internal document not found. Open on GitHub?": "Вътрешен документ не е намерен. Отворете на GitHub?",
-  "Open on GitHub": "Отвори на GitHub"
+  "Open on GitHub": "Отвори на GitHub",
+  "Select identity to delete": "Изберете самоличност за изтриване",
+  "Are you sure you want to delete '{0}'?": "Сигурни ли сте, че искате да изтриете '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' е текущата ви самоличност. Изтрийте въпреки това?",
+  "Identity '{0}' has been deleted.": "Самоличността '{0}' е изтрита.",
+  "Failed to delete identity: {0}": "Неуспешно изтриване на самоличност: {0}",
+  "Delete": "Изтрий"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.cs.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.cs.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Zrušit",
   "Internal document not found. Open on GitHub?": "Interní dokument nenalezen. Otevřít na GitHubu?",
-  "Open on GitHub": "Otevřít na GitHubu"
+  "Open on GitHub": "Otevřít na GitHubu",
+  "Select identity to delete": "Vyberte identitu k odstranění",
+  "Are you sure you want to delete '{0}'?": "Opravdu chcete odstranit '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' je vaše aktuální identita. Přesto odstranit?",
+  "Identity '{0}' has been deleted.": "Identita '{0}' byla odstraněna.",
+  "Failed to delete identity: {0}": "Nepodařilo se odstranit identitu: {0}",
+  "Delete": "Odstranit"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.de.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.de.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Abbrechen",
   "Internal document not found. Open on GitHub?": "Internes Dokument nicht gefunden. Auf GitHub öffnen?",
-  "Open on GitHub": "Auf GitHub öffnen"
+  "Open on GitHub": "Auf GitHub öffnen",
+  "Select identity to delete": "Identität zum Löschen auswählen",
+  "Are you sure you want to delete '{0}'?": "Möchten Sie '{0}' wirklich löschen?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' ist Ihre aktuelle Identität. Trotzdem löschen?",
+  "Identity '{0}' has been deleted.": "Identität '{0}' wurde gelöscht.",
+  "Failed to delete identity: {0}": "Identität konnte nicht gelöscht werden: {0}",
+  "Delete": "Löschen"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.es.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.es.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Cancelar",
   "Internal document not found. Open on GitHub?": "Documento interno no encontrado. ¿Abrir en GitHub?",
-  "Open on GitHub": "Abrir en GitHub"
+  "Open on GitHub": "Abrir en GitHub",
+  "Select identity to delete": "Seleccionar identidad para eliminar",
+  "Are you sure you want to delete '{0}'?": "¿Está seguro de que desea eliminar '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' es su identidad actual. ¿Eliminar de todos modos?",
+  "Identity '{0}' has been deleted.": "La identidad '{0}' ha sido eliminada.",
+  "Failed to delete identity: {0}": "Error al eliminar identidad: {0}",
+  "Delete": "Eliminar"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.fr.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.fr.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher : {0}",
   "Cancel": "Annuler",
   "Internal document not found. Open on GitHub?": "Document interne introuvable. Ouvrir sur GitHub ?",
-  "Open on GitHub": "Ouvrir sur GitHub"
+  "Open on GitHub": "Ouvrir sur GitHub",
+  "Select identity to delete": "Sélectionner l'identité à supprimer",
+  "Are you sure you want to delete '{0}'?": "Êtes-vous sûr de vouloir supprimer '{0}' ?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' est votre identité actuelle. Supprimer quand même ?",
+  "Identity '{0}' has been deleted.": "L'identité '{0}' a été supprimée.",
+  "Failed to delete identity: {0}": "Échec de la suppression de l'identité : {0}",
+  "Delete": "Supprimer"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.hu.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.hu.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Mégse",
   "Internal document not found. Open on GitHub?": "Belső dokumentum nem található. Megnyitás GitHubon?",
-  "Open on GitHub": "Megnyitás GitHubon"
+  "Open on GitHub": "Megnyitás GitHubon",
+  "Select identity to delete": "Válassza ki a törlendő identitást",
+  "Are you sure you want to delete '{0}'?": "Biztosan törölni szeretné a '{0}' identitást?",
+  "'{0}' is your current identity. Delete anyway?": "A '{0}' az aktuális identitása. Mégis törli?",
+  "Identity '{0}' has been deleted.": "A '{0}' identitás törölve.",
+  "Failed to delete identity: {0}": "Nem sikerült törölni az identitást: {0}",
+  "Delete": "Törlés"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.it.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.it.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Annulla",
   "Internal document not found. Open on GitHub?": "Documento interno non trovato. Aprire su GitHub?",
-  "Open on GitHub": "Apri su GitHub"
+  "Open on GitHub": "Apri su GitHub",
+  "Select identity to delete": "Seleziona l'identità da eliminare",
+  "Are you sure you want to delete '{0}'?": "Sei sicuro di voler eliminare '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' è la tua identità corrente. Eliminare comunque?",
+  "Identity '{0}' has been deleted.": "L'identità '{0}' è stata eliminata.",
+  "Failed to delete identity: {0}": "Eliminazione identità fallita: {0}",
+  "Delete": "Elimina"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.ja.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.ja.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "キャンセル",
   "Internal document not found. Open on GitHub?": "内部ドキュメントが見つかりませんでした。GitHubで開きますか？",
-  "Open on GitHub": "GitHubで開く"
+  "Open on GitHub": "GitHubで開く",
+  "Select identity to delete": "削除するプロフィールを選択",
+  "Are you sure you want to delete '{0}'?": "'{0}' を削除してもよろしいですか？",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' は現在使用中のプロフィールです。削除しますか？",
+  "Identity '{0}' has been deleted.": "プロフィール '{0}' を削除しました。",
+  "Failed to delete identity: {0}": "プロフィールの削除に失敗しました: {0}",
+  "Delete": "削除"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Cancel",
   "Internal document not found. Open on GitHub?": "Internal document not found. Open on GitHub?",
-  "Open on GitHub": "Open on GitHub"
+  "Open on GitHub": "Open on GitHub",
+  "Select identity to delete": "Select identity to delete",
+  "Are you sure you want to delete '{0}'?": "Are you sure you want to delete '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' is your current identity. Delete anyway?",
+  "Identity '{0}' has been deleted.": "Identity '{0}' has been deleted.",
+  "Failed to delete identity: {0}": "Failed to delete identity: {0}",
+  "Delete": "Delete"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.ko.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.ko.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "취소",
   "Internal document not found. Open on GitHub?": "내부 문서를 찾을 수 없습니다. GitHub에서 열까요?",
-  "Open on GitHub": "GitHub에서 열기"
+  "Open on GitHub": "GitHub에서 열기",
+  "Select identity to delete": "삭제할 ID 선택",
+  "Are you sure you want to delete '{0}'?": "'{0}'을(를) 삭제하시겠습니까?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}'은(는) 현재 사용 중인 ID입니다. 그래도 삭제하시겠습니까?",
+  "Identity '{0}' has been deleted.": "ID '{0}'이(가) 삭제되었습니다.",
+  "Failed to delete identity: {0}": "ID 삭제 실패: {0}",
+  "Delete": "삭제"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.pl.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.pl.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Anuluj",
   "Internal document not found. Open on GitHub?": "Nie znaleziono wewnętrznego dokumentu. Otworzyć na GitHub?",
-  "Open on GitHub": "Otwórz na GitHub"
+  "Open on GitHub": "Otwórz na GitHub",
+  "Select identity to delete": "Wybierz tożsamość do usunięcia",
+  "Are you sure you want to delete '{0}'?": "Czy na pewno chcesz usunąć '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' to twoja bieżąca tożsamość. Usunąć mimo to?",
+  "Identity '{0}' has been deleted.": "Tożsamość '{0}' została usunięta.",
+  "Failed to delete identity: {0}": "Nie udało się usunąć tożsamości: {0}",
+  "Delete": "Usuń"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.pt-BR.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.pt-BR.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Cancelar",
   "Internal document not found. Open on GitHub?": "Documento interno não encontrado. Abrir no GitHub?",
-  "Open on GitHub": "Abrir no GitHub"
+  "Open on GitHub": "Abrir no GitHub",
+  "Select identity to delete": "Selecionar identidade para excluir",
+  "Are you sure you want to delete '{0}'?": "Tem certeza de que deseja excluir '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' é sua identidade atual. Excluir mesmo assim?",
+  "Identity '{0}' has been deleted.": "A identidade '{0}' foi excluída.",
+  "Failed to delete identity: {0}": "Falha ao excluir identidade: {0}",
+  "Delete": "Excluir"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.ru.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.ru.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Отмена",
   "Internal document not found. Open on GitHub?": "Внутренний документ не найден. Открыть на GitHub?",
-  "Open on GitHub": "Открыть на GitHub"
+  "Open on GitHub": "Открыть на GitHub",
+  "Select identity to delete": "Выберите идентификатор для удаления",
+  "Are you sure you want to delete '{0}'?": "Вы уверены, что хотите удалить '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' — ваш текущий идентификатор. Всё равно удалить?",
+  "Identity '{0}' has been deleted.": "Идентификатор '{0}' удалён.",
+  "Failed to delete identity: {0}": "Не удалось удалить идентификатор: {0}",
+  "Delete": "Удалить"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.tr.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.tr.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "İptal",
   "Internal document not found. Open on GitHub?": "Dahili belge bulunamadı. GitHub'da açılsın mı?",
-  "Open on GitHub": "GitHub'da Aç"
+  "Open on GitHub": "GitHub'da Aç",
+  "Select identity to delete": "Silinecek kimliği seçin",
+  "Are you sure you want to delete '{0}'?": "'{0}' kimliğini silmek istediğinizden emin misiniz?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' mevcut kimliğiniz. Yine de silinsin mi?",
+  "Identity '{0}' has been deleted.": "'{0}' kimliği silindi.",
+  "Failed to delete identity: {0}": "Kimlik silinemedi: {0}",
+  "Delete": "Sil"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.uk.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.uk.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "Скасувати",
   "Internal document not found. Open on GitHub?": "Внутрішній документ не знайдено. Відкрити на GitHub?",
-  "Open on GitHub": "Відкрити на GitHub"
+  "Open on GitHub": "Відкрити на GitHub",
+  "Select identity to delete": "Виберіть ідентифікатор для видалення",
+  "Are you sure you want to delete '{0}'?": "Ви впевнені, що хочете видалити '{0}'?",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' — ваш поточний ідентифікатор. Все одно видалити?",
+  "Identity '{0}' has been deleted.": "Ідентифікатор '{0}' видалено.",
+  "Failed to delete identity: {0}": "Не вдалося видалити ідентифікатор: {0}",
+  "Delete": "Видалити"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.zh-CN.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.zh-CN.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "取消",
   "Internal document not found. Open on GitHub?": "内部文档未找到。是否在 GitHub 上打开？",
-  "Open on GitHub": "在 GitHub 上打开"
+  "Open on GitHub": "在 GitHub 上打开",
+  "Select identity to delete": "选择要删除的身份",
+  "Are you sure you want to delete '{0}'?": "确定要删除 '{0}' 吗？",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' 是您当前的身份。仍然删除吗？",
+  "Identity '{0}' has been deleted.": "身份 '{0}' 已删除。",
+  "Failed to delete identity: {0}": "删除身份失败: {0}",
+  "Delete": "删除"
 }

--- a/extensions/git-id-switcher/l10n/bundle.l10n.zh-TW.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.zh-TW.json
@@ -24,5 +24,11 @@
   "Git ID Switcher: {0}": "Git ID Switcher: {0}",
   "Cancel": "取消",
   "Internal document not found. Open on GitHub?": "內部文件未找到。是否在 GitHub 上開啟？",
-  "Open on GitHub": "在 GitHub 上開啟"
+  "Open on GitHub": "在 GitHub 上開啟",
+  "Select identity to delete": "選擇要刪除的身分",
+  "Are you sure you want to delete '{0}'?": "確定要刪除 '{0}' 嗎？",
+  "'{0}' is your current identity. Delete anyway?": "'{0}' 是您目前的身分。仍然刪除嗎？",
+  "Identity '{0}' has been deleted.": "身分 '{0}' 已刪除。",
+  "Failed to delete identity: {0}": "刪除身分失敗: {0}",
+  "Delete": "刪除"
 }

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -64,6 +64,11 @@
         "command": "git-id-switcher.showDocumentation",
         "title": "%command.showDocumentation%",
         "category": "Git ID Switcher"
+      },
+      {
+        "command": "git-id-switcher.deleteIdentity",
+        "title": "%command.deleteIdentity%",
+        "category": "Git ID Switcher"
       }
     ],
     "configuration": [

--- a/extensions/git-id-switcher/package.nls.bg.json
+++ b/extensions/git-id-switcher/package.nls.bg.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Избор на самоличност",
   "command.showCurrentIdentity": "Показване на текущата самоличност",
   "command.showDocumentation": "Показване на документация",
+  "command.deleteIdentity": "Изтриване на самоличност",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Идентичност",
   "config.category.submodule": "Git ID Switcher: Подмодул",

--- a/extensions/git-id-switcher/package.nls.cs.json
+++ b/extensions/git-id-switcher/package.nls.cs.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Vybrat identitu",
   "command.showCurrentIdentity": "Zobrazit aktuální identitu",
   "command.showDocumentation": "Zobrazit dokumentaci",
+  "command.deleteIdentity": "Odstranit identitu",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Identita",
   "config.category.submodule": "Git ID Switcher: Submodul",

--- a/extensions/git-id-switcher/package.nls.de.json
+++ b/extensions/git-id-switcher/package.nls.de.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Identität auswählen",
   "command.showCurrentIdentity": "Aktuelle Identität anzeigen",
   "command.showDocumentation": "Dokumentation anzeigen",
+  "command.deleteIdentity": "Identität löschen",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Identität",
   "config.category.submodule": "Git ID Switcher: Submodul",

--- a/extensions/git-id-switcher/package.nls.es.json
+++ b/extensions/git-id-switcher/package.nls.es.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Seleccionar identidad",
   "command.showCurrentIdentity": "Mostrar identidad actual",
   "command.showDocumentation": "Mostrar documentación",
+  "command.deleteIdentity": "Eliminar identidad",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Identidad",
   "config.category.submodule": "Git ID Switcher: Submódulo",

--- a/extensions/git-id-switcher/package.nls.fr.json
+++ b/extensions/git-id-switcher/package.nls.fr.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Sélectionner l'identité",
   "command.showCurrentIdentity": "Afficher l'identité actuelle",
   "command.showDocumentation": "Afficher la documentation",
+  "command.deleteIdentity": "Supprimer l'identité",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Identité",
   "config.category.submodule": "Git ID Switcher: Sous-module",

--- a/extensions/git-id-switcher/package.nls.hu.json
+++ b/extensions/git-id-switcher/package.nls.hu.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Identitás kiválasztása",
   "command.showCurrentIdentity": "Jelenlegi identitás megjelenítése",
   "command.showDocumentation": "Dokumentáció megjelenítése",
+  "command.deleteIdentity": "Identitás törlése",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Azonosító",
   "config.category.submodule": "Git ID Switcher: Almodul",

--- a/extensions/git-id-switcher/package.nls.it.json
+++ b/extensions/git-id-switcher/package.nls.it.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Seleziona identità",
   "command.showCurrentIdentity": "Mostra identità corrente",
   "command.showDocumentation": "Mostra documentazione",
+  "command.deleteIdentity": "Elimina identità",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Identità",
   "config.category.submodule": "Git ID Switcher: Sottomodulo",

--- a/extensions/git-id-switcher/package.nls.ja.json
+++ b/extensions/git-id-switcher/package.nls.ja.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "IDを選択",
   "command.showCurrentIdentity": "現在のIDを表示",
   "command.showDocumentation": "ドキュメントを表示",
+  "command.deleteIdentity": "プロフィールを削除",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: ID管理",
   "config.category.submodule": "Git ID Switcher: サブモジュール",

--- a/extensions/git-id-switcher/package.nls.json
+++ b/extensions/git-id-switcher/package.nls.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Select Identity",
   "command.showCurrentIdentity": "Show Current Identity",
   "command.showDocumentation": "Show Documentation",
+  "command.deleteIdentity": "Delete Identity",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Identity",
   "config.category.submodule": "Git ID Switcher: Submodule",

--- a/extensions/git-id-switcher/package.nls.ko.json
+++ b/extensions/git-id-switcher/package.nls.ko.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "ID 선택",
   "command.showCurrentIdentity": "현재 ID 표시",
   "command.showDocumentation": "문서 표시",
+  "command.deleteIdentity": "ID 삭제",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: ID 관리",
   "config.category.submodule": "Git ID Switcher: 서브모듈",

--- a/extensions/git-id-switcher/package.nls.pl.json
+++ b/extensions/git-id-switcher/package.nls.pl.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Wybierz tożsamość",
   "command.showCurrentIdentity": "Pokaż bieżącą tożsamość",
   "command.showDocumentation": "Pokaż dokumentację",
+  "command.deleteIdentity": "Usuń tożsamość",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Tożsamość",
   "config.category.submodule": "Git ID Switcher: Submoduł",

--- a/extensions/git-id-switcher/package.nls.pt-BR.json
+++ b/extensions/git-id-switcher/package.nls.pt-BR.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Selecionar Identidade",
   "command.showCurrentIdentity": "Mostrar Identidade Atual",
   "command.showDocumentation": "Mostrar Documentação",
+  "command.deleteIdentity": "Excluir Identidade",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Identidade",
   "config.category.submodule": "Git ID Switcher: Submódulo",

--- a/extensions/git-id-switcher/package.nls.ru.json
+++ b/extensions/git-id-switcher/package.nls.ru.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Выбрать идентификатор",
   "command.showCurrentIdentity": "Показать текущий идентификатор",
   "command.showDocumentation": "Показать документацию",
+  "command.deleteIdentity": "Удалить идентификатор",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Идентификация",
   "config.category.submodule": "Git ID Switcher: Подмодуль",

--- a/extensions/git-id-switcher/package.nls.tr.json
+++ b/extensions/git-id-switcher/package.nls.tr.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Kimlik Seç",
   "command.showCurrentIdentity": "Mevcut Kimliği Göster",
   "command.showDocumentation": "Belgeleri Göster",
+  "command.deleteIdentity": "Kimliği Sil",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Kimlik",
   "config.category.submodule": "Git ID Switcher: Alt modül",

--- a/extensions/git-id-switcher/package.nls.uk.json
+++ b/extensions/git-id-switcher/package.nls.uk.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "Вибрати ідентифікатор",
   "command.showCurrentIdentity": "Показати поточний ідентифікатор",
   "command.showDocumentation": "Показати документацію",
+  "command.deleteIdentity": "Видалити ідентифікатор",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: Ідентифікація",
   "config.category.submodule": "Git ID Switcher: Підмодуль",

--- a/extensions/git-id-switcher/package.nls.zh-CN.json
+++ b/extensions/git-id-switcher/package.nls.zh-CN.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "选择身份",
   "command.showCurrentIdentity": "显示当前身份",
   "command.showDocumentation": "显示文档",
+  "command.deleteIdentity": "删除身份",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: 身份管理",
   "config.category.submodule": "Git ID Switcher: 子模块",

--- a/extensions/git-id-switcher/package.nls.zh-TW.json
+++ b/extensions/git-id-switcher/package.nls.zh-TW.json
@@ -4,6 +4,7 @@
   "command.selectIdentity": "選擇身分",
   "command.showCurrentIdentity": "顯示目前身分",
   "command.showDocumentation": "顯示說明文件",
+  "command.deleteIdentity": "刪除身分",
   "config.title": "Git ID Switcher",
   "config.category.identity": "Git ID Switcher: 身份管理",
   "config.category.submodule": "Git ID Switcher: 子模組",


### PR DESCRIPTION
## Summary
- Add command title `command.deleteIdentity` to all 17 `package.nls.*.json` files
- Add 6 runtime messages for delete identity flow to all 17 `l10n/bundle.l10n.*.json` files
- Register `git-id-switcher.deleteIdentity` command in `package.json`

## Changes
- **35 files changed**: 17 package.nls files + 17 bundle.l10n files + 1 package.json
- **Languages**: English, Japanese, Bulgarian, Czech, German, Spanish, French, Hungarian, Italian, Korean, Polish, Portuguese (Brazil), Russian, Turkish, Ukrainian, Chinese (Simplified), Chinese (Traditional)

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes (0 errors, 2 pre-existing warnings)
- [x] `npm test` passes (all tests)
- [ ] Review i18n key consistency across all language files
- [ ] Verify command appears in VS Code command palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)