### PR TITLE
fix: use codicon in label for consistent icon display

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-01-28
+
+### Fixed
+
+- **Manage Profiles icon not visible without hover**:
+  - Use Codicon in label `$(gear)` instead of iconPath for consistent display
+- **Save button disabled state icon**:
+  - Changed from `$(loading~spin)` to `$(session-in-progress)` (static icon)
+
 ## [0.16.1] - 2026-01-28
 
 ### Fixed

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/test/e2e/identityManager.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/identityManager.test.ts
@@ -1019,7 +1019,7 @@ describe('identityManager E2E Test Suite', function () {
         );
         assert.ok(saveButton, 'Save button should be present');
         const label = (saveButton as { label: string }).label;
-        assert.ok(label.includes('$(loading~spin)'), `Save button should show $(loading~spin) when disabled, got: ${label}`);
+        assert.ok(label.includes('$(session-in-progress)'), `Save button should show $(session-in-progress) when disabled, got: ${label}`);
         assert.strictEqual((saveButton as { _isDisabled?: boolean })._isDisabled, true, 'Save button should be disabled');
       });
 

--- a/extensions/git-id-switcher/src/test/e2e/identityPicker.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/identityPicker.test.ts
@@ -292,8 +292,7 @@ describe('showIdentityQuickPick E2E Test Suite', function () {
       const manageItem = items.find(item => item._isManageOption === true);
       assert.ok(manageItem, 'Should have manage option');
       assert.ok(manageItem.label.includes('Manage'), 'Manage label should mention Manage');
-      assert.ok(manageItem.iconPath, 'Manage option should have iconPath');
-      assert.strictEqual(manageItem.iconPath?.id, 'gear', 'Manage option should have gear icon');
+      assert.ok(manageItem.label.includes('$(gear)'), 'Manage label should include gear icon codicon');
     });
   });
 

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': '54f16b767e57686b3eb46a2b4aa02b378554cc492c32c49ed96588f6d184b6b8',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': 'aee584f2ba3bd1b43b645997073c12379be379e4f7b6c6a3e54cb41ffdb822fb',
+  'extensions/git-id-switcher/CHANGELOG.md': '8731d6c5a1db51f4ac4084558f1ad5196a8bd54070fa97bc29f79766d281e3f1',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'a12dd717f83b28b648972a826701a29fcfd575e351c487f8c421402f80ac3d25',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/identityManager.ts
+++ b/extensions/git-id-switcher/src/ui/identityManager.ts
@@ -520,7 +520,7 @@ function buildAddFormItems(
   items.push({
     label: canSave
       ? `$(check) ${vs.l10n.t('Save')}`
-      : `$(loading~spin) ${vs.l10n.t('Save')}`,
+      : `$(session-in-progress) ${vs.l10n.t('Save')}`,
     description: canSave
       ? undefined
       : vs.l10n.t('(fill required fields)'),

--- a/extensions/git-id-switcher/src/ui/identityPicker.ts
+++ b/extensions/git-id-switcher/src/ui/identityPicker.ts
@@ -103,8 +103,7 @@ export async function showIdentityQuickPick(
   } as IdentityQuickPickItem;
 
   const manageItem: IdentityQuickPickItem = {
-    label: vs.l10n.t('Manage Profiles'),
-    iconPath: new vs.ThemeIcon('gear'),
+    label: `$(gear) ${vs.l10n.t('Manage Profiles')}`,
     identity: null as unknown as Identity,
     _isManageOption: true,
   };


### PR DESCRIPTION
## Summary

- Manage Profiles: use `$(gear)` in label instead of iconPath (iconPath only shows on hover without item buttons)
- Save button disabled: use `$(session-in-progress)` static icon instead of `$(loading~spin)` animated spinner

## Test plan

- [ ] Verify gear icon always visible for "Manage Profiles" option
- [ ] Verify save button shows static session-in-progress icon when disabled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)