### PR TITLE
docs(i18n): update zh-CN README to match ja/en structure

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# Run lint-staged for prettier formatting on staged files
+npx lint-staged
+
 # Auto-regenerate README.md when i18n/en/README.md changes
 # This ensures all commits are signed by the developer, not by GitHub Actions
 

--- a/extensions/git-id-switcher/docs/i18n/zh-CN/README.md
+++ b/extensions/git-id-switcher/docs/i18n/zh-CN/README.md
@@ -249,21 +249,21 @@ Host bitbucket.org
 
 ### 全局设置
 
-| 设置                                       | 默认值     | 描述                                                                               |
-| ------------------------------------------ | ---------- | ---------------------------------------------------------------------------------- |
-| `gitIdSwitcher.identities`                 | 见示例     | 身份配置列表                                                                       |
-| `gitIdSwitcher.defaultIdentity`            | 见示例     | 默认使用的身份 ID                                                                  |
-| `gitIdSwitcher.autoSwitchSshKey`           | `true`     | 切换身份时自动切换 SSH 密钥                                                        |
-| `gitIdSwitcher.showNotifications`          | `true`     | 切换身份时显示通知                                                                 |
-| `gitIdSwitcher.applyToSubmodules`          | `true`     | 将身份传播到 Git 子模块                                                            |
-| `gitIdSwitcher.submoduleDepth`             | `1`        | 嵌套子模块配置的最大深度（1-5）                                                    |
-| `gitIdSwitcher.includeIconInGitConfig`     | `false`    | 在 Git config `user.name` 中包含图标表情符号                                       |
-| `gitIdSwitcher.logging.fileEnabled`        | `false`    | 将审计日志保存到文件（记录身份切换、SSH 密钥操作等）                               |
-| `gitIdSwitcher.logging.filePath`           | `""`       | 日志文件路径（如 `~/.git-id-switcher/security.log`）。空字符串使用默认路径         |
-| `gitIdSwitcher.logging.maxFileSize`        | `10485760` | 轮换前的最大文件大小（字节，1MB-100MB）                                            |
-| `gitIdSwitcher.logging.maxFiles`           | `5`        | 保留的轮换日志文件最大数量（1-20）                                                 |
-| `gitIdSwitcher.logging.redactAllSensitive` | `false`    | 启用时，日志中的所有值都会被掩码（最大隐私模式）                                   |
-| `gitIdSwitcher.logging.level`              | `"INFO"`   | 日志详细程度（`DEBUG`、`INFO`、`WARN`、`ERROR`、`SECURITY`）。记录选定级别及以上   |
+| 设置                                       | 默认值     | 描述                                                                                |
+| ------------------------------------------ | ---------- | ----------------------------------------------------------------------------------- |
+| `gitIdSwitcher.identities`                 | 见示例     | 身份配置列表                                                                        |
+| `gitIdSwitcher.defaultIdentity`            | 见示例     | 默认使用的身份 ID                                                                   |
+| `gitIdSwitcher.autoSwitchSshKey`           | `true`     | 切换身份时自动切换 SSH 密钥                                                         |
+| `gitIdSwitcher.showNotifications`          | `true`     | 切换身份时显示通知                                                                  |
+| `gitIdSwitcher.applyToSubmodules`          | `true`     | 将身份传播到 Git 子模块                                                             |
+| `gitIdSwitcher.submoduleDepth`             | `1`        | 嵌套子模块配置的最大深度（1-5）                                                     |
+| `gitIdSwitcher.includeIconInGitConfig`     | `false`    | 在 Git config `user.name` 中包含图标表情符号                                        |
+| `gitIdSwitcher.logging.fileEnabled`        | `false`    | 将审计日志保存到文件（记录身份切换、SSH 密钥操作等）                                |
+| `gitIdSwitcher.logging.filePath`           | `""`       | 日志文件路径（如 `~/.git-id-switcher/security.log`）。空字符串使用默认路径          |
+| `gitIdSwitcher.logging.maxFileSize`        | `10485760` | 轮换前的最大文件大小（字节，1MB-100MB）                                             |
+| `gitIdSwitcher.logging.maxFiles`           | `5`        | 保留的轮换日志文件最大数量（1-20）                                                  |
+| `gitIdSwitcher.logging.redactAllSensitive` | `false`    | 启用时，日志中的所有值都会被掩码（最大隐私模式）                                    |
+| `gitIdSwitcher.logging.level`              | `"INFO"`   | 日志详细程度（`DEBUG`、`INFO`、`WARN`、`ERROR`、`SECURITY`）。记录选定级别及以上    |
 | `gitIdSwitcher.commandTimeouts`            | `{}`       | 每个命令的自定义超时值（毫秒，1 秒-5 分钟）。例：`{"git": 15000, "ssh-add": 10000}` |
 
 #### 关于 `includeIconInGitConfig`
