### PR TITLE
fix(ci): add GH_REPO env to all zoo bot review jobs

### DIFF
--- a/.github/workflows/blaze-bot.yml
+++ b/.github/workflows/blaze-bot.yml
@@ -22,6 +22,8 @@ jobs:
     name: 🐗 Release Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target'
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ciel-bot.yml
+++ b/.github/workflows/ciel-bot.yml
@@ -31,6 +31,8 @@ jobs:
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.event == 'pull_request_target' &&
       github.event.workflow_run.pull_requests[0].number > 0
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/justice-bot.yml
+++ b/.github/workflows/justice-bot.yml
@@ -25,6 +25,8 @@ jobs:
     if: >
       github.event_name == 'pull_request_target' &&
       (github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]')
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/luna-bot.yml
+++ b/.github/workflows/luna-bot.yml
@@ -22,6 +22,8 @@ jobs:
     name: 👧 Dependency Explorer
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target'
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/mimi-bot.yml
+++ b/.github/workflows/mimi-bot.yml
@@ -25,6 +25,8 @@ jobs:
     name: 🐰 Validation Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target'
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/slow-bot.yml
+++ b/.github/workflows/slow-bot.yml
@@ -25,6 +25,8 @@ jobs:
     name: 🦥 Code Quality Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target'
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

- Add `GH_REPO` environment variable at job level to all 6 zoo bot review jobs
- Fixes `gh pr diff` / `gh pr comment` failing with "fatal: not a git repository" when no `actions/checkout` is used

## Root cause

After removing `actions/checkout` from review jobs (Scorecard fix), `gh` CLI commands that resolve the repo from git remotes (`gh pr diff`, `gh pr comment`, `gh pr view`) fail because there is no `.git` directory. Setting `GH_REPO` tells `gh` which repository to use.

## Affected bots

All 6: Justice, Slow, Mimi, Luna, Blaze, Ciel

## Test plan

- [ ] Merge this fix, then re-trigger test PR #378
- [ ] Verify all bots post comments successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)