### PR TITLE
fix(ci): Dependabot npm directory to root for workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,9 @@ updates:
           - "minor"
           - "patch"
 
-  # npm dependencies for git-id-switcher extension
+  # npm dependencies (workspaces monorepo - must use root for lockfile sync)
   - package-ecosystem: "npm"
-    directory: "/extensions/git-id-switcher"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
- Change Dependabot `directory` from `/extensions/git-id-switcher` to `/`
- In npm workspaces monorepo, `package-lock.json` is managed at the root. Targeting a subdirectory caused Dependabot to update only the workspace `package.json` without updating the root lockfile, making all CI jobs fail on `npm ci`
- After this fix, future Dependabot PRs will correctly update both `package.json` and `package-lock.json`

## Related
- Root cause of #293

## Test plan
- [ ] CI passes on this PR (dependabot.yml change only)
- [ ] After merge, next Dependabot PR includes package-lock.json updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)