### PR TITLE
fix(ci): use ghcr.io for Trivy vulnerability DB

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,8 @@ jobs:
           chmod +x trivy
           ./trivy fs extensions/git-id-switcher \
             --severity CRITICAL,HIGH \
-            --exit-code 1
+            --exit-code 1 \
+            --db-repository ghcr.io/aquasecurity/trivy-db:2
           rm -f trivy trivy.tar.gz
 
       # Supply Chain Security: Cosign keyless signing for VSIX


### PR DESCRIPTION
## Summary

- Add `--db-repository ghcr.io/aquasecurity/trivy-db:2` to Trivy fs command
- Trivy defaults to `mirror.gcr.io` for vulnerability DB download, which is blocked by harden-runner egress policy
- `ghcr.io` is already in `allowed-endpoints`, so no new egress rules needed

## Context

This is the third fix for the Publish Extension workflow:
1. PR #361: Replaced `trivy-action` with direct GitHub Releases download (fixed `get.trivy.dev` block)
2. PR #362: Added `release-assets.githubusercontent.com` to egress allowlist (fixed binary download redirect)
3. **This PR**: Use `ghcr.io` for Trivy DB (fixed `mirror.gcr.io` block)

## Test plan

- [ ] Merge, delete + re-push `git-id-switcher-v0.17.0` tag, verify Publish Extension passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)