### PR TITLE
fix(ci): add timestamp.sigstore.dev to egress

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             registry.npmjs.org:443
             rekor.sigstore.dev:443
+            timestamp.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             uploads.github.com:443
 


### PR DESCRIPTION
## Summary

- Add `timestamp.sigstore.dev:443` to harden-runner `allowed-endpoints`
- Cosign keyless signing calls `timestamp.sigstore.dev` for RFC 3161 timestamping, which was blocked
- Previous run: Trivy ✓, Cosign Install ✓, Cosign Sign ✗ (this fix)

## Egress fixes summary (#361–#365)

| PR | Domain added | Used by |
|-----|-------------|---------|
| #361 | *(removed get.trivy.dev dependency)* | Trivy binary |
| #362 | `release-assets.githubusercontent.com` | GitHub Releases redirect |
| #363 | `--db-repository ghcr.io` | Trivy vuln DB |
| #364 | `raw.githubusercontent.com` | Cosign public key |
| **#365** | **`timestamp.sigstore.dev`** | **Cosign RFC 3161 timestamp** |

## Test plan

- [ ] Merge, delete + re-push `git-id-switcher-v0.17.0` tag, verify Publish Extension passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)