### PR TITLE
fix: differentiate ignoreFocusOut by QuickPick type

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.10] - 2026-02-02
+
+### Fixed
+
+- **Profile selector and delete picker now dismiss normally on focus loss**:
+  - v0.16.9 applied `ignoreFocusOut` to all QuickPick dialogs, which prevented simple pickers from being dismissed by clicking outside
+  - Now only form-style dialogs (new profile, edit, manage) retain focus; simple pickers follow standard VS Code behavior
+
 ## [0.16.9] - 2026-02-01
 
 ### Fixed

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.9",
+  "version": "0.16.10",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/test/e2e/deleteIdentityPicker.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/deleteIdentityPicker.test.ts
@@ -184,8 +184,8 @@ describe('showDeleteIdentityQuickPick E2E Test Suite', function () {
     });
   });
 
-  describe('Focus Retention', () => {
-    it('should set ignoreFocusOut to prevent dismissal on focus change', async () => {
+  describe('Focus Behavior', () => {
+    it('should not set ignoreFocusOut (simple picker dismisses on focus loss)', async () => {
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work],
         selectedIdentity: TEST_IDENTITIES.work,
@@ -194,7 +194,7 @@ describe('showDeleteIdentityQuickPick E2E Test Suite', function () {
 
       await showDeleteIdentityQuickPick();
 
-      assert.strictEqual(mockVSCode._getCapturedIgnoreFocusOut(), true, 'Delete identity QuickPick should have ignoreFocusOut=true');
+      assert.strictEqual(mockVSCode._getCapturedIgnoreFocusOut(), false, 'Delete identity QuickPick should not set ignoreFocusOut');
     });
   });
 

--- a/extensions/git-id-switcher/src/test/e2e/identityPicker.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/identityPicker.test.ts
@@ -237,8 +237,8 @@ describe('showIdentityQuickPick E2E Test Suite', function () {
     });
   });
 
-  describe('Focus Retention', () => {
-    it('should set ignoreFocusOut to prevent dismissal on focus change', async () => {
+  describe('Focus Behavior', () => {
+    it('should not set ignoreFocusOut (simple picker dismisses on focus loss)', async () => {
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work],
         selectedIdentity: TEST_IDENTITIES.work,
@@ -247,7 +247,7 @@ describe('showIdentityQuickPick E2E Test Suite', function () {
 
       await showIdentityQuickPick();
 
-      assert.strictEqual(mockVSCode._getCapturedIgnoreFocusOut(), true, 'Select profile QuickPick should have ignoreFocusOut=true');
+      assert.strictEqual(mockVSCode._getCapturedIgnoreFocusOut(), false, 'Select profile QuickPick should not set ignoreFocusOut');
     });
   });
 

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': '54f16b767e57686b3eb46a2b4aa02b378554cc492c32c49ed96588f6d184b6b8',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '3b18be1ee2c5d09c0b9c8c4ebdef1380bcad712d627e3d698fe14548080e0cad',
+  'extensions/git-id-switcher/CHANGELOG.md': 'b5bf6fb072263ef4a2c512cf583c31c9fbf3ab19ceb637304548bc4ff5cae6e1',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'a12dd717f83b28b648972a826701a29fcfd575e351c487f8c421402f80ac3d25',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/identityPicker.ts
+++ b/extensions/git-id-switcher/src/ui/identityPicker.ts
@@ -122,7 +122,6 @@ export async function showIdentityQuickPick(
   quickPick.items = allItems;
   quickPick.title = vs.l10n.t('Select Profile');
   quickPick.placeholder = vs.l10n.t('Search profiles...');
-  quickPick.ignoreFocusOut = true;
   quickPick.buttons = [manageButton];
   quickPick.matchOnDescription = true;
   quickPick.matchOnDetail = true;
@@ -244,7 +243,6 @@ export async function showDeleteIdentityQuickPick(
   quickPick.items = items;
   quickPick.title = vs.l10n.t('Delete Identity');
   quickPick.placeholder = vs.l10n.t('Select identity to delete');
-  quickPick.ignoreFocusOut = true;
   quickPick.matchOnDescription = true;
   quickPick.matchOnDetail = true;
 


### PR DESCRIPTION
### **User description**
## Summary
- Removed `ignoreFocusOut = true` from profile selector and delete picker (simple one-shot pickers with no unsaved state)
- Kept `ignoreFocusOut = true` on new profile form, edit form, and manage screen (form-style dialogs where data loss is a risk)
- Updated 2 test assertions from `true` to `false` with renamed describe/it blocks
- Bump version to 0.16.10

## Test plan
- [x] All 373 E2E tests pass
- [ ] Manual: profile selector dismisses when clicking outside or switching apps
- [ ] Manual: delete picker dismisses when clicking outside or switching apps
- [ ] Manual: new profile form persists when switching apps
- [ ] Manual: edit form persists when switching apps
- [ ] Manual: manage screen persists when switching apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `ignoreFocusOut` from simple one-shot pickers (profile selector, delete picker)

- Keep `ignoreFocusOut` on form-style dialogs to prevent data loss

- Update test assertions and descriptions to reflect new focus behavior

- Bump version to 0.16.10 and update CHANGELOG


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Simple Pickers<br/>Profile Selector<br/>Delete Picker"] -->|Remove ignoreFocusOut| B["Standard VS Code<br/>Dismiss on Focus Loss"]
  C["Form-Style Dialogs<br/>New Profile<br/>Edit Form<br/>Manage Screen"] -->|Keep ignoreFocusOut| D["Retain Focus<br/>Prevent Data Loss"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>identityPicker.ts</strong><dd><code>Remove ignoreFocusOut from simple pickers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/src/ui/identityPicker.ts

<ul><li>Removed <code>quickPick.ignoreFocusOut = true</code> from <code>showIdentityQuickPick()</code> <br>function<br> <li> Removed <code>quickPick.ignoreFocusOut = true</code> from <br><code>showDeleteIdentityQuickPick()</code> function<br> <li> Simple pickers now follow standard VS Code behavior and dismiss on <br>focus loss</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/257/files#diff-340162c6fe1d58a56b7f36b82a69949b2fd9944eab9519659fc68778a6bcb632">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>identityPicker.test.ts</strong><dd><code>Update profile selector focus behavior tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/src/test/e2e/identityPicker.test.ts

<ul><li>Renamed describe block from 'Focus Retention' to 'Focus Behavior'<br> <li> Updated test assertion from <code>true</code> to <code>false</code> for profile selector <br>ignoreFocusOut<br> <li> Updated test description to reflect that simple picker should not set <br>ignoreFocusOut</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/257/files#diff-2aac5bc2e0655f419a3407908aaba8b51bf3ba7a28206f65804c916a2e571ae5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deleteIdentityPicker.test.ts</strong><dd><code>Update delete picker focus behavior tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/src/test/e2e/deleteIdentityPicker.test.ts

<ul><li>Renamed describe block from 'Focus Retention' to 'Focus Behavior'<br> <li> Updated test assertion from <code>true</code> to <code>false</code> for delete picker <br>ignoreFocusOut<br> <li> Updated test description to reflect that simple picker should not set <br>ignoreFocusOut</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/257/files#diff-f2b18e53073c22e44145c18cc0a0efe33ae4b0b26d83e51a5b1966e05b7c46db">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version to 0.16.10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/package.json

- Bumped version from 0.16.9 to 0.16.10


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/257/files#diff-df2ff0ced7db6a80bf6b63d774a1d1c816f4c292e9d1d6526bf11e481a2c59b2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document version 0.16.10 focus behavior fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/CHANGELOG.md

<ul><li>Added new section for version 0.16.10 with release date 2026-02-02<br> <li> Documented fix for profile selector and delete picker focus behavior<br> <li> Explained that simple pickers now dismiss on focus loss while form <br>dialogs retain focus</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/257/files#diff-b59256585854bdd2d670ae154a3649ccddca95a22825a3aea473bbc1c132f2c6">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>documentationInternal.ts</strong><dd><code>Update documentation hash for CHANGELOG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/src/ui/documentationInternal.ts

<ul><li>Updated CHANGELOG.md hash from old value to new value reflecting <br>version 0.16.10 changes</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/257/files#diff-201a8ea7056fa1afeddff16030b3f6c395fde96b57bd79d4cb7dab2de613bf00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

