### PR TITLE
chore: rename deprecated config:base to config:recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "schedule": ["before 5am on wednesday"],
   "timezone": "Asia/Tokyo",
   "labels": ["dependencies", "renovate"],


### PR DESCRIPTION
## Summary
- Rename deprecated Renovate preset `config:base` to `config:recommended`
- `config:base` was renamed to `config:recommended` in Renovate v36
- No functional change; this resolves the deprecation warning

## Test plan
- [ ] Verify Renovate bot runs without deprecation warnings after merge