### PR TITLE
feat(security): add Allstar policy configuration

### DIFF
--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,0 +1,14 @@
+# Allstar repository-level configuration
+# https://github.com/ossf/allstar
+
+optConfig:
+  # Enable Allstar for this repository
+  optIn: true
+
+# Issue management
+issueLabel: allstar
+issueRepo: ""
+
+# Schedule: check once daily to avoid noise
+schedule:
+  interval: daily

--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,7 @@
+# Binary Artifacts policy
+# Detects checked-in binary files that should not be in the repository
+
+optConfig:
+  optIn: true
+
+action: issue

--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,15 @@
+# Branch Protection policy
+# Ensures main branch has proper protection rules
+
+optConfig:
+  optIn: true
+
+action: issue
+
+enforceDefault: true
+
+requireApproval: true
+approvalCount: 1
+
+dismissStale: true
+blockForce: true

--- a/.allstar/dangerous_workflow.yaml
+++ b/.allstar/dangerous_workflow.yaml
@@ -1,0 +1,8 @@
+# Dangerous Workflow policy
+# Flags GitHub Actions patterns that may be security risks
+# (e.g., pull_request_target with explicit checkout of PR head)
+
+optConfig:
+  optIn: true
+
+action: issue

--- a/.allstar/outside.yaml
+++ b/.allstar/outside.yaml
@@ -1,0 +1,9 @@
+# Outside Collaborators policy
+# Monitors external collaborators with elevated access
+
+optConfig:
+  optIn: true
+
+action: issue
+
+pushAdminOnly: true

--- a/.allstar/security.yaml
+++ b/.allstar/security.yaml
@@ -1,0 +1,7 @@
+# Security policy
+# Ensures SECURITY.md exists in the repository
+
+optConfig:
+  optIn: true
+
+action: issue


### PR DESCRIPTION
## Summary

- Enable [OpenSSF Allstar](https://github.com/ossf/allstar) GitHub App with repository-level configuration
- 5 policies enabled (all with `issue` action):
  - **Branch protection**: require approval, dismiss stale reviews, block force push
  - **Binary artifacts**: detect checked-in binaries
  - **SECURITY.md**: ensure security policy exists
  - **Outside collaborators**: monitor external access with admin-only push
  - **Dangerous workflows**: flag risky GitHub Actions patterns

## Context

Part of OpenSSF Best Practices Silver criteria compliance. Scorecard badge is already in place; this adds Allstar as an additional policy enforcement layer.

## Test plan

- [ ] Verify Allstar GitHub App is installed on this repository
- [ ] Confirm Allstar picks up `.allstar/` configuration
- [ ] Check no false-positive issues are created for existing compliant settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)