### PR TITLE
ci(git-id-switcher): harden publish pipeline and npm audit strategy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,22 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.cloudflare.com:443
+            api.github.com:443
+            fulcio.sigstore.dev:443
+            ghcr.io:443
+            github.com:443
+            marketplace.visualstudio.com:443
+            oauth2.sigstore.dev:443
+            objects.githubusercontent.com:443
+            open-vsx.org:443
+            pkg-containers.githubusercontent.com:443
+            registry.npmjs.org:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            uploads.github.com:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,9 +80,10 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
 
+      # SECURITY: Cosign signing failure aborts the entire release.
+      # Sigstore infrastructure is mature — failure indicates an anomaly.
       - name: Sign VSIX with Cosign (keyless)
         id: cosign-sign
-        continue-on-error: true
         run: |
           VSIX_FILE="extensions/git-id-switcher/git-id-switcher-${{ steps.version.outputs.version }}.vsix"
           VSIX_BASENAME=$(basename "$VSIX_FILE")
@@ -78,10 +94,6 @@ jobs:
 
           echo "vsix_file=$VSIX_FILE" >> $GITHUB_OUTPUT
           echo "bundle_file=extensions/git-id-switcher/${VSIX_BASENAME}.bundle" >> $GITHUB_OUTPUT
-
-      - name: Warn if Cosign signing failed
-        if: steps.cosign-sign.outcome == 'failure'
-        run: echo "::warning::Cosign VSIX signing failed. The VSIX will be published without a Cosign signature."
 
       # Supply Chain Security: SBOM generation (CycloneDX via Syft)
       - name: Generate SBOM (CycloneDX)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,7 +47,13 @@ jobs:
         working-directory: .
         run: npm ci
 
-      - name: Run npm audit
+      # 2-tier dev audit: high → CI fail, moderate → warn only
+      # Prevents Dependabot PRs from being blocked by moderate-level advisories
+      # while ensuring high/critical vulnerabilities are never missed
+      - name: Run npm audit (dev, high+critical = fail)
+        run: npm audit --audit-level=high
+
+      - name: Run npm audit (dev, moderate = warn only)
         run: npm audit --audit-level=moderate
         continue-on-error: true
 
@@ -191,7 +197,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Semgrep
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
+        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0, verified 2026-03-17)
         with:
           config: >-
             p/typescript


### PR DESCRIPTION
## Summary
- **LOW-9**: Remove `continue-on-error` from Cosign signing — signing failure now aborts the entire release to prevent unsigned VSIX publication
- **LOW-10**: Switch publish job Harden Runner from `egress-policy: audit` to `block` with 14 explicitly allowed endpoints
- **LOW-13**: Split dev npm audit into 2 tiers — `high` severity fails CI, `moderate` is warn-only (prevents blocking Dependabot PRs while catching critical CVEs)
- **LOW-15**: Verified Semgrep Action SHA is latest (v1 = v0.58.0), added verification date comment

## Test plan
- [x] YAML syntax verified (no runtime code changes)
- [x] `continue-on-error` removal verified on Cosign step
- [x] Allowed endpoints list covers: npm, GitHub API, Sigstore, Trivy, Marketplace, Open VSX, Cloudflare R2
- [x] npm audit 2-tier split preserves production audit unchanged
- [x] Semgrep Action SHA confirmed as latest via `gh api repos/semgrep/semgrep-action/tags`
- [ ] Verify CI passes on this PR
- [ ] Note: `egress-policy: block` endpoints will be fully validated on next actual publish (tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)