### PR TITLE
test: add branch coverage tests

### DIFF
--- a/extensions/git-id-switcher/src/test/configChangeDetector.test.ts
+++ b/extensions/git-id-switcher/src/test/configChangeDetector.test.ts
@@ -1135,6 +1135,16 @@ function testValuesEqualTypeMismatchAndNull(): void {
   const changes2b = detector.detectChanges(createTestSnapshot({ defaultIdentity: 'test' }));
   assert.strictEqual(changes2b.length, 1, 'null vs non-null should be detected as change');
 
+  // Test 2c: object vs null - both typeof "object", tests b === null branch at line 135
+  setDetectorSnapshot(detector, createTestSnapshot({ commandTimeouts: { git: 5000 } }));
+  const objectVsNullSnapshot = {
+    ...createTestSnapshot(),
+    commandTimeouts: null as unknown as Record<string, number>,
+  };
+  const changes2c = detector.detectChanges(objectVsNullSnapshot);
+  const timeoutChanges = changes2c.filter(c => c.key === 'commandTimeouts');
+  assert.strictEqual(timeoutChanges.length, 1, 'object vs null (both typeof "object") should be detected as change');
+
   // Test 3: null vs null (both null should be equal)
   setDetectorSnapshot(detector, {
     ...createTestSnapshot(),

--- a/extensions/git-id-switcher/src/test/securityLogger.test.ts
+++ b/extensions/git-id-switcher/src/test/securityLogger.test.ts
@@ -1419,6 +1419,76 @@ function testSanitizeConfigValueIdentities(): void {
 }
 
 /**
+ * Test buildIdentityChangeDetails with non-array newValue
+ *
+ * Coverage target: securityLogger.ts line 518
+ * When newValue is not an array, buildIdentityChangeDetails should use [] fallback.
+ */
+function testBuildIdentityChangeDetailsNonArrayNewValue(): void {
+  console.log('Testing buildIdentityChangeDetails with non-array newValue...');
+
+  const capture = new ConsoleCapture();
+  _resetCache();
+  securityLogger.initialize();
+
+  capture.start();
+  securityLogger.logConfigChanges([
+    {
+      key: 'identities',
+      previousValue: [{ id: 'old', name: 'Old' }],
+      newValue: 'not-an-array', // non-array triggers [] fallback
+    },
+  ]);
+  capture.stop();
+
+  const output = capture.getOutput();
+  const logLine = output.find(line => line.includes('CONFIG_CHANGE'));
+  assert.ok(logLine, 'Should produce CONFIG_CHANGE log');
+  assert.ok(logLine?.includes('identities'), 'Should include identities key');
+  // Non-array newValue is treated as [] by buildIdentityChangeDetails,
+  // so all previous identities are detected as "removed"
+  assert.ok(logLine?.includes('removed'), 'Should include removed identities when newValue is non-array');
+
+  console.log('✅ buildIdentityChangeDetails non-array newValue passed!');
+}
+
+/**
+ * Test buildIdentityChangeDetails with removal-only changes (no additions)
+ *
+ * Coverage target: securityLogger.ts line 524
+ * When s.added.length === 0, the ternary returns undefined.
+ */
+function testBuildIdentityChangeDetailsRemovalOnly(): void {
+  console.log('Testing buildIdentityChangeDetails with removal-only changes...');
+
+  const capture = new ConsoleCapture();
+  _resetCache();
+  securityLogger.initialize();
+
+  capture.start();
+  securityLogger.logConfigChanges([
+    {
+      key: 'identities',
+      previousValue: [
+        { id: 'removed1', name: 'Removed1' },
+        { id: 'removed2', name: 'Removed2' },
+      ],
+      newValue: [], // all removed, nothing added
+    },
+  ]);
+  capture.stop();
+
+  const output = capture.getOutput();
+  const logLine = output.find(line => line.includes('CONFIG_CHANGE'));
+  assert.ok(logLine, 'Should produce CONFIG_CHANGE log');
+  assert.ok(logLine?.includes('identities'), 'Should include identities key');
+  // With empty newValue, removed identities should be present
+  assert.ok(logLine?.includes('removed'), 'Should include removed identities');
+
+  console.log('✅ buildIdentityChangeDetails removal-only passed!');
+}
+
+/**
  * Test validateLogConfigRange() for log file setting validation
  */
 function testValidateLogConfigRange(): void {
@@ -1746,6 +1816,8 @@ export async function runSecurityLoggerTests(): Promise<void> {
     testWriteToOutputChannelJsonError();
     testSanitizeConfigValueIdentitiesNonArray();
     testSanitizeConfigValueIdentities();
+    testBuildIdentityChangeDetailsNonArrayNewValue();
+    testBuildIdentityChangeDetailsRemovalOnly();
     testValidateLogConfigRange();
     testLogConfigConstants();
     testRateLimitConstants();


### PR DESCRIPTION
## Summary

- Add tests for previously untested branches (test files only, no source changes)
- securityLogger: non-array newValue in buildIdentityChangeDetails, removal-only identity changes
- configChangeDetector: object vs null comparison where both are typeof "object" (covers `b === null` branch at line 135)

## Test plan

- [x] All unit tests pass (`npm run test`)
- [x] Coverage unchanged from main (test-only changes)