### PR TITLE
fix(ci): add release-assets domain to egress allowlist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
             marketplace.visualstudio.com:443
             oauth2.sigstore.dev:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             open-vsx.org:443
             pkg-containers.githubusercontent.com:443
             registry.npmjs.org:443


### PR DESCRIPTION
## Summary

- Add `release-assets.githubusercontent.com:443` to harden-runner `allowed-endpoints`
- GitHub Releases downloads redirect to `release-assets.githubusercontent.com` (not `objects.githubusercontent.com` as previously assumed), causing the Trivy direct download from PR #361 to be blocked by egress policy

## Test plan

- [ ] Merge, delete + re-push `git-id-switcher-v0.17.0` tag, verify Publish Extension passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)