### PR TITLE
chore(security): add Snyk policy to exclude test false positives

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+exclude:
+  global:
+    # Test fixtures intentionally contain secret-like patterns
+    # for testing sensitiveDataDetector and related security utilities.
+    # These are synthetic values (e.g., 'AbCdEfGh12345678...'), not real secrets.
+    - extensions/git-id-switcher/src/test

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,6 +65,7 @@ This repository contains VS Code extensions with the following security measures
 - **Static Code Analysis**: [SonarCloud](https://sonarcloud.io/project/overview?id=nullvariant_nullvariant-vscode-extensions) runs on every push and PR (CI-based analysis)
 - **Daily Vulnerability Scans**: `npm audit` runs daily via scheduled workflow
 - **Fork Protection**: Sensitive workflows skip on fork repositories
+- **SAST (Snyk Code)**: [Snyk](https://snyk.io/) runs static analysis; test fixtures are excluded via `.snyk` policy
 - **Runtime Security Monitoring**: [StepSecurity Harden-Runner](https://github.com/step-security/harden-runner) monitors all workflow runs for suspicious network egress, file access, and process execution
 
 ## Security Testing

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -62,7 +62,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'GOVERNANCE.md': '806cf32ec9fe9fd964a782927f8eaa7696d408c42d31f554eebd6755bd911c71',
   'LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
   'README.md': '89a6fc159f160a2b8fb96279deb3c2af558bd61341f4d9c99ff6a5d7b58c4253',
-  'SECURITY.md': '4dcd8884851a057738d9c6f58e9017f0dc8edc91fd4921a491bf66f3b2fe5e0f',
+  'SECURITY.md': 'f0a9554c55bbf84187bb0d10afaf2591ebf0ffef70e73d212e9ba0d9a4b2bb6e',
 };
 
 /** Supported locales for documentation */


### PR DESCRIPTION
## Summary

- Add `.snyk` policy file to exclude `extensions/git-id-switcher/src/test` from Snyk Code analysis. Test fixtures for `sensitiveDataDetector` intentionally contain secret-like patterns (CWE-547), triggering 11 false positives.
- Document Snyk Code in the CI/CD Security section of `SECURITY.md`, which was missing despite Snyk being actively used.

## Test plan

- [ ] Verify Snyk Code re-scan shows 0 issues after merge
- [ ] Confirm `SECURITY.md` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)