### PR TITLE
docs(readme): add FOSSA License and Security badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/nullvariant/nullvariant-vscode-extensions/badge.svg)](https://snyk.io/test/github/nullvariant/nullvariant-vscode-extensions)
 [![GitGuardian](https://img.shields.io/badge/GitGuardian-monitored-7042F5?logo=gitguardian)](https://www.gitguardian.com/)
 [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen?logo=renovatebot)](https://renovatebot.com)
+[![FOSSA License](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions?ref=badge_shield&issueType=license)
+[![FOSSA Security](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions?ref=badge_shield&issueType=security)
 [![codecov](https://codecov.io/gh/nullvariant/nullvariant-vscode-extensions/graph/badge.svg)](https://codecov.io/gh/nullvariant/nullvariant-vscode-extensions)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=nullvariant_nullvariant-vscode-extensions&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=nullvariant_nullvariant-vscode-extensions)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=nullvariant_nullvariant-vscode-extensions&metric=bugs)](https://sonarcloud.io/summary/new_code?id=nullvariant_nullvariant-vscode-extensions)

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -61,7 +61,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'extensions/git-id-switcher/README.md': '7993a7d57e06a77bfc6064587b4726c48b0a30f58df16acc0274747215996ace',
   'GOVERNANCE.md': '806cf32ec9fe9fd964a782927f8eaa7696d408c42d31f554eebd6755bd911c71',
   'LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
-  'README.md': '2597f0c6fca10b28cacc27696d4753f4d32a5abbb6339615da6144ce269d47bc',
+  'README.md': 'adb04aec2f7a82e01c4e6130f4f95b88a3129ffc878d5234d1218774b73e8b46',
   'SECURITY.md': 'bbae0e2a679851ea0ede598102c7d809aea11b7bab99ddf6a20f4dde31070c23',
 };
 


### PR DESCRIPTION
## Summary
- Add FOSSA License compliance badge
- Add FOSSA Security analysis badge
- Placed in License/Compliance group (after Renovate, before codecov)

FOSSA integration was completed in Phase 2 — both license scan and security scan are passing.

## Test plan
- [ ] FOSSA License badge renders and links to correct dashboard
- [ ] FOSSA Security badge renders and links to correct dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)