### PR TITLE
fix(ui): escape Markdown special characters in tooltip user values

### DIFF
--- a/extensions/git-id-switcher/src/test/e2e/statusBar.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/statusBar.test.ts
@@ -11,7 +11,7 @@
  * - State Sequences: Realistic usage patterns (e.g., Identity → Loading → Identity)
  * - Resource Management: dispose behavior
  *
- * Test Count: 17 tests covering identityStatusBar.ts functionality
+ * Test Count: 18 tests covering identityStatusBar.ts functionality
  * PRD Requirement: Minimum 8 tests ✓
  *
  * E2E Test Limitations:
@@ -502,6 +502,21 @@ describe('StatusBar E2E Test Suite', function () {
       ]);
 
       assert.ok(tooltip.includes('signingKey'), 'Should contain signingKey field');
+    });
+
+    it('should escape pipe characters in mismatch values', () => {
+      const tooltip = buildMismatchTooltip([
+        { field: 'name', expected: 'Org | Team', actual: 'Other | Group' },
+      ]);
+
+      assert.ok(
+        tooltip.includes(String.raw`Org \| Team`),
+        'Should escape pipe in expected value'
+      );
+      assert.ok(
+        tooltip.includes(String.raw`Other \| Group`),
+        'Should escape pipe in actual value'
+      );
     });
   });
 

--- a/extensions/git-id-switcher/src/test/markdownEscape.test.ts
+++ b/extensions/git-id-switcher/src/test/markdownEscape.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for Markdown escape functions in markdownEscape.ts
+ *
+ * Covers escapeMarkdownInline pure function.
+ */
+
+import * as assert from 'node:assert';
+import { escapeMarkdownInline } from '../ui/markdownEscape';
+
+function testEscapeMarkdownInline(): void {
+  console.log('  escapeMarkdownInline');
+
+  // Asterisks (bold/italic)
+  assert.strictEqual(
+    escapeMarkdownInline('**bold**'),
+    String.raw`\*\*bold\*\*`,
+    'Should escape asterisks'
+  );
+
+  // Underscores (italic)
+  assert.strictEqual(
+    escapeMarkdownInline('_italic_'),
+    String.raw`\_italic\_`,
+    'Should escape underscores'
+  );
+
+  // Backticks (code)
+  assert.strictEqual(
+    escapeMarkdownInline('`code`'),
+    String.raw`\`code\``,
+    'Should escape backticks'
+  );
+
+  // Square brackets (links)
+  assert.strictEqual(
+    escapeMarkdownInline('[link](url)'),
+    String.raw`\[link\](url)`,
+    'Should escape square brackets'
+  );
+
+  // Angle brackets (HTML)
+  assert.strictEqual(
+    escapeMarkdownInline('<script>'),
+    '&lt;script&gt;',
+    'Should escape angle brackets to HTML entities'
+  );
+
+  // Pipe character
+  assert.strictEqual(
+    escapeMarkdownInline('a|b'),
+    String.raw`a\|b`,
+    'Should escape pipe character'
+  );
+
+  // Backslash itself
+  assert.strictEqual(
+    escapeMarkdownInline(String.raw`a\b`),
+    String.raw`a\\b`,
+    'Should escape backslash'
+  );
+
+  // Combined special characters
+  assert.strictEqual(
+    escapeMarkdownInline('*user|name*'),
+    String.raw`\*user\|name\*`,
+    'Should escape multiple special chars together'
+  );
+
+  // Plain text — pass through unchanged
+  assert.strictEqual(
+    escapeMarkdownInline('John Doe'),
+    'John Doe',
+    'Should leave plain text unchanged'
+  );
+
+  // Empty string
+  assert.strictEqual(
+    escapeMarkdownInline(''),
+    '',
+    'Should handle empty string'
+  );
+
+  // Realistic git user.name with pipe
+  assert.strictEqual(
+    escapeMarkdownInline('Org | Team'),
+    String.raw`Org \| Team`,
+    'Should escape pipe in realistic user name'
+  );
+
+  // Newline characters are replaced with space
+  assert.strictEqual(
+    escapeMarkdownInline('line1\nline2'),
+    'line1 line2',
+    'Should replace LF with space'
+  );
+
+  // Carriage return is stripped
+  assert.strictEqual(
+    escapeMarkdownInline('line1\r\nline2'),
+    'line1 line2',
+    'Should strip CR and replace LF with space'
+  );
+
+  // Carriage return only
+  assert.strictEqual(
+    escapeMarkdownInline('line1\rline2'),
+    'line1line2',
+    'Should strip standalone CR'
+  );
+
+  // Backslash before pipe (realistic edge case)
+  assert.strictEqual(
+    escapeMarkdownInline(String.raw`a\|b`),
+    String.raw`a\\\|b`,
+    'Should escape both backslash and pipe independently'
+  );
+
+  console.log('    ✅ All escapeMarkdownInline tests passed');
+}
+
+export function runMarkdownEscapeTests(): void {
+  console.log('\n=== Markdown Escape Tests ===\n');
+
+  try {
+    testEscapeMarkdownInline();
+
+    console.log('\n  All markdown escape tests passed!\n');
+  } catch (error) {
+    console.error('\n  Test failed:', error);
+    process.exit(1);
+  }
+}
+
+// Run tests when executed directly
+if (require.main === module) {
+  runMarkdownEscapeTests();
+}

--- a/extensions/git-id-switcher/src/test/runTests.ts
+++ b/extensions/git-id-switcher/src/test/runTests.ts
@@ -32,6 +32,7 @@ import { runSyncCheckerTests } from './syncChecker.test';
 import { runErrorTests } from './errors.test';
 import { runGetSafeStackTests } from './getSafeStack.test';
 import { runHtmlTemplatesTests } from './htmlTemplates.test';
