### PR TITLE
refactor(errors): split validation types into dedicated module

### DIFF
--- a/extensions/git-id-switcher/src/core/errors.ts
+++ b/extensions/git-id-switcher/src/core/errors.ts
@@ -318,83 +318,12 @@ export function getUserSafeMessage(error: unknown): string {
   return 'An unexpected error occurred';
 }
 
-// ============================================================================
-// Unified Validation Types (Phase 4)
-// ============================================================================
-
 /**
- * Field-level validation error
- *
- * Represents a validation error for a specific field.
- * Properties are readonly to ensure immutability after creation.
+ * @deprecated Import directly from './validation-types' instead.
+ * These re-exports exist only for backward compatibility.
  */
-export interface FieldValidationError {
-  /** Field name that failed validation */
-  readonly field: string;
-  /** Error message describing the validation failure */
-  readonly message: string;
-}
-
-/**
- * Unified validation result
- *
- * A consistent structure for validation results across the codebase.
- * Properties are readonly to ensure immutability after creation.
- */
-export interface UnifiedValidationResult {
-  /** Whether validation passed */
-  readonly isValid: boolean;
-  /** List of field-level errors (empty if isValid is true) */
-  readonly errors: readonly FieldValidationError[];
-}
-
-/**
- * Parse a string error message into a FieldValidationError
- *
- * @deprecated This function exists for backward compatibility during migration.
- * New code should use structured validation that returns FieldValidationError directly.
- *
- * @param error - Error string in format "field: message" or plain message
- * @returns FieldValidationError with parsed field and message
- *
- * @example
- * ```typescript
- * // Standard format with colon separator
- * toFieldError('email: Invalid format')
- * // Returns: { field: 'email', message: 'Invalid format' }
- *
- * // No colon - treated as unknown field
- * toFieldError('Unknown error')
- * // Returns: { field: 'unknown', message: 'Unknown error' }
- *
- * // Empty string
- * toFieldError('')
- * // Returns: { field: 'unknown', message: '' }
- *
- * // Empty field name (colon at start) - treated as unknown
- * toFieldError(': message only')
- * // Returns: { field: 'unknown', message: ': message only' }
- * ```
- */
-export function toFieldError(error: string): FieldValidationError {
-  const colonIndex = error.indexOf(':');
-  if (colonIndex === -1) {
-    return {
-      field: 'unknown',
-      message: error,
-    };
-  }
-
-  const field = error.slice(0, colonIndex).trim();
-  const message = error.slice(colonIndex + 1).trim();
-
-  // If field is empty after trim, use 'unknown'
-  if (!field) {
-    return {
-      field: 'unknown',
-      message: error,
-    };
-  }
-
-  return { field, message };
-}
+export {
+  toFieldError,
+  type FieldValidationError,
+  type UnifiedValidationResult,
+} from './validation-types';

