### PR TITLE
fix(security): add email address and PII command argument masking

### DIFF
--- a/extensions/git-id-switcher/src/security/sensitiveDataDetector.ts
+++ b/extensions/git-id-switcher/src/security/sensitiveDataDetector.ts
@@ -46,9 +46,13 @@ const PII_COMMAND_ARGS = new Set([
  * @returns true if the string appears to contain an email address
  */
 export function looksLikeEmail(value: string): boolean {
+  // URLs with protocol (ssh://, ftp://) are not emails
+  if (value.includes('://')) return false;
   const atIndex = value.indexOf('@');
   if (atIndex <= 0) return false;
   const afterAt = value.slice(atIndex + 1);
+  // URL-like patterns after @ (colon for SCP/port, slash for path) are not emails
+  if (afterAt.includes('/') || afterAt.includes(':')) return false;
   return afterAt.includes('.') && afterAt.length > 1;
 }
 

--- a/extensions/git-id-switcher/src/test/sensitiveDataDetector.test.ts
+++ b/extensions/git-id-switcher/src/test/sensitiveDataDetector.test.ts
@@ -1447,6 +1447,28 @@ function testEmailDetection(): void {
     'user@x without dot should NOT be detected'
   );
 
+  // SSH/Git URLs should NOT be detected as emails
+  assert.strictEqual(
+    looksLikeEmail('git@github.com:org/repo'),
+    false,
+    'SCP-style git URL should NOT be detected (colon after @)'
+  );
+  assert.strictEqual(
+    looksLikeEmail('ssh://git@github.com/repo'),
+    false,
+    'SSH URL should NOT be detected (has ://)'
+  );
+  assert.strictEqual(
+    looksLikeEmail('git@github.com/repo.git'),
+    false,
+    'Git URL with slash should NOT be detected (slash after @)'
+  );
+  assert.strictEqual(
+    looksLikeEmail('ftp://user@files.example.com/data'),
+    false,
+    'FTP URL should NOT be detected (has ://)'
+  );
+
   console.log('✅ Email detection passed!');
 }
 


### PR DESCRIPTION
## Summary
- Add `looksLikeEmail()` function using `String.indexOf`/`includes` (ReDoS-safe, no regex) to detect email addresses in log values
- Add `PII_COMMAND_ARGS` Set for git config keys (`user.email`, `user.name`) to detect PII-revealing command arguments
- Mask email addresses as `[REDACTED:EMAIL]` in `sanitizeStringValue` chain (path → email → sensitive → truncate)
- Add 3 test functions covering email detection, PII arg detection, and `sanitizeValue` integration

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] ESLint passes with 0 errors (`npm run lint`)
- [x] All unit tests pass (23 test functions)
- [x] Statement coverage remains at 100%
- [x] Email addresses (`user@example.com`, `john.doe@company.co.jp`) correctly masked
- [x] npm scopes (`@types/node`) and non-email strings not falsely detected
- [x] PII git config keys (`user.email`, `user.name`) detected as sensitive
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)