### PR TITLE
fix(ci): separate Scorecard threshold into its own job

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -254,6 +254,23 @@ jobs:
         with:
           sarif_file: results.sarif
 
+  # Separate job: scorecard-action requires all steps in its job to use `uses` only.
+  # Shell script steps cause workflow verification failure on result publication.
+  scorecard-threshold:
+    name: Scorecard Threshold Gate
+    runs-on: ubuntu-latest
+    needs: scorecard
+    # Only run on main branch (push, schedule) - not on PRs
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
       - name: Check Scorecard score threshold
         env:
           SCORECARD_THRESHOLD: ${{ vars.SCORECARD_THRESHOLD || '7.0' }}


### PR DESCRIPTION
## Summary

- Move Scorecard threshold check from `scorecard` job to a new `scorecard-threshold` job
- The `scorecard-action` validates that its job contains only `uses` steps — the `run` step for threshold checking caused: `"scorecard job must only have steps with uses"`
- New job depends on `scorecard` via `needs:` to ensure proper execution order

## Root cause

[scorecard-action workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions) require that the job running `ossf/scorecard-action` must only contain steps with `uses` (action calls), not `run` (shell scripts). This is enforced server-side when publishing results.

## Test plan

- [ ] Verify Scorecard job succeeds on merge (no more workflow verification failure)
- [ ] Verify threshold check runs in the separate job after Scorecard completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)