### PR TITLE
fix(ci): add raw.githubusercontent.com to egress

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
             marketplace.visualstudio.com:443
             oauth2.sigstore.dev:443
             objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             open-vsx.org:443
             pkg-containers.githubusercontent.com:443


### PR DESCRIPTION
## Summary

- Add `raw.githubusercontent.com:443` to harden-runner `allowed-endpoints`
- Cosign installer downloads its public key from `raw.githubusercontent.com`, which was blocked
- Trivy scan now passes (fixed in #361 + #362 + #363); this fixes the next blocker (Cosign install)

## Test plan

- [ ] Merge, delete + re-push `git-id-switcher-v0.17.0` tag, verify Publish Extension passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)