### PR TITLE
fix: set ignoreFocusOut on all QuickPick dialogs

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.9] - 2026-02-01
+
+### Fixed
+
+- **All QuickPick dialogs now persist when the editor loses focus**:
+  - Previously, switching to another application (e.g., to copy text) would dismiss the QuickPick and discard all entered data
+  - Set `ignoreFocusOut = true` on all 5 QuickPick instances: new profile form, edit form, profile selector, delete picker, and manage screen
+  - Matches the existing InputBox behavior which already retained focus
+
 ## [0.16.8] - 2026-01-31
 
 ### Changed

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/test/e2e/deleteIdentityPicker.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/deleteIdentityPicker.test.ts
@@ -65,6 +65,7 @@ function createMockVSCode(options: {
 }) {
   let capturedItems: CapturedQuickPickItem[] = [];
   let capturedPlaceholder = '';
+  let capturedIgnoreFocusOut = false;
   let capturedTitle = '';
   const showWarningMessageCalls: string[] = [];
 
@@ -102,6 +103,8 @@ function createMockVSCode(options: {
           set placeholder(value: string) {
             capturedPlaceholder = value;
           },
+          get ignoreFocusOut() { return capturedIgnoreFocusOut; },
+          set ignoreFocusOut(value: boolean) { capturedIgnoreFocusOut = value; },
           matchOnDescription: false,
           matchOnDetail: false,
           get selectedItems(): T[] {
@@ -145,6 +148,7 @@ function createMockVSCode(options: {
     _getCapturedItems: () => capturedItems,
     _getCapturedPlaceholder: () => capturedPlaceholder,
     _getCapturedTitle: () => capturedTitle,
+    _getCapturedIgnoreFocusOut: () => capturedIgnoreFocusOut,
     _getShowWarningMessageCalls: () => showWarningMessageCalls,
   };
 }
@@ -177,6 +181,20 @@ describe('showDeleteIdentityQuickPick E2E Test Suite', function () {
         warnings[0].includes('No identities configured'),
         'Warning should mention no identities'
       );
+    });
+  });
+
+  describe('Focus Retention', () => {
+    it('should set ignoreFocusOut to prevent dismissal on focus change', async () => {
+      const mockVSCode = createMockVSCode({
+        identities: [TEST_IDENTITIES.work],
+        selectedIdentity: TEST_IDENTITIES.work,
+      });
+      _setMockVSCode(mockVSCode as never);
+
+      await showDeleteIdentityQuickPick();
+
+      assert.strictEqual(mockVSCode._getCapturedIgnoreFocusOut(), true, 'Delete identity QuickPick should have ignoreFocusOut=true');
     });
   });
 

--- a/extensions/git-id-switcher/src/test/e2e/handlers.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/handlers.test.ts
@@ -102,6 +102,7 @@ function createMockVSCode(options: {
           title: '',
           placeholder: '',
           buttons: [],
+          ignoreFocusOut: false,
           matchOnDescription: false,
           matchOnDetail: false,
           selectedItems: options.showQuickPickResult ? [{ identity: options.showQuickPickResult }] : [],
@@ -231,6 +232,7 @@ function createAddMockVSCode(options: {
           title: '',
           placeholder: '',
           buttons: [] as unknown[],
+          ignoreFocusOut: false,
           onDidAccept: (callback: () => void) => {
             acceptCallback = callback;
             return { dispose: () => {} };

--- a/extensions/git-id-switcher/src/test/e2e/identityPicker.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/identityPicker.test.ts
@@ -85,6 +85,7 @@ function createMockVSCode(options: {
   let capturedPlaceholder = '';
   let capturedTitle = '';
   let capturedButtons: unknown[] = [];
+  let capturedIgnoreFocusOut = false;
   const showWarningMessageCalls: string[] = [];
 
   return {
@@ -131,6 +132,8 @@ function createMockVSCode(options: {
           set activeItems(_value: T[]) {
             // Capture but don't need to track for tests
           },
+          get ignoreFocusOut() { return capturedIgnoreFocusOut; },
+          set ignoreFocusOut(value: boolean) { capturedIgnoreFocusOut = value; },
           matchOnDescription: false,
           matchOnDetail: false,
           get selectedItems(): T[] {
@@ -198,6 +201,7 @@ function createMockVSCode(options: {
     _getCapturedPlaceholder: () => capturedPlaceholder,
     _getCapturedTitle: () => capturedTitle,
     _getCapturedButtons: () => capturedButtons,
+    _getCapturedIgnoreFocusOut: () => capturedIgnoreFocusOut,
     _getShowWarningMessageCalls: () => showWarningMessageCalls,
   };
 }
@@ -230,6 +234,20 @@ describe('showIdentityQuickPick E2E Test Suite', function () {
         warnings[0].includes('No identities configured'),
         'Warning should mention no identities'
       );
+    });
+  });
+
+  describe('Focus Retention', () => {
+    it('should set ignoreFocusOut to prevent dismissal on focus change', async () => {
+      const mockVSCode = createMockVSCode({
+        identities: [TEST_IDENTITIES.work],
+        selectedIdentity: TEST_IDENTITIES.work,
+      });
+      _setMockVSCode(mockVSCode as never);
+
+      await showIdentityQuickPick();
+
+      assert.strictEqual(mockVSCode._getCapturedIgnoreFocusOut(), true, 'Select profile QuickPick should have ignoreFocusOut=true');
     });
   });
 
@@ -461,6 +479,7 @@ function createManageMockVSCode(options: {
   let capturedTitle = '';
   let capturedButtons: unknown[] = [];
   let capturedActiveItems: CapturedManageQuickPickItem[] = [];
+  let capturedIgnoreFocusOut = false;
 
   return {
     workspace: {
@@ -503,6 +522,8 @@ function createManageMockVSCode(options: {
           get activeItems(): T[] {
             return capturedActiveItems as unknown as T[];
           },
+          get ignoreFocusOut() { return capturedIgnoreFocusOut; },
+          set ignoreFocusOut(value: boolean) { capturedIgnoreFocusOut = value; },
           matchOnDescription: false,
           matchOnDetail: false,
           get selectedItems(): T[] {
@@ -604,6 +625,7 @@ function createManageMockVSCode(options: {
     _getCapturedTitle: () => capturedTitle,
     _getCapturedButtons: () => capturedButtons,
     _getCapturedActiveItems: () => capturedActiveItems,
+    _getCapturedIgnoreFocusOut: () => capturedIgnoreFocusOut,
   };
 }
 
@@ -616,6 +638,20 @@ describe('showManageIdentitiesQuickPick E2E Test Suite', function () {
 
   afterEach(() => {
     _resetCache();
+  });
+
+  describe('Focus Retention', () => {
+    it('should set ignoreFocusOut to prevent dismissal on focus change', async () => {
+      const mockVSCode = createManageMockVSCode({
+        identities: [TEST_IDENTITIES.work],
+        triggerAction: 'hide',
+      });
+      _setMockVSCode(mockVSCode as never);
+
+      await showManageIdentitiesQuickPick([TEST_IDENTITIES.work]);
+
+      assert.strictEqual(mockVSCode._getCapturedIgnoreFocusOut(), true, 'Manage profiles QuickPick should have ignoreFocusOut=true');
+    });
   });
 
   describe('Basic UI', () => {

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': '54f16b767e57686b3eb46a2b4aa02b378554cc492c32c49ed96588f6d184b6b8',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '5e0833ce75bf64f50e010d3930eae07a0f7418f6854333b863f1c6a25ebf81be',
+  'extensions/git-id-switcher/CHANGELOG.md': '3b18be1ee2c5d09c0b9c8c4ebdef1380bcad712d627e3d698fe14548080e0cad',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'a12dd717f83b28b648972a826701a29fcfd575e351c487f8c421402f80ac3d25',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/identityManager.ts
+++ b/extensions/git-id-switcher/src/ui/identityManager.ts
@@ -867,6 +867,7 @@ async function executeAddFormLoop(
   const quickPick = vs.window.createQuickPick<AddFormQuickPickItem>();
   quickPick.title = vs.l10n.t('New Profile');
   quickPick.placeholder = vs.l10n.t('Filter...');
+  quickPick.ignoreFocusOut = true;
   quickPick.buttons = [vs.QuickInputButtons.Back];
 
   try {
@@ -994,6 +995,7 @@ async function showFieldSelectionQuickPick(
   const quickPick = vs.window.createQuickPick<FieldQuickPickItem>();
   quickPick.title = vs.l10n.t('Edit Identity: {0}', identity.id);
   quickPick.placeholder = vs.l10n.t('Filter...');
+  quickPick.ignoreFocusOut = true;
   quickPick.buttons = [vs.QuickInputButtons.Back];
   quickPick.items = buildFieldItems(vs, identity, savedField, identityCount);
 

--- a/extensions/git-id-switcher/src/ui/identityPicker.ts
+++ b/extensions/git-id-switcher/src/ui/identityPicker.ts
@@ -122,6 +122,7 @@ export async function showIdentityQuickPick(
   quickPick.items = allItems;
   quickPick.title = vs.l10n.t('Select Profile');
   quickPick.placeholder = vs.l10n.t('Search profiles...');
+  quickPick.ignoreFocusOut = true;
   quickPick.buttons = [manageButton];
   quickPick.matchOnDescription = true;
   quickPick.matchOnDetail = true;
@@ -243,6 +244,7 @@ export async function showDeleteIdentityQuickPick(
   quickPick.items = items;
   quickPick.title = vs.l10n.t('Delete Identity');
   quickPick.placeholder = vs.l10n.t('Select identity to delete');
+  quickPick.ignoreFocusOut = true;
   quickPick.matchOnDescription = true;
   quickPick.matchOnDetail = true;
 
@@ -349,6 +351,7 @@ export async function showManageIdentitiesQuickPick(
   const quickPick = vs.window.createQuickPick<ManageIdentityQuickPickItem>();
   quickPick.items = items;
   quickPick.title = vs.l10n.t('Manage Profiles');
+  quickPick.ignoreFocusOut = true;
   quickPick.buttons = [vs.QuickInputButtons.Back, addButton];
   quickPick.matchOnDescription = true;
   quickPick.matchOnDetail = true;


### PR DESCRIPTION
### **User description**
## Summary
- Set `ignoreFocusOut = true` on all 5 QuickPick instances to prevent data loss when the editor loses focus (e.g., switching to another app to copy text)
- Added 5 tests (one per QuickPick) asserting `ignoreFocusOut` is set, plus updated 4 mock files for consistency
- Bump version to 0.16.9

## Test plan
- [x] All 373 E2E tests pass
- [x] All security tests pass
- [ ] Manual test: open new profile form → switch to another app → return to VS Code → form should still be open
- [ ] Manual test: open edit form → switch to another app → return → form persists
- [ ] Manual test: open profile selector → switch → return → picker persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Set `ignoreFocusOut = true` on all 5 QuickPick dialogs to prevent data loss when editor loses focus

- Added comprehensive tests for each QuickPick instance to verify focus retention behavior

- Updated all mock VSCode implementations to support `ignoreFocusOut` property

- Bumped version to 0.16.9 and updated CHANGELOG with fix details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["QuickPick Dialogs<br/>5 instances"] -->|"Set ignoreFocusOut=true"| B["Focus Retention<br/>Prevents dismissal"]
  B -->|"Matches behavior"| C["InputBox<br/>Already had focus retention"]
  D["Test Mocks<br/>4 files"] -->|"Add ignoreFocusOut<br/>property support"| E["Test Coverage<br/>5 new tests"]
  E -->|"Verify"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>identityManager.ts</strong><dd><code>Set ignoreFocusOut on add and edit form QuickPicks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-44b589e61faf4b8e990b61f78426d7f9e0a4c4309ff1fe2675a5908026f195e9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identityPicker.ts</strong><dd><code>Set ignoreFocusOut on all picker QuickPick instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-340162c6fe1d58a56b7f36b82a69949b2fd9944eab9519659fc68778a6bcb632">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>deleteIdentityPicker.test.ts</strong><dd><code>Add ignoreFocusOut mock support and test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-f2b18e53073c22e44145c18cc0a0efe33ae4b0b26d83e51a5b1966e05b7c46db">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identityPicker.test.ts</strong><dd><code>Add ignoreFocusOut mock support and test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-2aac5bc2e0655f419a3407908aaba8b51bf3ba7a28206f65804c916a2e571ae5">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identityManager.test.ts</strong><dd><code>Add ignoreFocusOut mock support and test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-ba1f88bc5dc30fd7f581bc95dcb032587b5a182b56db583b495279c40ce29c23">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handlers.test.ts</strong><dd><code>Add ignoreFocusOut property to mock QuickPicks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-654e98925306fe3a924dc2375919ef17d26a66a0a8d3e1ca6745960f933dde19">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document fix for QuickPick focus retention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-b59256585854bdd2d670ae154a3649ccddca95a22825a3aea473bbc1c132f2c6">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Bump version to 0.16.9</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-df2ff0ced7db6a80bf6b63d774a1d1c816f4c292e9d1d6526bf11e481a2c59b2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>documentationInternal.ts</strong><dd><code>Update CHANGELOG hash for documentation changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/253/files#diff-201a8ea7056fa1afeddff16030b3f6c395fde96b57bd79d4cb7dab2de613bf00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

