### PR TITLE
fix(git-id-switcher): add User-Agent to Webview fetch

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.18] - 2026-02-13
+
+### Fixed
+
+- **Add User-Agent header to Webview documentation fetch requests**: Node.js fetch in the extension host doesn't include VSCode's User-Agent (`Code/x.y.z`), causing Cloudflare analytics worker to classify documentation access as `OTHER/is_likely_human=0`. Now sends `Code/${vscode.version} git-id-switcher` to match existing `classifyTraffic` detection rules.
+
 ## [0.16.17] - 2026-02-07
 
 ### Documentation

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.17",
+  "version": "0.16.18",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': 'cb8170851742743e584cf21ff3427c78dc1c9471fd56d25a19abc174ed4fdd61',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': 'c67ad4a778f2be5f7f3984a2c94d07014a9f4660322fd03fa621448c3eadc29d',
+  'extensions/git-id-switcher/CHANGELOG.md': '0eec5a04436e23fa644aa7694f6410cebf6d1c4af26300bf4dab0d4cec8d15eb',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'a12dd717f83b28b648972a826701a29fcfd575e351c487f8c421402f80ac3d25',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/documentationPublic.ts
+++ b/extensions/git-id-switcher/src/ui/documentationPublic.ts
@@ -91,8 +91,13 @@ async function fetchDocumentByPath(path: string): Promise<string | null> {
   try {
     const url = `${ASSET_BASE_URL}/${path}`;
 
-    // Add header for CI/test environment access (for analytics filtering)
-    const headers: Record<string, string> = {};
+    // Add headers for analytics classification and CI/test filtering
+    // Node.js fetch doesn't include VSCode's User-Agent (Code/x.y.z),
+    // so analytics worker classifies requests as OTHER/is_likely_human=0.
+    // Setting User-Agent with "Code/" prefix matches existing classifyTraffic detection.
+    const headers: Record<string, string> = {
+      'User-Agent': `Code/${vscode.version} git-id-switcher`,
+    };
     if (isTestEnvironment()) {
       headers['X-Test-Environment'] = 'true';
     }


### PR DESCRIPTION
## Summary

- Add `User-Agent: Code/${vscode.version} git-id-switcher` header to documentation Webview fetch requests
- Node.js fetch in the extension host doesn't include VSCode's User-Agent (`Code/x.y.z`), so the Cloudflare analytics worker classifies documentation access as `OTHER/is_likely_human=0`
- This fix matches the existing `classifyTraffic` detection rule (`ua.includes("Code/")`) — no analytics worker changes needed

## Test plan

- [ ] Build passes (`npm run compile:all`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] After release, verify D1 `access_logs` shows Markdown fetch with `platform=VSCODE` and `is_likely_human=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)