### PR TITLE
docs(i18n): update LOLcat (x-lolcat) README to new structure

### DIFF
--- a/extensions/git-id-switcher/docs/i18n/x-lolcat/README.md
+++ b/extensions/git-id-switcher/docs/i18n/x-lolcat/README.md
@@ -10,7 +10,7 @@
       <img src="https://assets.nullvariant.com/nullvariant-vscode-extensions/extensions/git-id-switcher/images/icon.png" width="128" alt="Git ID Switcher">
     </td>
     <td>
-      SWITCH BETWEN UR MULTIPLE GIT IDENTITIEZ WIF WUN CLIK. MANAGE LOTZ OF GITHUB ACCOUNTZ, SSH KEYZ, GPG SININ, AN <b>AUTOMAGICALLY APPLY IDENTITY 2 GIT SUBMODULEZ</b>. KTHXBAI!
+      SWITCH BETWEN UR MULTIPLE GIT PROFILEZ WIF WUN CLIK. MANAGE LOTZ OF GITHUB ACCOUNTZ, SSH KEYZ, GPG SININ, AN <b>AUTOMAGICALLY APPLY PROFILE 2 GIT SUBMODULEZ</b>. KTHXBAI!
       <br><br>
       <a href="https://marketplace.visualstudio.com/items?itemName=nullvariant.git-id-switcher"><img src="https://img.shields.io/visual-studio-marketplace/v/nullvariant.git-id-switcher" alt="VS Code Marketplace"></a>
       <a href="https://open-vsx.org/extension/nullvariant/git-id-switcher"><img src="https://img.shields.io/open-vsx/v/nullvariant/git-id-switcher" alt="Open VSX Registry"></a>
@@ -33,31 +33,36 @@
 
 <br>
 
-<img src="https://assets.nullvariant.com/nullvariant-vscode-extensions/extensions/git-id-switcher/images/demo-x-lolcat.png" width="600" alt="Demo">
+<img src="https://assets.nullvariant.com/nullvariant-vscode-extensions/extensions/git-id-switcher/images/x-lolcat/demo.webp" width="600" alt="Demo" loading="lazy">
 
 ## 🎯 Y DIS EXTENSHUN?
 
-WILE MANY GIT IDENTITY SWITCHERZ EXIST, **GIT ID SWITCHER** SOLVEZ TEH HARD PROBLEMZ:
+WILE MANY GIT PROFILE SWITCHERZ EXIST, **GIT ID SWITCHER** SOLVEZ TEH HARD PROBLEMZ DAT OTHR TOOLZ MISS:
 
-1. **SUBMODULEZ NITEMARE**: WERKIN WIF REPOSITORIEZ DAT HAZ SUBMODULEZ USUALLY REQUIREZ SETTIN `git config user.name` MANUALLY 4 _EACH_ SUBMODULE. DIS EXTENSHUN HANDLEZ IT BY RECURSIVELY APPLYIN UR IDENTITY 2 ALL ACTIVE SUBMODULEZ. SO SMRT!
-2. **SSH & GPG HANDLIN**: IT DONT JUS CHANGE UR NAEM; IT SWAPZ UR SSH KEYZ IN TEH AGENT AN CONFIGUREZ GPG SININ SO U NEVR COMMIT WIF TEH RONG SIGNATUR. NO MOAR FAILZ!
+1. **SUBMODULEZ NITEMARE**: WERKIN WIF REPOSITORIEZ DAT HAZ SUBMODULEZ (LIEK HUGO TEMEZ, VENDOR LIBRARIEZ), U USUALLY HAZ 2 SET `git config user.name` MANUALLY 4 _EACH_ SUBMODULE. DIS EXTENSHUN SOLVEZ IT BY RECURSIVELY APPLYIN UR PROFILE 2 ALL ACTIVE SUBMODULEZ. SO SMRT!
+2. **SSH & GPG HANDLIN**: IT DONT JUS CHANGE UR NAEM; IT SWAPZ UR SSH KEYZ IN SSH-AGENT AN CONFIGUREZ GPG SININ SO U NEVR COMMIT WIF TEH RONG SIGNATUR. NO MOAR FAILZ!
 
 ## FEATUREZ 😺
 
-- **SUBMODULE SUPPORT**: AUTOMAGICALLY PROPAGATE UR IDENTITY 2 GIT SUBMODULEZ
+- **PROFILE MANAGEMINT UI**: ADD, EDIT, DELEET, AN REORDR PROFILEZ WITHOUT EDITIN settings.json. SO EZ!
+- **WUN-CLIK PROFILE SWITCH**: CHANGE UR GIT USER.NAME AN USER.EMAIL LIEK SPEEDEE CAT
+- **STATUS BAR**: ALWAYZ C UR CURRENT PROFILE AT A GLANS
+- **SUBMODULE SUPPORT**: AUTOMAGICALLY PROPAGATE UR PROFILE 2 GIT SUBMODULEZ
 - **SSH KEY MANAGEMINT**: AUTOMAGICALLY SWITCH UR SSH KEYZ IN SSH-AGENT
 - **GPG SININ SUPPORT**: CONFIGURE UR GPG KEY 4 COMMIT SININ (OPSHUNUL)
-- **WUN-CLIK IDENTITY SWITCH**: CHANGE UR GIT USER.NAME AN USER.EMAIL LIEK SPEEDEE CAT
-- **STATUS BAR**: ALWAYZ C UR CURRENT IDENTITY AT A GLANS
-- **RICH TOOLTIPZ**: DETAILD IDENTITY INFO WIF DESCRIPSHUN AN SSH HOST
+- **RICH TOOLTIPZ**: DETAILD PROFILE INFO WIF DESCRIPSHUN AN SSH HOST
 - **CROSS-PLATFORM**: WERKZ ON MACOS, LINUX, AN WINDOWZ - ALL TEH BOXEZ!
