### PR TITLE
fix(git-id-switcher): revert engines.vscode to ^1.85.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,11 @@ updates:
       - "npm"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    # @types/vscode must match engines.vscode.
+    # Bumping it forces engines.vscode up, cutting off fork editors
+    # (Cursor, Windsurf, etc.) that lag behind VS Code stable.
+    ignore:
+      - dependency-name: "@types/vscode"
     # Group minor and patch updates together
     groups:
       dev-dependencies:

--- a/extensions/git-id-switcher/.vscode-test.mjs
+++ b/extensions/git-id-switcher/.vscode-test.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
   files: 'out/test/e2e/**/*.test.js',
 
   // VS Code version to use for testing (matches engines.vscode in package.json)
-  version: '1.109.0',
+  version: '1.85.0',
 
   // Mocha configuration
   mocha: {

--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-03-18
+
+### Fixed
+
+- **Restore fork editor compatibility**: Reverted `engines.vscode` from `^1.109.0` to `^1.85.0`. The 1.109.0 requirement was introduced by a Dependabot `@types/vscode` bump in v0.16.20, but no APIs newer than 1.85.0 are actually used. This made v0.16.20+ invisible on Cursor, Windsurf, Antigravity, TRAE, and other VS Code forks whose engine version lags behind VS Code stable
+- **Prevent future `@types/vscode` auto-bumps**: Added `@types/vscode` to both Dependabot ignore list and Renovate ignoreDeps to prevent `engines.vscode` from being silently raised again
+
 ## [0.17.0] - 2026-03-18
 
 ### Added

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,11 +2,11 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {
-    "vscode": "^1.109.0"
+    "vscode": "^1.85.0"
   },
   "categories": [
     "SCM Providers"
@@ -305,7 +305,7 @@
     "@eslint/js": "^10.0.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.3.5",
-    "@types/vscode": "^1.109.0",
+    "@types/vscode": "^1.85.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.0.0",

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': 'cb8170851742743e584cf21ff3427c78dc1c9471fd56d25a19abc174ed4fdd61',
   'CODE_OF_CONDUCT.md': 'a5eb286c902437bbe0f6d409894f20e51c172fa869fe2f151bfa388f9d911b54',
   'CONTRIBUTING.md': '4150f8810aec7b2e8eff9f3c69ee1bae1374843f50a812efa6778cba27a833cd',
-  'extensions/git-id-switcher/CHANGELOG.md': '17586c20eab208757f6576eec7c0eac9238d9109af752aa2ec5a28682ae8adf0',
+  'extensions/git-id-switcher/CHANGELOG.md': '326cf5ac023d81102d818b6567c0139724540f4da5a4e33bc81a37d31c22611d',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'db6ba2f7809b2c7aa831eda3a4b9bb80521577e4e267c7b6ccad17ffba847548',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,13 @@
       }
     },
     "extensions/git-id-switcher": {
-      "version": "0.16.19",
+      "version": "0.17.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.3.5",
-        "@types/vscode": "^1.109.0",
+        "@types/vscode": "^1.85.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.0.0",
@@ -38,7 +38,7 @@
         "typescript-eslint": "^8.57.0"
       },
       "engines": {
-        "vscode": "^1.109.0"
+        "vscode": "^1.85.0"
       }
     },
     "extensions/git-id-switcher/node_modules/@eslint/js": {

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,5 @@
       "automerge": false
     }
   ],
-  "ignoreDeps": []
+  "ignoreDeps": ["@types/vscode"]
 }


### PR DESCRIPTION
## Summary

- Revert `engines.vscode` and `@types/vscode` from `^1.109.0` to `^1.85.0`
- Add `@types/vscode` to Dependabot ignore list and Renovate ignoreDeps to prevent recurrence
- Bump version to 0.17.1

## Context

Dependabot PR #308 bumped `@types/vscode` to 1.109.0, which forced `engines.vscode` up to `^1.109.0` (`vsce` requires `@types/vscode` ≤ `engines`). This made v0.16.20+ invisible on fork editors:

| Editor | VS Code Base | Meets `^1.109.0`? |
|---|---|---|
| VS Code | 1.111.0 | ✅ |
| Cursor | 1.105.1 | ❌ |
| Antigravity | 1.107.0 | ❌ |
| TRAE | 1.107.1 | ❌ |
| Windsurf | 1.108.2 | ❌ |

No APIs newer than 1.85.0 are actually used by this extension.

## Test plan

- [x] `npm run compile` passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — all tests pass
- [x] `npm run test:coverage` — 100% statement coverage maintained
- [x] `npx vsce package` — packages successfully without `@types/vscode > engines.vscode` error
- [ ] Verify extension installs on Cursor after publish
- [ ] Verify extension installs on Windsurf after publish

🤖 Generated with [Claude Code](https://claude.ai/claude-code)