### PR TITLE
docs: add FOSSA integration to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,7 @@ This repository contains VS Code extensions with the following security measures
 - **Daily Vulnerability Scans**: `npm audit` runs daily via scheduled workflow
 - **Fork Protection**: Sensitive workflows skip on fork repositories
 - **SAST (Snyk Code)**: [Snyk](https://snyk.io/) runs static analysis; test fixtures are excluded via `.snyk` policy
+- **License & Vulnerability Scanning**: [FOSSA](https://app.fossa.com/) runs license compliance, dependency quality, and security analysis on every commit (GitHub App integration)
 - **Runtime Security Monitoring**: [StepSecurity Harden-Runner](https://github.com/step-security/harden-runner) monitors all workflow runs for suspicious network egress, file access, and process execution
 
 ## Security Testing
@@ -94,6 +95,7 @@ This section documents all secrets used in CI/CD workflows.
 | VSCE_PAT              | VS Code Marketplace publishing         | publish.yml, unpublish.yml   | Annual    | High            |
 | OVSX_PAT              | Open VSX publishing                    | publish.yml, unpublish.yml   | Annual    | High            |
 | SONAR_TOKEN           | SonarCloud code analysis               | sonarcloud.yml               | As needed | Medium          |
+| FOSSA_API_KEY         | FOSSA license/vulnerability scanning   | (API access only)            | As needed | Medium          |
 | CLOUDFLARE_API_TOKEN  | Cloudflare Pages/R2 deployment         | deploy-docs.yml, publish.yml | Annual    | High            |
 | CLOUDFLARE_ACCOUNT_ID | Cloudflare account identifier (public) | deploy-docs.yml, publish.yml | Never     | Low (public ID) |
 | SLACK_WEBHOOK         | Bot monitoring alerts                  | bot-monitoring.yml           | As needed | Medium          |
@@ -141,6 +143,7 @@ Marketplace publishing secrets (VSCE_PAT, OVSX_PAT) are protected by the `produc
 | OVSX_PAT             | Open VSX     | [Open VSX Tokens](https://open-vsx.org/user-settings/tokens)                   | No expiration |
 | CLOUDFLARE_API_TOKEN | Cloudflare   | [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens)        | No expiration |
 | SONAR_TOKEN          | SonarCloud   | [SonarCloud Security](https://sonarcloud.io/account/security)                  | No expiration |
+| FOSSA_API_KEY        | FOSSA        | [FOSSA Settings](https://app.fossa.com/account/settings/integrations)          | No expiration |
 | GitHub App Keys      | GitHub       | [GitHub Apps](https://github.com/settings/apps)                                | No expiration |
 | SLACK_WEBHOOK        | Slack        | [Slack Apps](https://api.slack.com/apps)                                       | No expiration |
 

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -62,7 +62,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'GOVERNANCE.md': '806cf32ec9fe9fd964a782927f8eaa7696d408c42d31f554eebd6755bd911c71',
   'LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
   'README.md': '2597f0c6fca10b28cacc27696d4753f4d32a5abbb6339615da6144ce269d47bc',
-  'SECURITY.md': 'f0a9554c55bbf84187bb0d10afaf2591ebf0ffef70e73d212e9ba0d9a4b2bb6e',
+  'SECURITY.md': 'bbae0e2a679851ea0ede598102c7d809aea11b7bab99ddf6a20f4dde31070c23',
 };
 
 /** Supported locales for documentation */


### PR DESCRIPTION
## Summary

- Add FOSSA license/vulnerability scanning to CI/CD Security section
- Add FOSSA_API_KEY (Service Account, Editor role) to Secrets Management and Provider Links tables

## Context

FOSSA GitHub App integration was set up in Issue-00123 Phase 2. This PR documents the integration and API key in SECURITY.md for operational visibility.

## Test plan

- [ ] Verify SECURITY.md renders correctly on GitHub
- [ ] Verify FOSSA_API_KEY is registered in GitHub Secrets