-- **LOCALIZD**: SUPPORTZ 17 LANGUAGEZ PLUS LOLCAT!
+- **LOCALIZD**: SUPPORTZ 17 LANGUAGEZ!
 
 ## 🌏 BOUT MULTILINGUAL SUPPORT
 
 > **I VALUEZ TEH EXISTENS OF MINORITIEZ.**
 > I DONT WANT 2 DISCARD DEM JUS CUZ DEY R SMOL IN NUMBR.
 > EVEN IF TRANSLASHUNZ ARNT PERFICT, I HOEP U CAN FEEL OUR INTENT 2 SHOW RESPEKT!
+
+DIS EXTENSHUN SUPPORTZ ALL 17 LANGUAGEZ DAT VS CODE SUPPORTZ. AN 4 README DOCUMENTASHUN, WE ALSO CHALLENGD OURSELF 2 TRANSLAIT INTO MINORITY LANGUAGEZ AN JOKE LANGUAGEZ.
+
+DIS IZ NOT JUS "GLOBAL SUPPORT"—DIS IZ "RESPEKT 4 LINGUISTIK DIVERSITEE." AN ACROSS ALL LANGUAGEZ, IN EVERY PLACE, DEVELOPRZ MAKIN TEH WURLD BETTR WIF COMMITS... I WANT DIS 2 BE DAT KIND OF INFRASTRUCTUR. DO WANT!
 
 ---
 