@@ -336,12 +336,12 @@ Git ID Switcher 通过 `ssh-agent` 管理 SSH 密钥：
 
 如果您已有 SSH 配置，Git ID Switcher 会与其协同工作：
 
-| 您的设置                              | Git ID Switcher 的行为                               |
-| ------------------------------------- | ---------------------------------------------------- |
-| `~/.ssh/config` 中指定 `IdentityFile` | 两者都可使用；使用 `IdentitiesOnly yes` 防止冲突     |
-| 环境变量 `GIT_SSH_COMMAND`            | 使用您的自定义 SSH 命令；ssh-agent 仍然有效          |
-| `git config core.sshCommand`          | 同上                                                 |
-| direnv 设置 SSH 相关环境变量          | 可以共存；ssh-agent 独立运行                         |
+| 您的设置                              | Git ID Switcher 的行为                           |
+| ------------------------------------- | ------------------------------------------------ |
+| `~/.ssh/config` 中指定 `IdentityFile` | 两者都可使用；使用 `IdentitiesOnly yes` 防止冲突 |
+| 环境变量 `GIT_SSH_COMMAND`            | 使用您的自定义 SSH 命令；ssh-agent 仍然有效      |
+| `git config core.sshCommand`          | 同上                                             |
+| direnv 设置 SSH 相关环境变量          | 可以共存；ssh-agent 独立运行                     |
 
 **推荐:** 始终在 SSH 配置中使用 `IdentitiesOnly yes`。这可以防止 SSH 尝试多个密钥。
 

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -53,7 +53,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'extensions/git-id-switcher/docs/i18n/x-lolcat/README.md': 'c589c0469f376ea75ab93e945086f0f5a0b983a74600c4a9eb6f399710408faf',
   'extensions/git-id-switcher/docs/i18n/x-pirate/README.md': '2b38158e94bda57815dc39f271713186ad4e159665294bbbed090204dfe0fe10',
   'extensions/git-id-switcher/docs/i18n/x-shakespeare/README.md': '01df937e7785defb46087bace47b5b266794050e83c139c7fb1e17daf877c3b8',
-  'extensions/git-id-switcher/docs/i18n/zh-CN/README.md': '5d0828fb8bca3c13640e1a880ce25b7cda9cdb2e9b4e1ef6597a7d8ee30af174',
+  'extensions/git-id-switcher/docs/i18n/zh-CN/README.md': 'ca003fddc583d148b59cb41ea15ca3f1dfa4ae935c5eec53a33e2b25c23ed23c',
   'extensions/git-id-switcher/docs/i18n/zh-TW/README.md': '5b6abf9f58aea42d4dab5d05fc484be45be1ee47ba7e1b59ab7cd86043902390',
   'extensions/git-id-switcher/docs/LANGUAGES.md': 'da50222843094479fd826837038dd62d619ecbc87d67f0b2c299973587abe8e9',
   'extensions/git-id-switcher/LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,12 @@
       ],
       "devDependencies": {
         "husky": "^9.1.7",
+        "lint-staged": "^16.2.7",
         "prettier": "^3.8.1"
       }
     },
     "extensions/git-id-switcher": {
-      "version": "0.16.13",
+      "version": "0.16.15",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -1802,6 +1803,86 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
+      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "dev": true,
@@ -1855,6 +1936,13 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2481,6 +2569,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
@@ -3456,6 +3551,115 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
+      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.2",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^2.0.0",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -3533,6 +3737,115 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/lru-cache": {
@@ -3822,6 +4135,19 @@
       "version": "0.0.8",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
+      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -4278,6 +4604,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "dev": true,
@@ -4575,6 +4914,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -4906,6 +5252,16 @@
       "version": "5.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -5669,6 +6025,22 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,13 @@
   },
   "devDependencies": {
     "husky": "^9.1.7",
+    "lint-staged": "^16.2.7",
     "prettier": "^3.8.1"
   },
   "overrides": {
     "diff": "^8.0.3"
+  },
+  "lint-staged": {
+    "*.md": "prettier --write"
   }
 }


