### PR TITLE
fix(readme): correct Socket.dev badge link URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11709/badge)](https://www.bestpractices.dev/projects/11709)
 [![Harden-Runner](https://img.shields.io/badge/Harden--Runner-enabled-7037F5)](https://github.com/step-security/harden-runner)
 [![Known Vulnerabilities](https://snyk.io/test/github/nullvariant/nullvariant-vscode-extensions/badge.svg)](https://snyk.io/test/github/nullvariant/nullvariant-vscode-extensions)
-[![Socket.dev](https://img.shields.io/badge/Socket.dev-monitored-7042F5)](https://socket.dev/gh/nullvariant/nullvariant-vscode-extensions)
+[![Socket.dev](https://img.shields.io/badge/Socket.dev-monitored-7042F5)](https://socket.dev/dashboard/org/null-variant/repo/nullvariant-vscode-extensions)
 [![GitGuardian](https://img.shields.io/badge/GitGuardian-monitored-7042F5?logo=gitguardian)](https://www.gitguardian.com/)
 [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen?logo=renovatebot)](https://renovatebot.com)
 [![FOSSA License](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnullvariant%2Fnullvariant-vscode-extensions?ref=badge_shield&issueType=license)

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -61,7 +61,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'extensions/git-id-switcher/README.md': '7993a7d57e06a77bfc6064587b4726c48b0a30f58df16acc0274747215996ace',
   'GOVERNANCE.md': '806cf32ec9fe9fd964a782927f8eaa7696d408c42d31f554eebd6755bd911c71',
   'LICENSE': 'e2383295422577622666fa2ff00e5f03abd8f2772d74cca5d5443020ab23d03d',
-  'README.md': 'b9bdc53e3a535de8f59103be2bdcb06cf73b9b2579c9301fcc232caa244423f6',
+  'README.md': '990262ba0df29c031ee24c50d342fbf376bd1cc5c33849ec6b3ba1c09e898bb7',
   'SECURITY.md': 'bbae0e2a679851ea0ede598102c7d809aea11b7bab99ddf6a20f4dde31070c23',
 };
 


### PR DESCRIPTION
## Summary
- Fix broken Socket.dev badge link
- Previous URL (`/gh/nullvariant/...`) was incorrect
- Updated to actual dashboard URL (`/dashboard/org/null-variant/repo/...`)

## Test plan
- [ ] Socket.dev badge links to correct dashboard page

🤖 Generated with [Claude Code](https://claude.com/claude-code)