### PR TITLE
fix(git-id-switcher): switch to X-Extension-Id custom header for analytics

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.19] - 2026-02-13
+
+### Fixed
+
+- **Switch to X-Extension-Id custom header for analytics classification**: The User-Agent approach in 0.16.18 was ineffective because Node.js `fetch()` overrides User-Agent to `"node"`. Now uses `X-Extension-Id: git-id-switcher` custom header, which the assets worker forwards to the analytics worker for correct VSCODE/is_likely_human=1 classification.
+
 ## [0.16.18] - 2026-02-13
 
 ### Fixed

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.18",
+  "version": "0.16.19",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': 'cb8170851742743e584cf21ff3427c78dc1c9471fd56d25a19abc174ed4fdd61',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '0eec5a04436e23fa644aa7694f6410cebf6d1c4af26300bf4dab0d4cec8d15eb',
+  'extensions/git-id-switcher/CHANGELOG.md': '09ec3ba05e93b80cfaff401d0a35b3fb3816b26bd3432101e7d1a0e89e05b3d2',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'a12dd717f83b28b648972a826701a29fcfd575e351c487f8c421402f80ac3d25',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/documentationPublic.ts
+++ b/extensions/git-id-switcher/src/ui/documentationPublic.ts
@@ -92,11 +92,10 @@ async function fetchDocumentByPath(path: string): Promise<string | null> {
     const url = `${ASSET_BASE_URL}/${path}`;
 
     // Add headers for analytics classification and CI/test filtering
-    // Node.js fetch doesn't include VSCode's User-Agent (Code/x.y.z),
-    // so analytics worker classifies requests as OTHER/is_likely_human=0.
-    // Setting User-Agent with "Code/" prefix matches existing classifyTraffic detection.
+    // Node.js fetch overrides User-Agent to "node", so custom header is needed.
+    // Assets worker forwards X-Extension-Id to analytics worker for classification.
     const headers: Record<string, string> = {
-      'User-Agent': `Code/${vscode.version} git-id-switcher`,
+      'X-Extension-Id': 'git-id-switcher',
     };
     if (isTestEnvironment()) {
       headers['X-Test-Environment'] = 'true';


### PR DESCRIPTION
## Summary

- The User-Agent approach in 0.16.18 was ineffective because Node.js `fetch()` overrides User-Agent to `"node"`
- Now uses `X-Extension-Id: git-id-switcher` custom header
- Assets worker forwards this header to analytics worker for correct `VSCODE/is_likely_human=1` classification

## Test plan

- [ ] Deploy all 3 components (analytics worker, assets worker, extension)
- [ ] Open documentation in extension, verify D1 shows `platform: VSCODE`, `is_likely_human: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)