### PR TITLE
fix: normalize repository.url in npm placeholder package

### DIFF
--- a/packages/git-id-switcher-npm/package.json
+++ b/packages/git-id-switcher-npm/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://marketplace.visualstudio.com/items?itemName=nullvariant.git-id-switcher",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nullvariant/nullvariant-vscode-extensions.git",
+    "url": "git+https://github.com/nullvariant/nullvariant-vscode-extensions.git",
     "directory": "packages/git-id-switcher-npm"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- Add `git+` prefix to `repository.url` to match npm registry convention
- Suppresses `npm publish` warning about URL normalization

## Test plan

- [x] `npm pkg fix` no longer reports warnings for this field