@@ -67,315 +72,312 @@ TIPICAL SETUP 4 MANAGIN PURSONAL ACCOUNT AN COMPANY ACCOUNT (ENTERPRISE MANAGED 
 
 ### STEP 1: PREPAR UR SSH KEYZ
 
-```bash
-# CEILING CAT (WATCHIN U CODE)
-ssh-keygen -t ed25519 -C "ceiling@cat.example.com" -f ~/.ssh/id_ed25519_ceiling
+FURST, MAEK SSH KEYZ 4 EACH ACCOUNT (IF U ALREADY HAZ DEM, SKIP DIS):
 
-# KEYBOARD CAT (MAKIN TEH CODEZ)
-ssh-keygen -t ed25519 -C "keyboard@cat.example.com" -f ~/.ssh/id_ed25519_keyboard
+```bash
+# PURSONAL
+ssh-keygen -t ed25519 -C "ceiling@personal.example.com" -f ~/.ssh/id_ed25519_personal
+
+# WERK
+ssh-keygen -t ed25519 -C "ceiling.cat@techcorp.example.com" -f ~/.ssh/id_ed25519_work
 ```
 
-AFTR U MAK TEH KEYZ, REGISTAR UR PUBLIK KEYZ (`.pub`) 2 EACH SERVIS (GITHUB, GITLAB, BITBUCKET, ETC.). IMPORTINT!
+REGISTAR UR **PUBLIK KEYZ** (`.pub` FILEZ) 2 EACH GITHUB ACCOUNT.
+
+> **NOTE**: WAT U REGISTAR ON GITHUB IZ `id_ed25519_personal.pub` (PUBLIK KEY). `id_ed25519_personal` (NO EXTENSHUN) IZ TEH PRIVAT KEY—NEVR SHARE OR UPLOAD DIS! SRSLY!
 
 ### STEP 2: CONFIGUR SSH
 
 EDIT `~/.ssh/config`:
 
 ```ssh-config
-# CEILING CAT ACCOUNT (GITHUB)
+# PURSONAL GITHUB ACCOUNT (DEFALT)
 Host github.com
     HostName github.com
     User git
-    IdentityFile ~/.ssh/id_ed25519_ceiling
+    IdentityFile ~/.ssh/id_ed25519_personal
     IdentitiesOnly yes
 
-# KEYBOARD CAT ACCOUNT (GITHUB)
-Host github-keyboard
+# WERK GITHUB ACCOUNT
+Host github-work
     HostName github.com
     User git
-    IdentityFile ~/.ssh/id_ed25519_keyboard
+    IdentityFile ~/.ssh/id_ed25519_work
     IdentitiesOnly yes
 ```
 
 ### STEP 3: CONFIGUR TEH EXTENSHUN
 
-OPEN **EXTENSHUN SETTINGZ** AN CONFIGUR UR IDENTITIEZ IN `gitIdSwitcher.identities`:
+AFTR U INSTALL, SAMPLE PROFILEZ R REDDY 4 U. FOLLOW DIS GUIDE 2 EDIT DEM 4 URSELF.
 
-```json
-{
-  "gitIdSwitcher.identities": [
-    {
-      "id": "ceiling-cat",
-      "name": "Ceiling Cat",
-      "email": "ceiling@cat.example.com",
-      "service": "github",
-      "icon": "😼",
-      "description": "WATCHIN U CODE",
-      "sshKeyPath": "~/.ssh/id_ed25519_ceiling"
-    },
-    {
-      "id": "keyboard-cat",
-      "name": "Keyboard Cat",
-      "email": "keyboard@cat.example.com",
-      "service": "github",
-      "icon": "🎹",
-      "description": "PLAY HIM OFF",
-      "sshKeyPath": "~/.ssh/id_ed25519_keyboard",
-      "sshHost": "github-keyboard"
-    }
-  ],
-  "gitIdSwitcher.defaultIdentity": "ceiling-cat",
-  "gitIdSwitcher.autoSwitchSshKey": true,
-  "gitIdSwitcher.applyToSubmodules": true
-}
-```
+<img src="https://assets.nullvariant.com/nullvariant-vscode-extensions/extensions/git-id-switcher/images/x-lolcat/first-ux.webp" width="600" alt="FURST SETUP STEPS (13): OPEN PROFILE MANAGEMINT FROM STATUS BAR, EDIT AN CREEATE NEW PROFILEZ" loading="lazy">
 
-### STEP 4: DO TEH THING
+> **UR KEY FILEZ R NOT SENT ANYWHER**: WEN U SET SSH KEY PATH, ONLY TEH FILE PATH (LOCASHUN) IZ RECORDD. TEH KEY FILE CONTENTS R NEVR UPLOADD OR SENT 2 EXTERNAL SERVISEZ. SAFETY FURST!
 
-1. CLIK TEH IDENTITY ICON IN TEH STATUS BAR
-2. PIK UR IDENTITY
-3. INVISIBLE IDENTITY SWITCH! U CANT C IT BUT ITS DERE!
+> **IF U WANT GPG SININ**: U CAN ALSO SET `gpgKeyId` IN TEH PROFILE EDIT SCREEN.
+> 4 HOW 2 FIND UR GPG KEY ID, C "[TROUBLESHOOTIN](#gpg-sinin-not-werkin)". KTHX!
 
-<img src="https://assets.nullvariant.com/nullvariant-vscode-extensions/extensions/git-id-switcher/images/quickpick-x-lolcat.png" width="600" alt="Quick Pick">
+> **TIP**: U CAN ALSO CONFIGUR DIRECTLY FROM settings.json.
+> OPEN EXTENSHUN SETTINGZ (`Cmd+,` / `Ctrl+,`) → SEARCH "Git ID Switcher" → CLIK "EDIT IN settings.json".
+> 4 JSON FORMAT EXAMPLZ, C "[FULL EXAMPL](#full-exampl-4-accountz-wif-ssh--gpg)".
 
 ---
 
-## OPSHUNUL: GPG SININ
-
-IF U WANT 2 SIGN UR COMMITS WIF GPG (LIEK A FANCY CAT):
-
-### STEP 1: FIND UR GPG KEY ID
-
-```bash
-gpg --list-secret-keys --keyid-format SHORT
-```
-
-EXAMPL OUTPUT:
-
-```text
-sec   ed25519/ABCD1234 2024-01-01 [SC]
-      ...
-uid         [ultimate] Ceiling Cat <ceiling@cat.example.com>
-```
-
-UR KEY ID IZ `ABCD1234`. REMEMBR IT!
-
-### STEP 2: ADD GPG KEY 2 UR IDENTITY
-
-```json
-{
-  "gitIdSwitcher.identities": [
-    {
-      "id": "ceiling-cat",
-      "name": "Ceiling Cat",
-      "email": "ceiling@cat.example.com",
-      "service": "GitHub",
-      "icon": "😼",
-      "description": "WATCHIN U CODE",
-      "sshKeyPath": "~/.ssh/id_ed25519_ceiling",
-      "gpgKeyId": "ABCD1234"
-    }
-  ]
-}
-```
-
-WEN U SWITCH 2 DIS IDENTITY, TEH EXTENSHUN SETZ:
-
-- `git config user.signingkey ABCD1234`
-- `git config commit.gpgsign true`
-
-KTHXBAI! UR COMMITS R NOW SIGNED LIEK A BOSS CAT!
-
----
-
-## FULL EXAMPL: 4 ACCOUNTZ WIF SSH + GPG (MOAR CATZ)
+## FULL EXAMPL: 4 ACCOUNTZ WIF SSH + GPG
 
 ALL TEH THINGZ COMBIND! HEER IZ FULL EXAMPL:
 
 ### SSH CONFIG (`~/.ssh/config`)
 
 ```ssh-config
-# CEILING CAT ACCOUNT (DEFALT)
+# PURSONAL ACCOUNT (DEFALT)
 Host github.com
     HostName github.com
     User git
-    IdentityFile ~/.ssh/id_ed25519_ceiling
+    IdentityFile ~/.ssh/id_ed25519_personal
     IdentitiesOnly yes
 
-# KEYBOARD CAT ACCOUNT (COMPANY EMU)
-Host github-keyboard
+# WERK ACCOUNT (COMPANY ENTERPRISE MANAGED USUR)
+Host github-work
     HostName github.com
     User git
-    IdentityFile ~/.ssh/id_ed25519_keyboard
+    IdentityFile ~/.ssh/id_ed25519_work
     IdentitiesOnly yes
 
-# NYAN CAT ACCOUNT (BITBUCKET)
-Host bitbucket.org
+# BITBUCKET ACCOUNT
+Host bitbucket-clienta
     HostName bitbucket.org
     User git
-    IdentityFile ~/.ssh/id_ed25519_nyan
+    IdentityFile ~/.ssh/id_ed25519_clienta
     IdentitiesOnly yes
 ```
 
-### EXTENSHUN CONFIG
+### EXTENSHUN SETTINGZ
 
 ```json
 {
   "gitIdSwitcher.identities": [
     {
-      "id": "ceiling-cat",
+      "id": "personal",
       "name": "Ceiling Cat",
-      "email": "ceiling@cat.example.com",
+      "email": "ceiling@personal.example.com",
       "service": "GitHub",
-      "icon": "😼",
-      "description": "PURSONAL - WATCHIN U CODE",
-      "sshKeyPath": "~/.ssh/id_ed25519_ceiling",
+      "icon": "🐱",
+      "description": "MAH STUFFZ",
+      "sshKeyPath": "~/.ssh/id_ed25519_personal",
       "gpgKeyId": "CEILING1"
     },
     {
-      "id": "keyboard-cat",
-      "name": "Keyboard Cat",
-      "email": "keyboard@company_ceiling-cat.example.com",
-      "service": "GitHub COMPANY",
-      "icon": "🎹",
-      "description": "COMPANY (EMU) - PLAY HIM OFF",
-      "sshKeyPath": "~/.ssh/id_ed25519_keyboard",
-      "sshHost": "github-keyboard",
+      "id": "work-main",
+      "name": "Ceiling Cat",
+      "email": "ceiling.cat@techcorp.example.com",
+      "service": "GitHub Werk",
+      "icon": "⌨️",
+      "description": "TechCorp SRIUS BIZNESS",
+      "sshKeyPath": "~/.ssh/id_ed25519_work",
+      "sshHost": "github-work",
       "gpgKeyId": "KEYBOARD1"
     },
     {
-      "id": "nyan-cat",
-      "name": "Nyan Cat",
-      "email": "nyan@cat.example.com",
+      "id": "client-a",
+      "name": "Ceiling Cat",
+      "email": "ceiling@clienta.example.com",
       "service": "Bitbucket",
-      "icon": "🪣",
-      "description": "BITBUCKET - NYANYANYA",
-      "sshKeyPath": "~/.ssh/id_ed25519_nyan",
-      "sshHost": "bitbucket.org"
+      "icon": "😼",
+      "description": "ClientA MOAR WERK",
+      "sshKeyPath": "~/.ssh/id_ed25519_clienta",
+      "sshHost": "bitbucket-clienta"
     },
     {
-      "id": "grumpy-cat",
-      "name": "Grumpy Cat",
-      "email": "grumpy@freelance.example.com",
+      "id": "oss",
+      "name": "ceiling-dev",
+      "email": "ceiling.dev@example.com",
       "service": "GitLab",
-      "icon": "😾",
-      "description": "FREELANS - I HAD FUN ONCE"
+      "icon": "🐈",
+      "description": "I CAN HAZ OSS"
     }
   ],
-  "gitIdSwitcher.defaultIdentity": "ceiling-cat",
+  "gitIdSwitcher.defaultIdentity": "personal",
   "gitIdSwitcher.autoSwitchSshKey": true,
   "gitIdSwitcher.applyToSubmodules": true
 }
 ```
 
-NOTE: TEH LAST IDENTITY (`grumpy-cat`) HAZ NO SSH. U CAN USE DIS 4 SWITCHIN JUSS GIT CONFIG (LIEK DIFFRNT COMITTR INFO ON SAEM ACCOUNT).
+NOTE: TEH LAST PROFILE (`oss`) HAZ NO SSH. U CAN USE DIS 4 SWITCHIN JUS GIT CONFIG (LIEK DIFFRNT COMITTR INFO ON SAEM ACCOUNT). EZ!
 
 ---
 
-## FAMOUS CAT MEMEZ EXPLANED 📚
+## PROFILE MANAGEMINT
 
-| CAT             | MEME ORIGIN            | Y FAMOUS                                                 |
-| --------------- | ---------------------- | -------------------------------------------------------- |
-| 😼 Ceiling Cat  | 2006 image macro       | "Ceiling Cat iz watchin u" - teh original all-seeing cat |
-| 🎹 Keyboard Cat | 1984 video, viral 2007 | Played ppl off wen dey fail                              |
-| 😾 Grumpy Cat   | Tardar Sauce, 2012     | "I had fun once. It was awful." RIP 2019                 |
-| 🌈 Nyan Cat     | 2011 YouTube video     | Pop-Tart cat flyin thru space wif rainbowz               |
+CLIK TEH STATUS BAR → AT TEH BOTTOM OF TEH LIST, CLIK "PROFILE MANAGEMINT" 2 OPEN TEH MANAGEMINT SCREEN.
+U CAN ADD, EDIT, DELEET, AN REORDR PROFILEZ ALL FROM TEH UI. NO MOAR EDITIN JSON!
 
----
+<img src="https://assets.nullvariant.com/nullvariant-vscode-extensions/extensions/git-id-switcher/images/x-lolcat/identity-management.webp" width="600" alt="PROFILE MANAGEMINT: DELEET AN REORDR OPERASHUNZ" loading="lazy">
 
-## IDENTITY PROPERTIEZ
-
-| PROPRTY       | REQIRED | DESCRIPSHUN                                          |
-| ------------- | ------- | ---------------------------------------------------- |
-| `id`          | ✅      | UNIQ IDENTIFYR 4 DIS IDENTITY                        |
-| `name`        | ✅      | GIT `user.name` (SHOWZ IN COMMITS)                   |
-| `email`       | ✅      | GIT `user.email`                                     |
-| `icon`        | ❌      | SINGUL EMOJI 4 STATUS BAR. EMOJI ONLY! NO TEXTIE!    |
-| `description` | ❌      | DESCRIPSHUN (SHOWZ IN DROPDOWN)                      |
-| `sshKeyPath`  | ❌      | PATH 2 SSH PRIVAT KEY                                |
-| `sshHost`     | ❌      | SSH HOST ALIAS (`Host` IN ~/.ssh/config)             |
-| `gpgKeyId`    | ❌      | GPG KEY ID 4 COMMIT SININ                            |
-| `service`     | ❌      | GIT SERVIS: `github`, `gitlab`, `bitbucket`, `other` |
+U CAN ALSO DELEET PROFILEZ FROM COMMAND PALETTE: `Git ID Switcher: Delete Identity`. KTHX!
 
 ---
 
 ## COMMANDZ
 
-| COMMAND                                  | WAT IT DOEZ                |
-| ---------------------------------------- | -------------------------- |
-| `Git ID Switcher: Select Identity`       | OPEN TEH IDENTITY PIKR     |
-| `Git ID Switcher: Show Current Identity` | SHOW CURRENT IDENTITY INFO |
-| `Git ID Switcher: Show Documentation`    | SHOW TEH DOCUMENTZ         |
+| COMMAND                                  | WAT IT DOEZ               |
+| ---------------------------------------- | ------------------------- |
+| `Git ID Switcher: Select Identity`       | OPEN TEH PROFILE PIKR     |
+| `Git ID Switcher: Delete Identity`       | DELEET A PROFILE          |
+| `Git ID Switcher: Show Current Identity` | SHOW CURRENT PROFILE INFO |
+| `Git ID Switcher: Show Documentation`    | SHOW TEH DOCUMENTZ        |
 
 ---
 
-## SETTINGZ
+## SETTINGZ REFERENS
 
-| SETTIN                                     | DEFALT     | DESCRIPSHUN                                                     |
-| ------------------------------------------ | ---------- | --------------------------------------------------------------- |
-| `gitIdSwitcher.identities`                 | `[]`       | LIST OF IDENTITIEZ                                              |
-| `gitIdSwitcher.defaultIdentity`            | `""`       | DEFALT IDENTITY ID                                              |
-| `gitIdSwitcher.autoSwitchSshKey`           | `true`     | AUTOMAGICALLY SWITCH SSH KEYZ                                   |
-| `gitIdSwitcher.showNotifications`          | `true`     | SHOW NOTIFICASHUN WEN SWITCHIN                                  |
-| `gitIdSwitcher.applyToSubmodules`          | `true`     | APPLY IDENTITY 2 SUBMODULEZ                                     |
-| `gitIdSwitcher.submoduleDepth`             | `1`        | MAX DEPTH 4 NESTED SUBMODULEZ (1-5)                             |
-| `gitIdSwitcher.includeIconInGitConfig`     | `false`    | INCLUD EMOJI IN GIT CONFIG (C BELOW)                            |
-| `gitIdSwitcher.logging.fileEnabled`        | `false`    | ENABL FILE LOGGIN 4 AUDITIN                                     |
-| `gitIdSwitcher.logging.filePath`           | `""`       | CUSTOM LOG FILE PATH                                            |
-| `gitIdSwitcher.logging.maxFileSize`        | `10485760` | MAX LOG FILE SIEZ B4 ROTASHUN (BYTEZ, 1MB-100MB)                |
-| `gitIdSwitcher.logging.maxFiles`           | `5`        | NUMBR OF LOG FILEZ 2 KEEP (1-20)                                |
-| `gitIdSwitcher.logging.level`              | `"INFO"`   | LOGGIN LEVL (DEBUG/INFO/WARN/ERROR/SECURITY)                    |
-| `gitIdSwitcher.logging.redactAllSensitive` | `false`    | WEN ENABLD, ALL VALUEZ R MASKD IN LOGZ (MAXIMUMZ PRIVACYZ MODE) |
-| `gitIdSwitcher.commandTimeouts`            | `{}`       | EXTERNL COMMAND TIEMOUTZ (MS, 1S-5MIN)                          |
+### PROFILE PROPERTIEZ
+
+| PROPRTY       | REQIRED | DESCRIPSHUN                                                    |
+| ------------- | ------- | -------------------------------------------------------------- |
+| `id`          | ✅      | UNIQ IDENTIFYR (E.G., `"personal"`, `"work-main"`)             |
+| `name`        | ✅      | GIT `user.name` — SHOWZ IN COMMITS                             |
+| `email`       | ✅      | GIT `user.email` — SHOWZ IN COMMITS                            |
+| `icon`        |         | EMOJI 4 STATUS BAR (E.G., `"🐱"`). SINGUL EMOJI ONLY!          |
+| `service`     |         | SERVIS NAEM (E.G., `"GitHub"`, `"GitLab"`). UZED IN UI DISPLAY |
+| `description` |         | SHORT DESCRIPSHUN 4 PIKR AN TOOLTIP                            |
+| `sshKeyPath`  |         | PATH 2 SSH PRIVAT KEY (E.G., `"~/.ssh/id_ed25519_work"`)       |
+| `sshHost`     |         | SSH CONFIG HOST ALIAS (E.G., `"github-work"`)                  |
+| `gpgKeyId`    |         | GPG KEY ID 4 COMMIT SININ                                      |
+
+#### DISPLAY LIMITASHUNZ
+
+- **STATUS BAR**: IF LONGR DAN ~25 CHARACTERZ, IT GETZ TRUNCATD WIF `...`
+- **`icon`**: SINGUL EMOJI (GRAPHEME CLUSTR) ONLY. NO MULTIPUL EMOJIZ OR LONG STRINGZ ALLOWD
+
+### GLOBAL SETTINGZ
+
+| SETTIN                                     | DEFALT     | DESCRIPSHUN                                                                                 |
+| ------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------- |
+| `gitIdSwitcher.identities`                 | C SAMPLEZ  | LIST OF PROFILEZ                                                                            |
+| `gitIdSwitcher.defaultIdentity`            | C SAMPLEZ  | DEFALT PROFILE ID                                                                           |
+| `gitIdSwitcher.autoSwitchSshKey`           | `true`     | AUTOMAGICALLY SWITCH SSH KEYZ WEN CHANGIN PROFILEZ                                          |
+| `gitIdSwitcher.showNotifications`          | `true`     | SHOW NOTIFICASHUN WEN SWITCHIN PROFILEZ                                                     |
+| `gitIdSwitcher.applyToSubmodules`          | `true`     | PROPAGATE PROFILE 2 GIT SUBMODULEZ                                                          |
+| `gitIdSwitcher.submoduleDepth`             | `1`        | MAX DEPTH 4 NESTED SUBMODULEZ (1-5)                                                         |
+| `gitIdSwitcher.includeIconInGitConfig`     | `false`    | INCLUD EMOJI IN GIT CONFIG `user.name`                                                      |
+| `gitIdSwitcher.logging.fileEnabled`        | `false`    | SAVE AUDIT LOGZ 2 FILE (RECORDZ PROFILE SWITCHEZ, SSH KEY OPERASHUNZ, ETC.)                 |
+| `gitIdSwitcher.logging.filePath`           | `""`       | LOG FILE PATH (E.G., `~/.git-id-switcher/security.log`). EMPTY = DEFALT PATH                |
+| `gitIdSwitcher.logging.maxFileSize`        | `10485760` | MAX FILE SIEZ B4 ROTASHUN (BYTEZ, 1MB-100MB)                                                |
+| `gitIdSwitcher.logging.maxFiles`           | `5`        | NUMBR OF ROTATD LOG FILEZ 2 KEEP (1-20)                                                     |
+| `gitIdSwitcher.logging.redactAllSensitive` | `false`    | WEN ENABLD, ALL VALUEZ R MASKD IN LOGZ (MAXIMUMZ PRIVACYZ MODE)                             |
+| `gitIdSwitcher.logging.level`              | `"INFO"`   | LOG VERBOSITEE (`DEBUG`, `INFO`, `WARN`, `ERROR`, `SECURITY`). RECORDZ SELECTD LEVL AN ABUV |
+| `gitIdSwitcher.commandTimeouts`            | `{}`       | CUSTOM TIEMOUTZ PER COMMAND (MS, 1S-5MIN). E.G., `{"git": 15000, "ssh-add": 10000}`         |
+
+#### `includeIconInGitConfig` SETTIN
+
+DIS CONTROLZ WAT HAPPENZ WEN U SET TEH `icon` FEELD:
+
+| SETTIN           | BEHAVYR                                                              |
+| ---------------- | -------------------------------------------------------------------- |
+| `false` (DEFALT) | `icon` ONLY SHOWZ IN EDITR UI. ONLY `name` IZ RITTN 2 GIT CONFIG     |
+| `true`           | `icon + name` IZ RITTN 2 GIT CONFIG. EMOJI SHOWZ IN COMMIT HISTORY 2 |
+
+EXAMPL: `icon: "🐱"`, `name: "Ceiling Cat"`
+
+| includeIconInGitConfig | GIT CONFIG `user.name` | COMMIT SIGNATUR          |
+| ---------------------- | ---------------------- | ------------------------ |
+| `false`                | `Ceiling Cat`          | `Ceiling Cat <email>`    |
+| `true`                 | `🐱 Ceiling Cat`       | `🐱 Ceiling Cat <email>` |
 
 ---
 
-## DISPLAY LIMITASHUNZ
+## HOW IT WERKZ
 
-- **`icon` PROPRTY**: ONLY SINGUL EMOJI! NO TEXTIE LIEK "🐱 CAT". JUS "🐱".
-- **`includeIconInGitConfig`**: WHEN DISABLD (DEFALT), EMOJI NOT ADED 2 GIT CONFIG USER.NAME.
+### GIT CONFIG LAYR STRUCTUR
 
----
-
-## `includeIconInGitConfig` SETTIN
-
-DIS SETTIN CONTROLZ IF EMOJI IZ ADED 2 GIT `user.name`.
-
-| SETTIN           | BEHAVYR                                                    |
-| ---------------- | ---------------------------------------------------------- |
-| `false` (DEFALT) | GIT CONFIG: `user.name = Ceiling Cat` (NO EMOJI IN CONFIG) |
-| `true`           | GIT CONFIG: `user.name = 😼 Ceiling Cat` (EMOJI IN CONFIG) |
-
-> **NOTE**: EMOJI ALWAYZ SHOWZ IN STATUS BAR REGARDLES OF DIS SETTIN! DIS ONLY AFFEKTS GIT CONFIG.
-
----
-
-## GIT CONFIG LAYR STRUCTUR
-
-### HOW GIT CONFIG WERKZ
-
-GIT CONFIG HAZ 3 LAYERZ, LIEK A SANDWICH:
+GIT CONFIG HAZ 3 LAYERZ, LIEK A LASAGNA. BOTTOM GETZ OVERRIDN BY TOP:
 
 ```text
 SYSTEM (/etc/gitconfig)
-   ↓ OVERRIDEN BY
+    ↓ OVERRIDN BY
 GLOBAL (~/.gitconfig)
-   ↓ OVERRIDEN BY
-LOCAL (.git/config)  ← DIS EXTENSHUN WRITZ HEER WIF `--local`
+    ↓ OVERRIDN BY
+LOCAL (.git/config)  ← HIGHEST PRIORITEE
 ```
+
+**GIT ID SWITCHER WRITZ 2 `--local` (REPOSITRY LOCAL).**
+
+DAT MEENZ:
+
+- SAVEZ PROFILE IN EACH REPOSITRY'Z `.git/config`
+- U CAN HAZ DIFFRNT PROFILEZ 4 EACH REPOSITRY
+- GLOBAL SETTINGZ (`~/.gitconfig`) R NOT MODIFYD
+
+### PROFILE SWITCHIN BEHAVYR
+
+WEN U SWITCH PROFILEZ, TEH EXTENSHUN DOEZ DEEZ THINGZ (IN ORDR):
+
+1. **GIT CONFIG** (ALWAYZ): SETZ `git config --local user.name` AN `user.email`
+2. **SSH KEY** (WEN `sshKeyPath` IZ SET): REMOVEZ OTHR KEYZ FROM SSH-AGENT, ADDZ SELECTD KEY
+3. **GPG KEY** (WEN `gpgKeyId` IZ SET): SETZ `git config --local user.signingkey` AN ENABLZ SININ
+4. **SUBMODULEZ** (WEN ENABLD): PROPAGATEZ SETTINGZ 2 ALL SUBMODULEZ (DEFALT: DEPTH 1)
 
 ### SUBMODULE PROPAGASHUN
 
-LOKAL SETTINGZ R PER-REPOSITRY, SO SUBMODULEZ DONT AUTOMAGICALLY GET DEM.
+LOCAL SETTINGZ R PER-REPOSITRY, SO SUBMODULEZ DONT AUTOMAGICALLY GET DEM.
 DAT Y DIS EXTENSHUN HAZ PROPAGASHUN FEATUR (C "ADVANSED: SUBMODULE SUPPORT" SEKSHUN).
+
+### SSH KEY MANAGEMINT DETAILZ
+
+GIT ID SWITCHER MANAGEZ SSH KEYZ THRU `ssh-agent`:
+
+| OPERASHUN  | COMMAND EXECUTD        |
+| ---------- | ---------------------- |
+| ADD KEY    | `ssh-add <keyPath>`    |
+| REMOVE KEY | `ssh-add -d <keyPath>` |
+| LIST KEYZ  | `ssh-add -l`           |
+
+**IMPORTINT:** DIS EXTENSHUN DOEZ **NOT** MODIFY `~/.ssh/config`. U HAZ 2 CONFIGUR SSH CONFIG MANUALLY (C "QUICK START" STEP 2). KTHX!
+
+### EXISTIN SSH SETTINGZ
+
+IF U ALREADY HAZ SSH SETTINGZ, GIT ID SWITCHER WERKZ LIEK DIS:
+
+| UR SETTIN                          | GIT ID SWITCHER BEHAVYR                                  |
+| ---------------------------------- | -------------------------------------------------------- |
+| `~/.ssh/config` WIF `IdentityFile` | BOTH CAN B UZED; `IdentitiesOnly yes` PREVENTZ CONFLICTZ |
+| ENV VAR `GIT_SSH_COMMAND` SET      | UR CUSTOM SSH COMMAND IZ UZED; SSH-AGENT STILL WERKZ     |
+| `git config core.sshCommand` SET   | SAEM AZ ABUV                                             |
+| DIRENV WIF SSH ENV VARZ            | CAN COEXIST; SSH-AGENT WERKZ INDEPENDNTLY                |
+
+**RECOMENDASHUN:** ALWAYZ SET `IdentitiesOnly yes` IN UR SSH CONFIG. DIS PREVENTZ SSH FROM TRYIN MULTIPUL KEYZ.
+
+### Y `IdentitiesOnly yes`?
+
+WITHOUT DIS SETTIN, SSH MAI TRY KEYZ IN DIS ORDR:
+
+1. KEYZ LOADD IN SSH-AGENT (MANAGD BY GIT ID SWITCHER)
+2. KEYZ SPECIFYD IN `~/.ssh/config`
+3. DEFALT KEYZ (`~/.ssh/id_rsa`, `~/.ssh/id_ed25519`, ETC.)
+
+DIS CAN CAUZ AUTHENTICASHUN FAILURZ OR UZIN TEH RONG KEY. NOT GUD!
+
+WIF `IdentitiesOnly yes`, SSH UZEZ **ONLY TEH SPECIFYD KEY**. DIS ENSURZ TEH KEY SET BY GIT ID SWITCHER IZ UZED.
+
+```ssh-config
+# RECOMENDID SETTIN
+Host github-work
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_work
+    IdentitiesOnly yes  # ← DIS LIEN IZ IMPORTINT!
+```
+
+WIF DIS SETTIN, CONEKTIN 2 `github-work` HOST ONLY UZEZ `~/.ssh/id_ed25519_work`. NO OTHR KEYZ R TRYD.
 
 ---
 
 ## ADVANSED: SUBMODULE SUPPORT
 
-WEN U HAZ KOMPLEKS REPOSITORIEZ WIF GIT SUBMODULEZ, IDENTITY MANAGEMINT CAN B ANNOYIN. WEN U COMMIT INSIED A SUBMODULE, GIT USES DAT SUBMODULE'Z LOKAL CONFIG, AN IF NOT SET, IT FALLZ BAK 2 GLOBAL CONFIG (RONG EMAEL ADRES!).
+WEN U HAZ KOMPLEKS REPOSITORIEZ WIF GIT SUBMODULEZ, PROFILE MANAGEMINT CAN B ANNOYIN. WEN U COMMIT INSIED A SUBMODULE, GIT UZEZ DAT SUBMODULE'Z LOCAL CONFIG, AN IF NOT SET, IT FALLZ BAK 2 GLOBAL CONFIG (RONG EMAEL ADRES!).
 
-**GIT ID SWITCHER** AUTOMAGICALLY DETEKTZ SUBMODULEZ AN APPLIEZ UR SELECTED IDENTITY.
+**GIT ID SWITCHER** AUTOMAGICALLY DETEKTZ SUBMODULEZ AN APPLIEZ UR SELECTD PROFILE.
 
 ```json
 {
@@ -389,49 +391,119 @@ WEN U HAZ KOMPLEKS REPOSITORIEZ WIF GIT SUBMODULEZ, IDENTITY MANAGEMINT CAN B AN
   - `1`: ONLY DIRECT SUBMODULEZ (MOST COMMON)
   - `2+`: NESTED SUBMODULEZ (SUBMODULE INSIED SUBMODULE - INCEPTSHUN!)
 
-DIS WAI, WHETHER U COMMIT IN MAIN REPO OR IN VENDOR LIBRARY, UR IDENTITY IZ ALWAYZ CORREKT. NO MOAR EMBARASING COMMITS!
+DIS WAI, WHETHER U COMMIT IN MAIN REPO OR IN VENDOR LIBRARY, UR PROFILE IZ ALWAYZ CORREKT. NO MOAR EMBARASING COMMITS!
 
 ---
 
 ## TROUBLESHOOTIN
 
-### "NAME FEELD IZ REQIRED" ERUR
+### SSH KEY NOT SWITCHIN?
 
-IF U C DIS ERUR, CHEEK UR SETTINGZ:
+1. MAEK SHUR `ssh-agent` IZ RUNNIN:
 
-```json
-{
-  "gitIdSwitcher.identities": [
-    {
-      "id": "ceiling-cat",
-      "name": "Ceiling Cat", // ← DIS IZ REQIRED!
-      "email": "ceiling@cat.example.com" // ← DIS 2!
-    }
-  ]
-}
+   ```bash
+   eval "$(ssh-agent -s)"
+   ```
+
+2. CHEEK IF KEY PATH IZ CORREKT:
+
+   ```bash
+   ls -la ~/.ssh/id_ed25519_*
+   ```
+
+3. ON MACOS, ADD 2 KEYCHAIN WUNCE:
+
+   ```bash
+   ssh-add --apple-use-keychain ~/.ssh/id_ed25519_work
+   ```
+
+### PUSHIN WIF RONG PROFILE?
+
+**WEN CLONIN NEW REPO:**
+
+4 WERK REPOSITORIEZ, USE TEH HOST ALIAS FROM UR SSH CONFIG:
+
+```bash
+# WERK (USIN github-work ALIAS)
+git clone git@github-work:company/repo.git
+
+# PURSONAL (USIN DEFALT github.com)
+git clone git@github.com:yourname/repo.git
 ```
 
-BOTH `name` AN `email` R REQIRED. CANT HAZ IDENTITY WITHOUT DEM!
+**4 EXISTIN REPOSITORIEZ:**
 
-### NEW SETTINGZ NOT SHOWIN
+1. CHEEK IF REMOTE URL UZEZ TEH RITE HOST ALIAS:
 
-IF NEW SETTINGZ LIEK `service` OR `includeIconInGitConfig` NOT SHOWIN:
+   ```bash
+   git remote -v
+   # WERK REPO SHUD B git@github-work:...
+   ```
 
-1. **RELOAD WINDOE**: PRES `Cmd+Shift+P` (MAC) OR `Ctrl+Shift+P` (WINDOWZ/LINUX)
-2. **TIPE**: "Developr: Reload Window"
-3. **PRES ENTR**
+2. UPDATE IF NEEDID:
 
-VS CODE CACHZ SETTIN SKEEMAZ. RELOAD FIXEZ IT!
+   ```bash
+   git remote set-url origin git@github-work:company/repo.git
+   ```
 
-### SETTINGZ SYNC CONFLICTZ
+### GPG SININ NOT WERKIN?
 
-IF U USE VS CODE SETTINGZ SYNC AN HAZ DIFFRNT IDENTITIEZ ON DIFFRNT MASHINEZ:
+1. CHEEK UR GPG KEY ID:
 
-1. **OPSHUN A**: DISABL SYNC 4 DIS EXTENSHUN SETTINGZ
-2. **OPSHUN B**: USE SAEM IDENTITIEZ ON ALL MASHINEZ
-3. **OPSHUN C**: USE WORKSPASE SETTINGZ (`.vscode/settings.json`) INSTED
+   ```bash
+   gpg --list-secret-keys --keyid-format SHORT
+   ```
 
-> **TIP**: WORKSPASE SETTINGZ R PUR-PROJEKT AN DONT SYNC. GUD 4 DIFFRNT IDENTITIEZ!
+2. TEST SININ:
+
+   ```bash
+   echo "test" | gpg --clearsign
+   ```
+
+3. MAEK SHUR PROFILE EMAEL MATCHZ GPG KEY EMAEL
+
+### PROFILE NOT DETECTD?
+
+- MAEK SHUR UR IN A GIT REPOSITRY
+- CHEEK 4 SYNTAX ERRORZ IN `settings.json`
+- RELOAD VS CODE WINDOE (`Cmd+Shift+P` → "RELOAD WINDOE")
+
+### `name` FEELD GIVZ ERUR?
+
+DEEZ CHARACTERZ IN `name` FEELD CAUZ ERURZ:
+
+`` ` `` `$` `(` `)` `{` `}` `|` `&` `<` `>`
+
+IF U WANT 2 INCLUD SERVIS NAEM, USE TEH `service` FEELD INSTED.
+
+```jsonc
+// BAD - NO CAN HAZ
+"name": "Ceiling Cat (Pursonal)"
+
+// GUD - I CAN HAZ
+"name": "Ceiling Cat",
+"service": "GitHub"
+```
+
+### NEW SETTINGZ NOT SHOWIN?
+
+AFTR UPDATIN TEH EXTENSHUN, NEW SETTIN ITEMZ MAI NOT APEER IN SETTINGZ SCREEN.
+
+**FIX:** RESTART UR HOLE MASHEEN.
+
+VS CODE AN OTHR EDITORZ CACHE SETTIN SKEEMAZ IN MEMRY. "RELOAD WINDOE" OR REINSTALLIN TEH EXTENSHUN MAI NOT B ENUF.
+
+### DEFALT VALUEZ (IDENTITIEZ ETC.) R EMPTY?
+
+IF SAMPLE SETTINGZ DONT SHOW ON FRESH INSTALL, **SETTINGZ SYNC** MAI B TEH CAUZ.
+
+IF U SAVD EMPTY SETTINGZ B4, DEY GOT SYNCD 2 CLOUD AN NOW OVERRIDE TEH DEFALTZ ON NEW INSTALLZ.
+
+**FIX:**
+
+1. FIND TEH SETTIN IN SETTINGZ SCREEN
+2. CLIK GEAR ICON → "RESET SETTIN"
+3. SYNC WIF SETTINGZ SYNC (OLD SETTINGZ GET REMOVD FROM CLOUD)
 
 ---
 
@@ -439,8 +511,8 @@ IF U USE VS CODE SETTINGZ SYNC AN HAZ DIFFRNT IDENTITIEZ ON DIFFRNT MASHINEZ:
 
 > "HU AM I?" — DAT DA ONLY QUESHUN DIS EXTENSHN ANSWRZ.
 
-BILT ON **KARESANSUI ARKITEKCHUR**: SIMPUL CORE (100 LINEZ),
-SURROUNDID BY DELIBERAT QUALITEE (90% COVERAJ, LOGGIN, TAIMOUTZ)
+BILT ON **KARESANSUI ARKITEKCHUR**: CORE CAN B RITTN IN 100 LINEZ.
+DAT Y WE CAN SPEND TEH REST ON QUALITEE (90% TEST COVERAJ, LOGGIN, TIEMOUTZ)
 AN INTENSHUNUL CONSTRAINTZ (NO GITHUB API, NO TOKN MANAGEMNT).
 
 [![Karesansui Architecture](https://img.shields.io/badge/🪨_Karesansui-Architecture-4a5568)](../../DESIGN_PHILOSOPHY.md)

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -50,7 +50,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'extensions/git-id-switcher/docs/i18n/tok/README.md': '4f423369cd4ce7f7aecae387e2fc971f4af2ff373fc671032bb60c03db1f94a0',
   'extensions/git-id-switcher/docs/i18n/tr/README.md': '89f7e55adf8958d083ffb769d2ce55de553eb6d31a379354fec73ac49c046884',
   'extensions/git-id-switcher/docs/i18n/uk/README.md': '83f5775af9462e5c0056eba6f7450e5997e780eb60cd756b986a4b89dfc0eebd',
-  'extensions/git-id-switcher/docs/i18n/x-lolcat/README.md': 'fcd5c189e98ae194aea20c27c2e2e8ee0498390cf0a614d208f3ece1e9c5a76b',
+  'extensions/git-id-switcher/docs/i18n/x-lolcat/README.md': '33b2d348785e2ada8ad2302b39869006feea46c2a5883b55d843aa7311ea2caf',
   'extensions/git-id-switcher/docs/i18n/x-pirate/README.md': 'fae08065d4aff87eb9d9dd2327d27428c899ae48d53dfcf9ed73a6140e1343f7',
   'extensions/git-id-switcher/docs/i18n/x-shakespeare/README.md': '9ce452f06e699e9c7a5807877047c277dd76ce3b826b1a03f6412590b3e72b2c',
   'extensions/git-id-switcher/docs/i18n/zh-CN/README.md': '31edabe01f4d545427e455ee23c9b97d2fc6e7fa2872f514e5a5cd9a98e59151',


### PR DESCRIPTION
## Summary

- Rewrite x-lolcat README to match ja/en structure while preserving LOLcat-specific opening and closing sections
- Add Profile Management UI, SSH Key Management, IdentitiesOnly explanation, expanded Troubleshooting
- Fix image paths (`ja/` → `x-lolcat/`), language flags, sample profiles from Log-0007 (Ceiling Cat theme)
- 3 rounds of self-review improvements

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify all image paths point to `x-lolcat/` directory
- [ ] Verify language flag section: bold 🐱, 🇯🇵 links to `../ja/README.md`
- [ ] Verify LOLcat tone is consistent throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)