### PR TITLE
fix(ci): allow restyled-io/actions AGPL-3.0 in dependency review

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -22,9 +22,10 @@ allow-licenses:
   - 'Python-2.0'
   - 'Unlicense'
 
-# GitHub Actions with undetectable licenses
+# GitHub Actions with undetectable or incompatible licenses
 # These are CI-only tools (not bundled in VSIX), so license compatibility
 # with the extension's MIT license is not a concern.
 allow-dependencies-licenses:
   - 'pkg:githubactions/semgrep/semgrep-action'
   - 'pkg:githubactions/SocketDev/action'
+  - 'pkg:githubactions/restyled-io/actions'


### PR DESCRIPTION
## Summary
- Add `restyled-io/actions` to `allow-dependencies-licenses` in dependency review config
- This action is licensed under AGPL-3.0, which is flagged as incompatible with MIT
- Since it runs only in CI (not bundled in VSIX), there is no license compatibility concern

## Context
PR #344 (Dependabot bump of `restyled-io/actions` to v4.4.15) fails the Dependency Review check because AGPL-3.0 is not in the global `allow-licenses` list. Adding it to the per-dependency allow-list keeps the global policy strict while unblocking CI-only actions.

## Test plan
- [ ] Verify Dependency Review check passes on this PR
- [ ] Verify PR #344 Dependency Review check passes after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)