--- a/extensions/git-id-switcher/src/core/validation-types.ts
+++ b/extensions/git-id-switcher/src/core/validation-types.ts
@@ -1,0 +1,80 @@
+/**
+ * Unified Validation Types (Phase 4)
+ *
+ * Provides field-level validation error types and utilities
+ * for consistent validation result handling across the codebase.
+ */
+
+/**
+ * Field-level validation error
+ *
+ * Represents a validation error for a specific field.
+ * Properties are readonly to ensure immutability after creation.
+ */
+export interface FieldValidationError {
+  /** Field name that failed validation */
+  readonly field: string;
+  /** Error message describing the validation failure */
+  readonly message: string;
+}
+
+/**
+ * Unified validation result
+ *
+ * A consistent structure for validation results across the codebase.
+ * Properties are readonly to ensure immutability after creation.
+ */
+export interface UnifiedValidationResult {
+  /** Whether validation passed */
+  readonly isValid: boolean;
+  /** List of field-level errors (empty if isValid is true) */
+  readonly errors: readonly FieldValidationError[];
+}
+
+/**
+ * Parse a string error message into a FieldValidationError
+ *
+ * @param error - Error string in format "field: message" or plain message
+ * @returns FieldValidationError with parsed field and message
+ *
+ * @example
+ * ```typescript
+ * // Standard format with colon separator
+ * toFieldError('email: Invalid format')
+ * // Returns: { field: 'email', message: 'Invalid format' }
+ *
+ * // No colon - treated as unknown field
+ * toFieldError('Unknown error')
+ * // Returns: { field: 'unknown', message: 'Unknown error' }
+ *
+ * // Empty string
+ * toFieldError('')
+ * // Returns: { field: 'unknown', message: '' }
+ *
+ * // Empty field name (colon at start) - treated as unknown
+ * toFieldError(': message only')
+ * // Returns: { field: 'unknown', message: ': message only' }
+ * ```
+ */
+export function toFieldError(error: string): FieldValidationError {
+  const colonIndex = error.indexOf(':');
+  if (colonIndex === -1) {
+    return {
+      field: 'unknown',
+      message: error,
+    };
+  }
+
+  const field = error.slice(0, colonIndex).trim();
+  const message = error.slice(colonIndex + 1).trim();
+
+  // If field is empty after trim, use 'unknown'
+  if (!field) {
+    return {
+      field: 'unknown',
+      message: error,
+    };
+  }
+
+  return { field, message };
+}

--- a/extensions/git-id-switcher/src/test/errors.test.ts
+++ b/extensions/git-id-switcher/src/test/errors.test.ts
@@ -14,8 +14,8 @@ import {
   isSecurityError,
   isFatalError,
   getUserSafeMessage,
-  toFieldError,
 } from '../core/errors';
+import { toFieldError } from '../core/validation-types';
 
 /**
  * Test SecurityError constructor

--- a/extensions/git-id-switcher/src/test/runTests.ts
+++ b/extensions/git-id-switcher/src/test/runTests.ts
@@ -29,6 +29,7 @@ import { runPathSeparatorTests } from './pathSeparator.test';
 import { runDisplayLimitsTests } from './displayLimits.test';
 import { runSshAgentParsingTests } from './sshAgentParsing.test';
 import { runSyncCheckerTests } from './syncChecker.test';
+import { runErrorTests } from './errors.test';
 
 async function main(): Promise<void> {
   console.log('╔════════════════════════════════════════════╗');
@@ -110,6 +111,9 @@ async function main(): Promise<void> {
 
     // Run sync checker tests (profile vs git config comparison)
     await runSyncCheckerTests();
+
+    // Run error classes and validation types tests
+    await runErrorTests();
 
     console.log('╔════════════════════════════════════════════╗');
     console.log('║   🎉 All Security Tests Passed!            ║');


### PR DESCRIPTION
## Summary

- Extract `FieldValidationError`, `UnifiedValidationResult`, and `toFieldError()` from `errors.ts` (382 lines) into `validation-types.ts` (81 lines)
- Add `@deprecated` re-exports in `errors.ts` for backward compatibility
- Register `errors.test.ts` in test runner (was previously unregistered)

## Details

`errors.ts` exceeded the 300-line threshold due to Phase 4 Unified Validation Types coexisting with SecurityError classes. This change separates concerns:

| File | Before | After |
|------|--------|-------|
| `errors.ts` | 401 lines | 328 lines |
| `validation-types.ts` | — | 81 lines (new) |

The re-exports in `errors.ts` are marked `@deprecated` to guide consumers toward the canonical import path (`./validation-types`).

**Bonus fix**: `errors.test.ts` was not registered in any test runner, meaning its tests (SecurityError + toFieldError) never ran as part of the test suite. This was hidden because `errors.ts` was excluded from c8 coverage. Now registered in `runTests.ts`.

## Verification

- TypeScript compile: pass
- ESLint: 0 errors (changed files)
- All tests: pass
- Coverage: `validation-types.ts` 100% (Stmts/Branch/Funcs/Lines)

## Quality review

4-agent review (architect + security + test engineer + sergeant). One in-scope finding (`@deprecated` design contradiction) was fixed and re-reviewed. Out-of-scope findings tracked as Issue-00115, Issue-00116.