### PR TITLE
refactor(ui): derive AddFormState from Identity and remove GenericQuickPick

### DIFF
--- a/extensions/git-id-switcher/src/ui/identityAddForm.ts
+++ b/extensions/git-id-switcher/src/ui/identityAddForm.ts
@@ -7,6 +7,7 @@
  * @module ui/identityAddForm
  */
 
+import type { QuickPick } from 'vscode';
 import { getVSCode } from '../core/vscodeLoader';
 import {
   type Identity,
@@ -16,7 +17,6 @@ import {
 import { MAX_IDENTITIES } from '../core/constants';
 import {
   type VSCodeAPI,
-  type GenericQuickPick,
   type QuickInputResult,
   getPlaceholderForField,
   getInputBoxPrompt,
@@ -33,19 +33,16 @@ import {
 // Type Definitions
 // ============================================================================
 
-/** State for add identity form */
-interface AddFormState {
-  [key: string]: string | undefined;
+/**
+ * State for add identity form — derived from Identity to maintain SSOT.
+ * All fields are string-typed (user input). Required fields are always present,
+ * optional fields may be undefined.
+ */
+type AddFormState = Partial<Record<keyof Identity, string>> & {
   id: string;
   name: string;
   email: string;
-  service?: string;
-  icon?: string;
-  description?: string;
-  sshKeyPath?: string;
-  sshHost?: string;
-  gpgKeyId?: string;
-}
+};
 
 /** QuickPick item for add form field */
 interface AddFormQuickPickItem {
@@ -58,7 +55,7 @@ interface AddFormQuickPickItem {
 }
 
 /** QuickPick type for add form */
-type AddFormQuickPick = GenericQuickPick<AddFormQuickPickItem>;
+type AddFormQuickPick = QuickPick<AddFormQuickPickItem>;
 
 // ============================================================================
 // Form State Helpers
@@ -119,7 +116,7 @@ function buildAddFormItems(
   const items: AddFormQuickPickItem[] = [];
 
   for (const meta of FIELD_METADATA) {
-    const value = state[meta.key as keyof AddFormState];
+    const value = state[meta.key];
     const hasValue = value !== undefined && value.trim() !== '';
     const requiredMark = meta.required ? '*' : '';
     const displayValue = hasValue

--- a/extensions/git-id-switcher/src/ui/identityFormUtils.ts
+++ b/extensions/git-id-switcher/src/ui/identityFormUtils.ts
@@ -7,6 +7,7 @@
  * @module ui/identityFormUtils
  */
 
+import type { QuickPick, QuickPickItem } from 'vscode';
 import { getVSCode } from '../core/vscodeLoader';
 import {
   type Identity,
@@ -34,10 +35,6 @@ export interface FieldQuickPickItem {
   readonly _isDisabled?: boolean;
 }
 
-/** Generic QuickPick type */
-export type GenericQuickPick<T> = ReturnType<VSCodeAPI['window']['createQuickPick']> & {
-  readonly selectedItems: readonly T[];
-};
 
 /** InputBox type */
 export type GenericInputBox = ReturnType<VSCodeAPI['window']['createInputBox']>;
@@ -284,9 +281,9 @@ function createDisposableCleanup(): {
  * @param quickPick - The QuickPick instance
  * @returns Selected item, 'back' if back pressed, undefined if cancelled
  */
-export function waitForQuickPickSelection<T>(
+export function waitForQuickPickSelection<T extends QuickPickItem>(
   vs: VSCodeAPI,
-  quickPick: GenericQuickPick<T>
+  quickPick: QuickPick<T>
 ): Promise<T | 'back' | undefined> {
   return new Promise(resolve => {
     const { cleanup } = createDisposableCleanup();
@@ -294,7 +291,7 @@ export function waitForQuickPickSelection<T>(
     const disposables: { dispose(): void }[] = [
       quickPick.onDidAccept(() => {
         cleanup(disposables);
-        resolve(quickPick.selectedItems[0] as T | undefined);
+        resolve(quickPick.selectedItems[0]);
       }),
       quickPick.onDidTriggerButton(button => {
         if (button === vs.QuickInputButtons.Back) {


### PR DESCRIPTION
## Summary

- Derive `AddFormState` from `Identity` type using `Partial<Record<keyof Identity, string>>` to maintain SSOT — eliminates manual field enumeration that could drift out of sync when `Identity` gains new fields
- Remove `GenericQuickPick<T>` intersection type wrapper, use VS Code's native `QuickPick<T>` type parameter directly
- Remove unsafe `as T` cast in `waitForQuickPickSelection` — `QuickPick<T>.selectedItems[0]` now infers correctly via generic constraint `T extends QuickPickItem`
- Remove unnecessary `as keyof AddFormState` cast that became redundant after index signature removal

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] ESLint passes (0 errors)
- [x] All tests pass (114 tests)
- [x] Statement coverage remains at 100%
- [x] Quality review passed (architect, security, test engineer, sergeant)
- [x] ARCHITECTURE.md compliance verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)