### PR TITLE
fix: remove forced default icon for identities without icon

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.7] - 2026-01-30
+
+### Fixed
+
+- **Remove forced default icon (👤) for identities without an icon configured**:
+  - Status bar now shows only the identity name when no icon is set
+  - Previously, identities created without an icon always displayed 👤 in the status bar
+  - The default preset profile still shows 👤 as it has `"icon": "👤"` explicitly configured
+
 ## [0.16.6] - 2026-01-30
 
 ### Fixed

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': '54f16b767e57686b3eb46a2b4aa02b378554cc492c32c49ed96588f6d184b6b8',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '6093287b17cf311b5d3c77ee135a2bf45029cafc1b88e58212ba1bc453f118bd',
+  'extensions/git-id-switcher/CHANGELOG.md': 'c55d8013a0da0afbb51cfd08097c1ed38924e1758c0558c7d35eb816ae666040',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'a12dd717f83b28b648972a826701a29fcfd575e351c487f8c421402f80ac3d25',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/identityStatusBar.ts
+++ b/extensions/git-id-switcher/src/ui/identityStatusBar.ts
@@ -35,14 +35,14 @@ export class IdentityStatusBar implements vscode.Disposable {
 
   /**
    * Update status bar with current identity
-   * Shows emoji icon if configured, otherwise uses default 👤
+   * Shows emoji icon only if configured
    */
   setIdentity(identity: Identity): void {
     this.currentIdentity = identity;
-    // Use identity's icon if available, otherwise default emoji
-    const icon = identity.icon || '👤';
     // Truncate for status bar to avoid taking too much horizontal space
-    const displayText = truncateForStatusBar(`${icon} ${identity.name}`);
+    const displayText = truncateForStatusBar(
+      identity.icon ? `${identity.icon} ${identity.name}` : identity.name
+    );
     this.statusBarItem.text = displayText;
     this.statusBarItem.tooltip = new vscode.MarkdownString(
       this.buildTooltip(identity)


### PR DESCRIPTION
## Summary
- Remove hardcoded fallback icon (`identity.icon || '...'`) in status bar display
- Identities without an icon now show only the name in the status bar
- The default preset profile is unaffected as it has `"icon": "..."` explicitly configured
- Bump version to 0.16.7

## Test plan
- [x] All 356 tests pass
- [ ] Create new identity without icon -> verify status bar shows name only
- [ ] Verify default preset profile still shows person icon
- [ ] Verify identity with custom icon still displays correctly