### PR TITLE
docs(readme): add Socket.dev static badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11709/badge)](https://www.bestpractices.dev/projects/11709)
 [![Harden-Runner](https://img.shields.io/badge/Harden--Runner-enabled-7037F5)](https://github.com/step-security/harden-runner)
 [![Known Vulnerabilities](https://snyk.io/test/github/nullvariant/nullvariant-vscode-extensions/badge.svg)](https://snyk.io/test/github/nullvariant/nullvariant-vscode-extensions)
+[![Socket.dev](https://img.shields.io/badge/Socket.dev-monitored-7042F5)](https://socket.dev/gh/nullvariant/nullvariant-vscode-extensions)
 [![GitGuardian](https://img.shields.io/badge/GitGuardian-monitored-7042F5?logo=gitguardian)](https://www.gitguardian.com/)
 [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen?logo=renovatebot)](https://renovatebot.com)
 [![FOSSA License](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions?ref=badge_shield&issueType=license)

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -61,7 +61,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'extensions/git-id-switcher/README.md': '7993a7d57e06a77bfc6064587b4726c48b0a30f58df16acc0274747215996ace',
   'GOVERNANCE.md': '806cf32ec9fe9fd964a782927f8eaa7696d408c42d31f554eebd6755bd911c71',
   'LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
-  'README.md': 'adb04aec2f7a82e01c4e6130f4f95b88a3129ffc878d5234d1218774b73e8b46',
+  'README.md': 'b9bdc53e3a535de8f59103be2bdcb06cf73b9b2579c9301fcc232caa244423f6',
   'SECURITY.md': 'bbae0e2a679851ea0ede598102c7d809aea11b7bab99ddf6a20f4dde31070c23',
 };
 


### PR DESCRIPTION
## Summary
- Add Socket.dev monitoring badge using shields.io static badge
- The official Socket.dev badge API (`socket.dev/api/badge/`) is blocked by Cloudflare managed challenge (403), so a static badge is used as a workaround
- Placed in Scanning group (after Snyk, before GitGuardian)

## Test plan
- [ ] Socket.dev badge renders correctly via shields.io
- [ ] Badge links to Socket.dev dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)