### PR DESCRIPTION
### **User description**
## Summary

- Rewrite zh-CN README based on ja version for structural consistency
- Add Identity Management UI section
- Add Delete Identity command to commands table
- Add SSH key management details section
- Add IdentitiesOnly yes explanation section
- Update image paths to zh-CN localized versions
- Update Quick Start to new UI-based setup flow

## Test plan

- [ ] Verify zh-CN README renders correctly on GitHub
- [ ] Confirm all internal anchor links work
- [ ] Check image paths are correct

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Documentation


___

### **Description**
- Restructure zh-CN README to match ja/en documentation layout

- Add Identity Management UI section with visual guide

- Add Delete Identity command to commands reference table

- Add SSH key management and IdentitiesOnly configuration details

- Update demo image paths to localized zh-CN versions with lazy loading

- Simplify Quick Start flow to UI-based setup instead of JSON editing

- Improve formatting with consistent spacing around Chinese text


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["zh-CN README"] -->|"Restructure sections"| B["Match ja/en layout"]
  A -->|"Add UI guide"| C["Identity Management section"]
  A -->|"Update images"| D["Localized zh-CN paths with lazy loading"]
  A -->|"Simplify setup"| E["UI-based instead of JSON editing"]
  A -->|"Add details"| F["SSH key management & IdentitiesOnly"]
  B --> G["Updated documentation"]
  C --> G
  D --> G
  E --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Restructure zh-CN README with UI-based setup guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/docs/i18n/zh-CN/README.md

<ul><li>Restructured Quick Start section to use UI-based identity management <br>instead of manual JSON editing<br> <li> Added new "Identity Management" section with visual guide for adding, <br>editing, deleting and reordering identities<br> <li> Added "SSH 密钥管理详情" (SSH Key Management Details) section explaining <br>ssh-agent operations and IdentitiesOnly configuration<br> <li> Updated demo image paths from <code>demo-zh-CN.png</code> to <code>zh-CN/demo.webp</code> and <br>added new <code>zh-CN/first-ux.webp</code> and <code>zh-CN/identity-management.webp</code> with <br>lazy loading<br> <li> Improved Chinese text formatting with consistent spacing around <br>technical terms (Git, GitHub, VS Code, SSH, GPG)<br> <li> Reorganized feature list to prioritize Identity Management UI as first <br>feature<br> <li> Moved Commands section before Configuration Reference for better <br>navigation<br> <li> Enhanced troubleshooting section with new "推送时身份错误" subsection for <br>cloning with SSH host aliases<br> <li> Updated configuration descriptions for clarity and consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/268/files#diff-cc94e0fba94a308e347926ce0e435a19bda711fcb36b4003d360219067ff6ffd">+132/-167</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>documentationInternal.ts</strong><dd><code>Update zh-CN README document hash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/git-id-switcher/src/ui/documentationInternal.ts

<ul><li>Updated document hash for zh-CN README.md to reflect structural <br>changes and content updates</ul>


</details>


  </td>
  <td><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/pull/268/files#diff-201a8ea7056fa1afeddff16030b3f6c395fde96b57bd79d4cb7dab2de613bf00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

