### PR TITLE
fix(ci): fix printf invalid option error in Ciel-bot

### DIFF
--- a/.github/workflows/ciel-bot.yml
+++ b/.github/workflows/ciel-bot.yml
@@ -140,7 +140,7 @@ jobs:
 
             printf '%s zoo members have reviewed this PR.\n\n' "$TOTAL"
             cat /tmp/ciel-findings.md
-            printf '---\n\n'
+            printf '\n---\n\n'
             printf '> まあまあ、ほどほどに。\n\n'
             printf '*This mediation was peacefully delivered by nullvariant-ciel[bot]*\n'
           } > /tmp/ciel-comment.md


### PR DESCRIPTION
## Summary

Fix `printf: --: invalid option` error in Ciel-bot's comment posting step.

`printf '---\n\n'` → `printf '\n---\n\n'` (bash interprets leading `---` as option flags).

## Test plan

- [ ] CI passes
- [ ] Merge, retrigger test PR #378, verify Ciel posts comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)