### PR TITLE
security(git-id-switcher): remove unsafe-inline from CSP style-src

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.22] - 2026-03-17
+
+### Security
+
+- **Webview CSP hardening**: Removed `'unsafe-inline'` from `style-src` directive and migrated all inline `<style>` tags to nonce-based CSP, matching the existing nonce-only `script-src` policy
+
 ## [0.16.21] - 2026-03-15
 
 ### Fixed

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.16.21",
+  "version": "0.16.22",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': 'cb8170851742743e584cf21ff3427c78dc1c9471fd56d25a19abc174ed4fdd61',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '847d1136ce7afc42d87ac5f5168e6cdcfccd1982f413b54dafe8e3b83be71dd3',
+  'extensions/git-id-switcher/CHANGELOG.md': 'b74e9b9d80cee8c470e2606d53b9ca83e6b2cbde255e2d673c0a847323688093',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'db6ba2f7809b2c7aa831eda3a4b9bb80521577e4e267c7b6ccad17ffba847548',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/documentationPublic.ts
+++ b/extensions/git-id-switcher/src/ui/documentationPublic.ts
@@ -215,7 +215,7 @@ async function handleNavigation(
     case 'internal-md': {
       if (classification.resolvedPath) {
         // Show loading
-        panel.webview.html = getLoadingHtml(panel.webview);
+        panel.webview.html = getLoadingHtml(panel.webview, nonce);
 
         // Try to fetch the document
         const content = await fetchDocumentByPath(classification.resolvedPath);
@@ -292,12 +292,12 @@ async function handleBack(
     // Update panel title to show current document name
     panel.title = getDocumentDisplayName(state.currentPath);
 
-    panel.webview.html = getLoadingHtml(panel.webview);
+    panel.webview.html = getLoadingHtml(panel.webview, nonce);
     const success = await updateWebviewContent(panel, state, nonce);
 
     if (!success) {
       // Document no longer available - show error
-      panel.webview.html = getErrorHtml(panel.webview, 'network');
+      panel.webview.html = getErrorHtml(panel.webview, 'network', nonce);
     }
   }
 }
@@ -339,7 +339,7 @@ export async function showDocumentation(
   };
 
   // Show loading state
-  panel.webview.html = getLoadingHtml(panel.webview);
+  panel.webview.html = getLoadingHtml(panel.webview, nonce);
 
   // Handle messages from Webview
   panel.webview.onDidReceiveMessage(
@@ -376,10 +376,10 @@ export async function showDocumentation(
         false
       );
     } else {
-      panel.webview.html = getErrorHtml(panel.webview, 'network');
+      panel.webview.html = getErrorHtml(panel.webview, 'network', nonce);
     }
   } catch (error) {
     console.error('[Git ID Switcher] Documentation fetch error:', error);
-    panel.webview.html = getErrorHtml(panel.webview, 'server');
+    panel.webview.html = getErrorHtml(panel.webview, 'server', nonce);
   }
 }

--- a/extensions/git-id-switcher/src/ui/webview.ts
+++ b/extensions/git-id-switcher/src/ui/webview.ts
@@ -40,23 +40,19 @@ export function generateNonce(): string {
  * Build Content Security Policy header value
  *
  * @param webview - Webview instance for cspSource
- * @param nonce - Optional nonce for script-src (required when enableScripts: true)
+ * @param nonce - Nonce for style-src and script-src (required for inline styles/scripts)
  * @returns CSP header string
  */
-export function buildCsp(webview: vscode.Webview, nonce?: string): string {
+export function buildCsp(webview: vscode.Webview, nonce: string): string {
   const directives = [
     `default-src 'none'`,
     // Allow images from: VSCode, our CDN, shields.io badges, GitHub avatars
     `img-src ${webview.cspSource} https://assets.nullvariant.com https://img.shields.io https://*.githubusercontent.com`,
-    `style-src ${webview.cspSource} 'unsafe-inline'`,
+    `style-src ${webview.cspSource} 'nonce-${nonce}'`,
+    `script-src 'nonce-${nonce}'`,
     `connect-src https://assets.nullvariant.com`,
     `font-src ${webview.cspSource}`,
   ];
-
-  // Add script-src with nonce when scripts are enabled
-  if (nonce) {
-    directives.push(`script-src 'nonce-${nonce}'`);
-  }
 
   return directives.join('; ');
 }
@@ -72,7 +68,7 @@ export function buildCsp(webview: vscode.Webview, nonce?: string): string {
  * @param content - Rendered HTML content
  * @param locale - Current locale
  * @param currentPath - Current document path (for relative link resolution)
- * @param nonce - CSP nonce for inline scripts
+ * @param nonce - CSP nonce for inline styles and scripts
  * @param canGoBack - Whether back navigation is available
  * @returns Complete HTML document
  */
@@ -131,7 +127,7 @@ export function getDocumentHtml(
   <meta http-equiv="Content-Security-Policy" content="${csp}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Git ID Switcher Documentation</title>
-  <style>
+  <style nonce="${nonce}">
     body {
       font-family: var(--vscode-font-family);
       font-size: var(--vscode-font-size);
@@ -267,17 +263,18 @@ export function getDocumentHtml(
  * Generate loading state HTML
  *
  * @param webview - Webview instance
+ * @param nonce - CSP nonce for inline styles
  * @returns Loading HTML document
  */
-export function getLoadingHtml(webview: vscode.Webview): string {
-  const csp = buildCsp(webview);
+export function getLoadingHtml(webview: vscode.Webview, nonce: string): string {
+  const csp = buildCsp(webview, nonce);
 
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="${csp}">
-  <style>
+  <style nonce="${nonce}">
     body {
       font-family: var(--vscode-font-family);
       color: var(--vscode-foreground);
@@ -320,13 +317,15 @@ export function getLoadingHtml(webview: vscode.Webview): string {
  *
  * @param webview - Webview instance
  * @param errorType - Type of error
+ * @param nonce - CSP nonce for inline styles
  * @returns Error HTML document
  */
 export function getErrorHtml(
   webview: vscode.Webview,
-  errorType: ErrorType
+  errorType: ErrorType,
+  nonce: string
 ): string {
-  const csp = buildCsp(webview);
+  const csp = buildCsp(webview, nonce);
 
   const messages = {
     network: {
@@ -349,7 +348,7 @@ export function getErrorHtml(
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="${csp}">
-  <style>
+  <style nonce="${nonce}">
     body {
       font-family: var(--vscode-font-family);
       color: var(--vscode-foreground);


### PR DESCRIPTION
## Summary
- Remove `'unsafe-inline'` from CSP `style-src` directive, replacing with nonce-based policy
- Add `nonce` attribute to all `<style>` tags in Webview HTML templates (document, loading, error)
- Update `getLoadingHtml` and `getErrorHtml` signatures to require nonce parameter
- All call sites in `documentationPublic.ts` updated to pass nonce

## Motivation
The `script-src` directive already used nonce-only policy, but `style-src` still allowed `'unsafe-inline'`, leaving a potential inline style injection vector. This change unifies both directives under nonce-based CSP.

## Test plan
- [x] `npx tsc --noEmit` — no compilation errors
- [x] `npm run lint` — 0 errors
- [x] `npm run test:coverage` — all tests pass, 100% statement coverage maintained
- [ ] Manual: open documentation panel, verify no style regression
- [ ] Manual: verify loading spinner displays correctly
- [ ] Manual: verify error states display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)