### PR TITLE
docs: add GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,68 @@
+# Governance
+
+## The Gardener
+
+This garden has one gardener: **Null;Variant**.
+
+All design decisions, feature direction, release timing, and quality standards
+are determined by the gardener alone. There is no committee, no vote, no
+consensus process. The gardener places every stone.
+
+## The Sekimori-ishi
+
+A [sekimori-ishi](https://en.wikipedia.org/wiki/Sekimori-ishi) is a small
+stone tied with rope, placed on a garden path. It carries no force — yet
+everyone who understands the garden knows: _do not pass beyond this stone._
+
+This garden is protected by several such boundaries:
+
+| Name                     | What it guards                                             |
+| ------------------------ | ---------------------------------------------------------- |
+| **CI / Build Check**     | No broken stone enters the garden                          |
+| **Branch Protection**    | The main path cannot be altered without a gate review      |
+| **Signed Commits**       | Every placed stone bears the mason's mark                  |
+| **Automated Publishing** | When a release tag is placed, the garden opens its gate    |
+| **AI Review Agents**     | Tireless apprentices that rake sand patterns day and night |
+
+The AI review agents deserve special mention. They are not gardeners — they
+cannot place stones or choose where paths lead. They are **apprentices bound by
+[AGENTS.md](AGENTS.md)**: they check sand patterns (lint, types, coverage),
+verify stone placement (code review), and report to the gardener. The gardener
+makes the final call.
+
+> _Six apprentices live in the gardener's head. They have been taught to rake,_
+> _but not to dream._
+
+## Decision Process
+
+1. The gardener decides what to build
+2. The apprentices verify it was built correctly
+3. The gardener approves and merges
+
+For external contributions:
+
+1. Open an issue or pull request
+2. The apprentices will review mechanically
+3. The gardener will review aesthetically
+4. The gardener merges, or explains why the stone does not belong
+
+## Quality Standard
+
+This garden follows the principle in our [Code of Conduct](CODE_OF_CONDUCT.md):
+
+> _"If it works, it's fine"_ is not welcome here.
+
+Code must be correct, secure, tested, and — yes — beautiful.
+
+## Bus Factor
+
+The bus factor is 1. This is a personal garden, not a public park.
+
+The garden is open source (MIT License), so anyone may fork it and start their
+own. But this particular arrangement of stones reflects one person's vision,
+and that is by design.
+
+## Contact
+
+To reach the gardener: open an issue on this repository, or see
+[SECURITY.md](SECURITY.md) for security-related matters.

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -59,6 +59,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'extensions/git-id-switcher/docs/THREAT_MODEL.md': '1947cc3c940b872641a8f291bc7ad52eac02df1e91f8b91f67588149bc6fa6f7',
   'extensions/git-id-switcher/LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
   'extensions/git-id-switcher/README.md': 'c70e13824ea64644d064dda6dbafa8d9a3d959c63f1671e98fb250c4b91dedf0',
+  'GOVERNANCE.md': 'a4a8ee6f97fb5ccbbbf310defd745e9bb38f1637336dba10eda87d0a65be5bf5',
   'LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
   'README.md': '0ef369d8edab407d769f764342e898cebb2d17feb558169093d56dfd1989228a',
   'SECURITY.md': 'b5df8a04b199315ccc25ff1421641411357de7ed3c2ec58d18b29edc45614550',


### PR DESCRIPTION
## Summary

- Add GOVERNANCE.md documenting the project's governance model
- Extends the karesansui (dry landscape garden) metaphor from CODE_OF_CONDUCT.md
- Documents: decision authority (single maintainer), sekimori-ishi (boundary mechanisms like CI, branch protection, signed commits), AI review agents (bound by AGENTS.md), bus factor transparency
- Supports OpenSSF Best Practices Silver badge criteria (Governance item)

## Test plan

- [ ] Verify all internal links resolve (AGENTS.md, CODE_OF_CONDUCT.md, SECURITY.md)
- [ ] Verify Wikipedia link for sekimori-ishi is valid
- [ ] Confirm markdown renders correctly on GitHub