+import { runMarkdownEscapeTests } from './markdownEscape.test';
 
 async function main(): Promise<void> {
   console.log('╔════════════════════════════════════════════╗');
@@ -122,6 +123,9 @@ async function main(): Promise<void> {
 
     // Run HTML template tests (pure functions, no VS Code dependency)
     runHtmlTemplatesTests();
+
+    // Run Markdown escape tests (pure functions, no VS Code dependency)
+    runMarkdownEscapeTests();
 
     console.log('╔════════════════════════════════════════════╗');
     console.log('║   🎉 All Security Tests Passed!            ║');

--- a/extensions/git-id-switcher/src/ui/identityStatusBar.ts
+++ b/extensions/git-id-switcher/src/ui/identityStatusBar.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { Identity, getIdentityLabel } from '../identity/identity';
 import type { SyncCheckResult, SyncMismatch } from '../core/syncChecker';
 import { truncateForStatusBar } from './displayLimits';
+import { escapeMarkdownInline } from './markdownEscape';
 
 /**
  * Status bar item wrapper
@@ -153,28 +154,28 @@ export class IdentityStatusBar implements vscode.Disposable {
    */
   private buildTooltip(identity: Identity): string {
     const lines = [
-      `### ${getIdentityLabel(identity)}`,
+      `### ${escapeMarkdownInline(getIdentityLabel(identity))}`,
       '',
     ];
 
     // Add description if available
     if (identity.description) {
-      lines.push(`**${identity.description}**`, '');
+      lines.push(`**${escapeMarkdownInline(identity.description)}**`, '');
     }
 
     // Identity details
-    lines.push('---', '', '- ' + vscode.l10n.t('**Email:** {0}', identity.email));
+    lines.push('---', '', '- ' + vscode.l10n.t('**Email:** {0}', escapeMarkdownInline(identity.email)));
 
     if (identity.sshHost) {
-      lines.push('- ' + vscode.l10n.t('**SSH Host:** {0}', identity.sshHost));
+      lines.push('- ' + vscode.l10n.t('**SSH Host:** {0}', escapeMarkdownInline(identity.sshHost)));
     }
 
     if (identity.sshKeyPath) {
-      lines.push('- ' + vscode.l10n.t('**SSH Key:** {0}', maskSshKeyPath(identity.sshKeyPath)));
+      lines.push('- ' + vscode.l10n.t('**SSH Key:** {0}', escapeMarkdownInline(maskSshKeyPath(identity.sshKeyPath))));
     }
 
     if (identity.gpgKeyId) {
-      lines.push('- ' + vscode.l10n.t('**GPG Key:** {0}', maskGpgKeyId(identity.gpgKeyId)));
+      lines.push('- ' + vscode.l10n.t('**GPG Key:** {0}', escapeMarkdownInline(maskGpgKeyId(identity.gpgKeyId))));
     }
 
     lines.push('', '---', '', vscode.l10n.t('*Click to switch identity*'));
@@ -241,7 +242,7 @@ export function buildMismatchTooltip(mismatches: readonly SyncMismatch[]): strin
 
   for (const mismatch of mismatches) {
     lines.push(
-      `| ${FIELD_LABELS[mismatch.field]} | ${mismatch.expected} | ${mismatch.actual} |`
+      `| ${FIELD_LABELS[mismatch.field]} | ${escapeMarkdownInline(mismatch.expected)} | ${escapeMarkdownInline(mismatch.actual)} |`
     );
   }
 

--- a/extensions/git-id-switcher/src/ui/markdownEscape.ts
+++ b/extensions/git-id-switcher/src/ui/markdownEscape.ts
@@ -1,0 +1,25 @@
+/**
+ * Markdown escape utilities for tooltip rendering.
+ *
+ * Pure functions with no VS Code dependency — safe for unit testing.
+ */
+
+/**
+ * Escape Markdown special characters in user-supplied text.
+ * Prevents accidental formatting when values contain *, _, `, etc.
+ * Also escapes pipe characters for safe use inside Markdown table cells,
+ * and strips newline characters to prevent Markdown structure injection.
+ */
+export function escapeMarkdownInline(value: string): string {
+  return value.replaceAll('\\', String.raw`\\`)
+    .replaceAll('*', String.raw`\*`)
+    .replaceAll('_', String.raw`\_`)
+    .replaceAll('`', String.raw`\``)
+    .replaceAll('[', String.raw`\[`)
+    .replaceAll(']', String.raw`\]`)
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('|', String.raw`\|`)
+    .replaceAll('\n', ' ')
+    .replaceAll('\r', '');
+}


### PR DESCRIPTION
## Summary

- Add `escapeMarkdownInline()` pure function in `markdownEscape.ts` to escape Markdown special characters (`\`, `*`, `_`, `` ` ``, `[`, `]`, `<`, `>`, `|`) and sanitize newlines (`\n` → space, `\r` → removed)
- Apply to all user-supplied values in `buildTooltip()` (identity name, description, email, SSH host, SSH key, GPG key) and `buildMismatchTooltip()` (expected/actual mismatch values)
- Add 15 unit tests covering each character class, edge cases (empty string, combined chars, backslash+pipe), and newline handling
- Add 1 E2E test verifying pipe escape in mismatch tooltip table

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] ESLint passes (0 errors)
- [x] Unit tests pass (`npm run test`)
- [x] Coverage maintained at 100% (`markdownEscape.ts`: 100% all metrics)
- [x] Mechanical validation script passes
- [ ] E2E tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)