### PR TITLE
chore(ci): migrate R2 deploy target from nullvariant-assets to kura

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Deploy documentation to R2
         run: |
-          R2_BASE="nullvariant-assets/nullvariant-vscode-extensions"
+          R2_BASE="kura/nullvariant.com/nullvariant-vscode-extensions"
           EXT_PATH="extensions/git-id-switcher"
 
           # === Monorepo root files ===

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Deploy documentation to R2
         run: |
-          R2_BASE="nullvariant-assets/nullvariant-vscode-extensions"
+          R2_BASE="kura/nullvariant.com/nullvariant-vscode-extensions"
           EXT_PATH="extensions/git-id-switcher"
 
           # Upload all language READMEs from docs/i18n/ (including en/)


### PR DESCRIPTION
## Summary

- Migrate R2 deploy target in `deploy-docs.yml` and `publish.yml` from `nullvariant-assets` bucket to `kura` bucket with `nullvariant.com/` namespace prefix
- Part of the kura R2 bucket consolidation (all assets under a single bucket with namespace separation)

## Test plan

- [ ] Verify `deploy-docs.yml` workflow runs successfully after merge (trigger via workflow_dispatch or doc change)
- [ ] Verify documentation is accessible at `assets.nullvariant.com` after deploy

> **Note:** This PR should be merged **after** the kura Worker's `bucket_name` is switched to `kura` (Stage 2), to avoid a window where new deploys go to `kura` but the Worker still reads from `nullvariant-assets`.