### PR TITLE
fix(security): webview HTML escape defense-in-depth

### DIFF
--- a/extensions/git-id-switcher/src/test/documentation.test.ts
+++ b/extensions/git-id-switcher/src/test/documentation.test.ts
@@ -628,8 +628,27 @@ function testEscapeHtmlEntities(): void {
 
   assert.strictEqual(
     escapeHtmlEntities('<a href="test">'),
-    '&lt;a href="test"&gt;',
-    'Full tag should be escaped'
+    '&lt;a href=&quot;test&quot;&gt;',
+    'Full tag should be escaped including quotes'
+  );
+
+  // Quote escaping (defense-in-depth for attribute contexts)
+  assert.strictEqual(
+    escapeHtmlEntities('a "quoted" value'),
+    'a &quot;quoted&quot; value',
+    'Double quotes should be escaped'
+  );
+
+  assert.strictEqual(
+    escapeHtmlEntities("it's"),
+    'it&#39;s',
+    'Single quotes should be escaped'
+  );
+
+  assert.strictEqual(
+    escapeHtmlEntities(`"double" & 'single'`),
+    '&quot;double&quot; &amp; &#39;single&#39;',
+    'Mixed quotes and ampersand should all be escaped'
   );
 
   // Edge cases

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -210,7 +210,9 @@ export function escapeHtmlEntities(text: string): string {
   return text
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;');
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 
 // ============================================================================

--- a/extensions/git-id-switcher/src/ui/webview.ts
+++ b/extensions/git-id-switcher/src/ui/webview.ts
@@ -13,6 +13,8 @@
 import * as vscode from 'vscode';
 import * as crypto from 'node:crypto';
 
+import { escapeHtmlEntities } from './documentationInternal';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -121,7 +123,7 @@ export function getDocumentHtml(
   `;
 
   return `<!DOCTYPE html>
-<html lang="${locale}">
+<html lang="${escapeHtmlEntities(locale)}">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="${csp}">
@@ -247,7 +249,7 @@ export function getDocumentHtml(
 <body>
   <div class="nav-bar">
     <button id="back-btn" ${canGoBack ? '' : 'disabled'}>← Back</button>
-    <span class="current-path">${currentPath}</span>
+    <span class="current-path">${escapeHtmlEntities(currentPath)}</span>
   </div>
   ${content}
   <div class="footer">


### PR DESCRIPTION
## Summary

- Apply `escapeHtmlEntities` to `locale` and `currentPath` template variables in `webview.ts` to prevent potential HTML injection (defense-in-depth)
- Enhance `escapeHtmlEntities` with `"` → `&quot;` and `'` → `&#39;` escaping for proper attribute-context protection
- Add 3 test cases for quote escaping + update existing test expectations

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] ESLint passes (0 errors on `webview.ts`)
- [x] All unit tests pass
- [x] Statement coverage remains at 100%

🤖 Generated with [Claude Code](https://claude.ai/code)