### PR TITLE
security(git-id-switcher): add rate limiter to security logger (LOW-14)

### DIFF
--- a/extensions/git-id-switcher/src/security/securityLogger.ts
+++ b/extensions/git-id-switcher/src/security/securityLogger.ts
@@ -82,6 +82,23 @@ export interface ISecurityLogger {
 }
 
 /**
+ * Rate limiting constants for security event logging
+ * @security Prevents I/O DoS from rapid-fire validation failures or attack attempts
+ */
+const RATE_LIMIT_WINDOW_MS = 10_000;  // 10-second sliding window
+const RATE_LIMIT_MAX_EVENTS = 10;     // Max events per window per event type
+
+/**
+ * Per-event-type rate limiter state
+ */
+interface RateLimitState {
+  /** Timestamps of events within the current window */
+  timestamps: number[];
+  /** Count of events dropped since last allowed event */
+  droppedCount: number;
+}
+
+/**
  * Log file configuration validation constants
  * @security Prevents DoS via extreme log file settings from malicious workspace config
  */
@@ -127,6 +144,8 @@ export {
   MAX_LOG_FILE_SIZE_BYTES as _MAX_LOG_FILE_SIZE_BYTES,
   MIN_LOG_FILES as _MIN_LOG_FILES,
   MAX_LOG_FILES as _MAX_LOG_FILES,
+  RATE_LIMIT_WINDOW_MS as _RATE_LIMIT_WINDOW_MS,
+  RATE_LIMIT_MAX_EVENTS as _RATE_LIMIT_MAX_EVENTS,
 };
 
 /**
@@ -139,6 +158,7 @@ class SecurityLoggerImpl implements ISecurityLogger {
   private minLogLevel: LogLevel = LogLevel.INFO;
   private globalStorageUri: string | null = null;
   private sanitizeOptions: SanitizeOptions = {};
+  private readonly rateLimitState = new Map<SecurityEventType, RateLimitState>();
 
   /**
    * Initialize with extension context for secure file logging
@@ -241,9 +261,53 @@ class SecurityLoggerImpl implements ISecurityLogger {
       this.fileLogWriter.dispose();
       this.fileLogWriter = null;
     }
+    this.rateLimitState.clear();
   }
 
-  private log(event: Omit<SecurityEvent, 'timestamp'>): void {
+  /**
+   * Check rate limit for an event type.
+   * @returns The number of previously dropped events if this event is allowed, or -1 if rate-limited
+   */
+  private checkRateLimit(eventType: SecurityEventType): number {
+    const now = Date.now();
+    let state = this.rateLimitState.get(eventType);
+    if (!state) {
+      state = { timestamps: [], droppedCount: 0 };
+      this.rateLimitState.set(eventType, state);
+    }
+
+    // Evict timestamps outside the sliding window
+    const windowStart = now - RATE_LIMIT_WINDOW_MS;
+    while (state.timestamps.length > 0 && state.timestamps[0] < windowStart) {
+      state.timestamps.shift();
+    }
+
+    if (state.timestamps.length >= RATE_LIMIT_MAX_EVENTS) {
+      // Rate limited — drop this event
+      state.droppedCount++;
+      return -1;
+    }
+
+    // Allowed — record timestamp and return dropped count
+    state.timestamps.push(now);
+    const dropped = state.droppedCount;
+    state.droppedCount = 0;
+    return dropped;
+  }
+
+  private log(event: Omit<SecurityEvent, 'timestamp'>, skipRateLimit = false): void {
+    // defense-in-depth: rate limit to prevent I/O DoS from rapid-fire events
+    if (!skipRateLimit) {
+      const droppedCount = this.checkRateLimit(event.type);
+      if (droppedCount === -1) {
+        return; // Rate limited — silently drop
+      }
+
+      if (droppedCount > 0) {
+        event = { ...event, details: { ...event.details, _rateLimitDropped: `dropped: ${droppedCount} events` } };
+      }
+    }
+
     const sanitizedDetails = sanitizeDetails(event.details, this.sanitizeOptions);
     const timestamp = new Date().toISOString();
     const fullEvent: SecurityEvent = {
@@ -438,14 +502,15 @@ class SecurityLoggerImpl implements ISecurityLogger {
   logConfigChanges(changes: ConfigChangeDetail[]): void {
     if (changes.length === 0) return;
     const MAX_CHANGES = 100;
+    // Skip rate limit for config change batch — already bounded by MAX_CHANGES
     for (const change of changes.slice(0, MAX_CHANGES)) {
       const details = change.key === 'identities'
         ? this.buildIdentityChangeDetails(change)
         : { configKey: change.key, previousValue: this.sanitizeConfigValue(change.key, change.previousValue), newValue: this.sanitizeConfigValue(change.key, change.newValue) };
-      this.log({ type: SecurityEventType.CONFIG_CHANGE, severity: 'info', details });
+      this.log({ type: SecurityEventType.CONFIG_CHANGE, severity: 'info', details }, true);
     }
     if (changes.length > MAX_CHANGES) {
-      this.log({ type: SecurityEventType.CONFIG_CHANGE, severity: 'warning', details: { message: `Truncated (${changes.length})` } });
+      this.log({ type: SecurityEventType.CONFIG_CHANGE, severity: 'warning', details: { message: `Truncated (${changes.length})` } }, true);
     }
   }
 
@@ -497,3 +562,8 @@ class SecurityLoggerImpl implements ISecurityLogger {
 }
 
 export const securityLogger = new SecurityLoggerImpl();
+
+// Export for testing — allows resetting rate limiter state between tests
+export function _resetRateLimitState(): void {
+  (securityLogger as unknown as { rateLimitState: Map<SecurityEventType, RateLimitState> }).rateLimitState.clear();
+}

--- a/extensions/git-id-switcher/src/test/securityLogger.test.ts
+++ b/extensions/git-id-switcher/src/test/securityLogger.test.ts
@@ -22,6 +22,9 @@ import {
   _MAX_LOG_FILE_SIZE_BYTES,
   _MIN_LOG_FILES,
   _MAX_LOG_FILES,
+  _RATE_LIMIT_WINDOW_MS,
+  _RATE_LIMIT_MAX_EVENTS,
+  _resetRateLimitState,
 } from '../security/securityLogger';
 import {
   severityToLogLevel,
@@ -1516,6 +1519,189 @@ function testLogConfigConstants(): void {
 }
 
 /**
+ * Test rate limit constants have expected values
+ */
+function testRateLimitConstants(): void {
+  console.log('Testing rate limit constants...');
+
+  assert.strictEqual(_RATE_LIMIT_WINDOW_MS, 10_000, 'Rate limit window should be 10 seconds');
+  assert.strictEqual(_RATE_LIMIT_MAX_EVENTS, 10, 'Rate limit max events should be 10 per window');
+
+  console.log('✅ Rate limit constants tests passed!');
+}
+
+/**
+ * Test that events within the rate limit are all logged
+ */
+function testRateLimitAllowsWithinLimit(): void {
+  console.log('Testing rate limit allows events within limit...');
+
+  _resetRateLimitState();
+
+  const consoleCapture = new ConsoleCapture();
+  consoleCapture.start();
+
+  // Log exactly RATE_LIMIT_MAX_EVENTS events — all should pass
+  for (let i = 0; i < _RATE_LIMIT_MAX_EVENTS; i++) {
+    securityLogger.logValidationFailure('field', `reason-${i}`);
+  }
+
+  consoleCapture.stop();
+
+  const output = consoleCapture.getOutput();
+  const validationEvents = output.filter(line => line.includes('VALIDATION_FAILURE'));
+  assert.strictEqual(
+    validationEvents.length, _RATE_LIMIT_MAX_EVENTS,
+    `All ${_RATE_LIMIT_MAX_EVENTS} events within limit should be logged`
+  );
+
+  _resetRateLimitState();
+
+  console.log('✅ Rate limit allows events within limit passed!');
+}
+
+/**
+ * Test that events exceeding the rate limit are dropped
+ */
+function testRateLimitDropsExcessEvents(): void {
+  console.log('Testing rate limit drops excess events...');
+
+  _resetRateLimitState();
+
+  const consoleCapture = new ConsoleCapture();
+  consoleCapture.start();
+
+  // Log more than the limit — excess should be dropped
+  const totalEvents = _RATE_LIMIT_MAX_EVENTS + 5;
+  for (let i = 0; i < totalEvents; i++) {
+    securityLogger.logValidationFailure('field', `reason-${i}`);
+  }
+
+  consoleCapture.stop();
+
+  const output = consoleCapture.getOutput();
+  const validationEvents = output.filter(line => line.includes('VALIDATION_FAILURE'));
+  assert.strictEqual(
+    validationEvents.length, _RATE_LIMIT_MAX_EVENTS,
+    `Only ${_RATE_LIMIT_MAX_EVENTS} events should be logged, excess dropped`
+  );
+
+  _resetRateLimitState();
+
+  console.log('✅ Rate limit drops excess events passed!');
+}
+
+/**
+ * Test that rate limiting is per event type (independent counters)
+ */
+function testRateLimitPerEventType(): void {
+  console.log('Testing rate limit is per event type...');
+
+  _resetRateLimitState();
+
+  const consoleCapture = new ConsoleCapture();
+  consoleCapture.start();
+
+  // Exhaust VALIDATION_FAILURE limit
+  for (let i = 0; i < _RATE_LIMIT_MAX_EVENTS + 3; i++) {
+    securityLogger.logValidationFailure('field', `reason-${i}`);
+  }
+
+  // COMMAND_BLOCKED should still be allowed (separate counter)
+  securityLogger.logCommandBlocked('git', ['push'], 'blocked');
+
+  consoleCapture.stop();
+
+  const output = consoleCapture.getOutput();
+  const blockedEvents = output.filter(line => line.includes('COMMAND_BLOCKED'));
+  assert.strictEqual(blockedEvents.length, 1, 'COMMAND_BLOCKED should not be affected by VALIDATION_FAILURE rate limit');
+
+  _resetRateLimitState();
+
+  console.log('✅ Rate limit per event type passed!');
+}
+
+/**
+ * Test that dropped event count is reported on the next allowed event
+ */
+function testRateLimitDroppedCountReported(): void {
+  console.log('Testing rate limit dropped count is reported...');
+
+  _resetRateLimitState();
+
+  // Use a mock to control Date.now for time manipulation
+  const originalDateNow = Date.now;
+  let mockNow = 1_000_000;
+  Date.now = () => mockNow;
+
+  try {
+    const consoleCapture = new ConsoleCapture();
+    consoleCapture.start();
+
+    // Fill up the rate limit window
+    for (let i = 0; i < _RATE_LIMIT_MAX_EVENTS; i++) {
+      securityLogger.logValidationFailure('field', `reason-${i}`);
+    }
+
+    // These 3 events should be dropped
+    securityLogger.logValidationFailure('field', 'dropped-1');
+    securityLogger.logValidationFailure('field', 'dropped-2');
+    securityLogger.logValidationFailure('field', 'dropped-3');
+
+    // Advance time past the window to allow new events
+    mockNow += _RATE_LIMIT_WINDOW_MS + 1;
+
+    // This event should be allowed and include dropped count
+    securityLogger.logValidationFailure('field', 'after-window');
+
+    consoleCapture.stop();
+
+    const output = consoleCapture.getOutput();
+    const droppedLine = output.find(line => line.includes('dropped: 3 events'));
+    assert.ok(droppedLine, 'Should report 3 dropped events on next allowed event');
+  } finally {
+    Date.now = originalDateNow;
+    _resetRateLimitState();
+  }
+
+  console.log('✅ Rate limit dropped count reported passed!');
+}
+
+/**
+ * Test that rate limit state is cleared on dispose
+ */
+function testRateLimitClearedOnDispose(): void {
+  console.log('Testing rate limit state cleared on dispose...');
+
+  _resetRateLimitState();
+
+  const consoleCapture = new ConsoleCapture();
+
+  // Fill up the rate limit
+  consoleCapture.start();
+  for (let i = 0; i < _RATE_LIMIT_MAX_EVENTS + 5; i++) {
+    securityLogger.logValidationFailure('field', `reason-${i}`);
+  }
+  consoleCapture.stop();
+
+  // Dispose should clear rate limit state
+  securityLogger.dispose();
+
+  // After dispose, rate limit should be fresh — events should be allowed again
+  consoleCapture.start();
+  securityLogger.logValidationFailure('field', 'after-dispose');
+  consoleCapture.stop();
+
+  const output = consoleCapture.getOutput();
+  const validationEvents = output.filter(line => line.includes('VALIDATION_FAILURE'));
+  assert.strictEqual(validationEvents.length, 1, 'After dispose, rate limit should be reset');
+
+  _resetRateLimitState();
+
+  console.log('✅ Rate limit cleared on dispose passed!');
+}
+
+/**
  * Run all tests
  */
 export async function runSecurityLoggerTests(): Promise<void> {
@@ -1524,6 +1710,8 @@ export async function runSecurityLoggerTests(): Promise<void> {
   console.log('╚════════════════════════════════════════════╝\n');
 
   try {
+    // Reset rate limit state before running tests to ensure clean state
+    _resetRateLimitState();
     testSecurityEventTypeEnum();
     testLogLevelEnum();
     testSeverityToLogLevel();
@@ -1560,6 +1748,12 @@ export async function runSecurityLoggerTests(): Promise<void> {
     testSanitizeConfigValueIdentities();
     testValidateLogConfigRange();
     testLogConfigConstants();
+    testRateLimitConstants();
+    testRateLimitAllowsWithinLimit();
+    testRateLimitDropsExcessEvents();
+    testRateLimitPerEventType();
+    testRateLimitDroppedCountReported();
+    testRateLimitClearedOnDispose();
 
     console.log('\n✅ All security logger tests passed!\n');
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add per-event-type sliding window rate limiter to `SecurityLoggerImpl` (10 events per 10s per `SecurityEventType`)
- Dropped events are counted and reported via `_rateLimitDropped` field on the next allowed event
- `logConfigChanges()` batch processing bypasses rate limit (already bounded by `MAX_CHANGES=100`)
- Rate limit state is cleared on `dispose()`
- 6 new test cases covering: limit enforcement, excess drop, per-type independence, drop count reporting, dispose cleanup

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run test` — all tests pass (including 6 new rate limiter tests)
- [x] `npm run lint` — 0 errors
- [x] `npm run test:coverage` — statement coverage 100% maintained
- [x] Existing tests unaffected by rate limiter (config change batch uses `skipRateLimit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)