### PR TITLE
fix(deps): bump flatted 3.4.1 to 3.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3597,9 +3597,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary
- Bump `flatted` from 3.4.1 to 3.4.2 to fix high severity Prototype Pollution vulnerability ([GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh))
- This resolves the `security.yml` workflow failure since 2026-03-20

## Test plan
- [ ] Verify `security.yml` workflow passes (npm audit returns 0 vulnerabilities)
- [ ] Verify OpenSSF Scorecard no longer flags GHSA-rf6f-7fwh-wjgh

🤖 Generated with [Claude Code](https://claude.com/claude-code)