### PR TITLE
chore: bump version to 0.16.14 with l10n changelog

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.14] - 2026-02-04
+
+### Changed
+
+- **L10n terminology unified to "profile" for better user comprehension**:
+  - Updated all 17 language bundle files (`bundle.l10n.*.json`)
+  - Changed "identity" → "profile" in user-facing UI text (status bar, QuickPick items, messages)
+  - Internal code and settings still use "identity" for backward compatibility
+
 ## [0.16.13] - 2026-02-03
 
 ### Documentation

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': '54f16b767e57686b3eb46a2b4aa02b378554cc492c32c49ed96588f6d184b6b8',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '37f11892af5092c9d7272df671cdc9543c6a27308b8ac88b2511d7948479ad86',
+  'extensions/git-id-switcher/CHANGELOG.md': '75d29d9f427c29d3907b51b219e0ddcf5e1d95f4c8e863d93783a1caf8c7a9cd',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'a12dd717f83b28b648972a826701a29fcfd575e351c487f8c421402f80ac3d25',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',


### PR DESCRIPTION
### **User description**
## Summary
- Bump version from 0.16.13 to 0.16.14
- Add CHANGELOG entry for l10n terminology unification (identity → profile)

## Context
PR #264 merged l10n terminology changes but missed version bump and changelog update. This PR fixes that oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Bump version from 0.16.13 to 0.16.14

- Add CHANGELOG entry for l10n terminology unification

- Update documentation hash for CHANGELOG.md file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version Update"] --> B["0.16.13 → 0.16.14"]
  C["CHANGELOG Entry"] --> D["L10n terminology changes"]
  E["Documentation Hash"] --> F["Updated for CHANGELOG.md"]
  B --> G["Release"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Version bump to 0.16.14</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/package.json

- Updated version field from 0.16.13 to 0.16.14


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/265/files#diff-df2ff0ced7db6a80bf6b63d774a1d1c816f4c292e9d1d6526bf11e481a2c59b2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add version 0.16.14 changelog entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/CHANGELOG.md

<ul><li>Added new section for version 0.16.14 released on 2026-02-04<br> <li> Documented l10n terminology unification from "identity" to "profile"<br> <li> Listed changes across 17 language bundle files and UI text updates<br> <li> Noted backward compatibility for internal code and settings</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/265/files#diff-b59256585854bdd2d670ae154a3649ccddca95a22825a3aea473bbc1c132f2c6">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>documentationInternal.ts</strong><dd><code>Update documentation hash for CHANGELOG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/src/ui/documentationInternal.ts

<ul><li>Updated CHANGELOG.md hash value to reflect new content<br> <li> Changed hash from <br>37f11892af5092c9d7272df671cdc9543c6a27308b8ac88b2511d7948479ad86 to <br>75d29d9f427c29d3907b51b219e0ddcf5e1d95f4c8e863d93783a1caf8c7a9cd</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/265/files#diff-201a8ea7056fa1afeddff16030b3f6c395fde96b57bd79d4cb7dab2de613bf00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

