### PR TITLE
fix(ci): resolve Semgrep false positive on SonarCloud Action SHA pin

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -26,5 +26,4 @@ allow-licenses:
 # These are CI-only tools (not bundled in VSIX), so license compatibility
 # with the extension's MIT license is not a concern.
 allow-dependencies-licenses:
-  - 'pkg:githubactions/semgrep/semgrep-action'
   - 'pkg:githubactions/SocketDev/action'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -190,13 +190,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install Semgrep
+        run: pip install semgrep
+
       - name: Run Semgrep
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
-        with:
-          config: >-
-            p/typescript
-            p/security-audit
-            p/secrets
+        run: |
+          semgrep scan \
+            --config p/typescript \
+            --config p/security-audit \
+            --config p/secrets \
+            --exclude-rule generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key \
+            --error
 
   socket-security:
     name: Socket.dev Security


### PR DESCRIPTION
## Summary
- Replace `semgrep/semgrep-action` Docker image with direct `pip install semgrep` + `semgrep scan` to enable `--exclude-rule` flag
- Exclude false positive rule `generic.secrets.security.detected-sonarqube-docs-api-key` (SHA-pinned commit hash misidentified as API key)
- Remove `semgrep-action` from `allow-dependencies-licenses` (no longer used as GitHub Action)

## Test plan
- [ ] Verify Semgrep SAST job passes (no false positive)
- [ ] Verify dependency-review still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)