### PR TITLE
fix(git-id-switcher): Webview template a11y improvements

### DIFF
--- a/extensions/git-id-switcher/src/test/htmlTemplates.test.ts
+++ b/extensions/git-id-switcher/src/test/htmlTemplates.test.ts
@@ -668,19 +668,28 @@ function testBuildDocumentHtmlNavigation(): void {
     'Should use nav element with aria-label'
   );
 
-  // Back button enabled when canGoBack=true
+  // Back button enabled: aria-disabled="false" (not the [disabled] attribute),
+  // so Safari/VoiceOver keep it in focus order (Issue-00188).
   assert.ok(
-    htmlWithBack.includes('<button id="back-btn" >'),
-    'Back button should be enabled when canGoBack is true'
+    htmlWithBack.includes('aria-disabled="false"'),
+    'Back button should have aria-disabled="false" when canGoBack is true'
+  );
+  assert.ok(
+    !/<button id="back-btn"[^>]*\sdisabled(>|\s)/.test(htmlWithBack),
+    'Back button must NOT use the native [disabled] attribute'
   );
 
-  // Back button disabled when canGoBack=false
+  // Back button disabled when canGoBack=false — aria-disabled="true"
   const htmlNoBack = buildDocumentHtml(
     TEST_CSP_SOURCE, asSanitizedHtml('<p>Content</p>'), 'en', 'docs/test.md', TEST_NONCE, false
   );
   assert.ok(
-    htmlNoBack.includes('<button id="back-btn" disabled>'),
-    'Back button should be disabled when canGoBack is false'
+    htmlNoBack.includes('aria-disabled="true"'),
+    'Back button should have aria-disabled="true" when canGoBack is false'
+  );
+  assert.ok(
+    !/<button id="back-btn"[^>]*\sdisabled(>|\s)/.test(htmlNoBack),
+    'Back button must NOT use the native [disabled] attribute when disabled'
   );
 
   // Current path should be displayed (escaped)
@@ -786,7 +795,7 @@ function testBuildLoadingHtmlAccessibility(): void {
     'Loading text should have role="status"'
   );
   assert.ok(
-    html.includes('<p role="status">Loading documentation...</p>'),
+    /<p role="status"[^>]*>Loading documentation\.\.\.<\/p>/.test(html),
     'role="status" should be on the loading paragraph'
   );
 
@@ -937,6 +946,200 @@ function testLangAttributes(): void {
 }
 
 // ============================================================================
+// Issue-00188: Existing template a11y improvements
+// ============================================================================
+
+/**
+ * Cover the a11y contract introduced by Issue-00188:
+ *  - back-btn uses aria-label="Go back" with ← inside aria-hidden span
+ *  - document/error templates wrap body content in <main> landmark
+ *  - error template wraps message in div role="alert" (not on <h1>)
+ *  - loading status has aria-live="polite" + aria-atomic="true"
+ *  - footer GitHub link has descriptive aria-label
+ *  - nav-bar current-path carries aria-current="page"
+ *  - focus-visible rule is present in document & error styles
+ *  - @media (forced-colors: active) overrides zebra + focus outline
+ *  - linkInterceptScript handles keydown in addition to click
+ */
+function testIssue00188A11yImprovements(): void {
+  console.log('Testing Issue-00188 a11y improvements...');
+
+  const docHtmlCanBack = buildDocumentHtml(
+    TEST_CSP_SOURCE, asSanitizedHtml('<p>Content</p>'), 'en', 'docs/README.md', TEST_NONCE, true
+  );
+  const docHtmlNoBack = buildDocumentHtml(
+    TEST_CSP_SOURCE, asSanitizedHtml('<p>Content</p>'), 'en', 'docs/README.md', TEST_NONCE, false
+  );
+  const loadingHtml = buildLoadingHtml(TEST_CSP_SOURCE, TEST_NONCE);
+
+  // (2) back-btn: aria-label="Go back" + arrow inside aria-hidden span
+  assert.ok(
+    docHtmlCanBack.includes('aria-label="Go back"'),
+    'back-btn must carry aria-label="Go back"'
+  );
+  assert.ok(
+    /<span aria-hidden="true">←\s*<\/span>/.test(docHtmlCanBack),
+    'back-btn decorative arrow must live inside aria-hidden span'
+  );
+
+  // (8) aria-disabled both directions (fixed value contract, not a union).
+  assert.ok(
+    /id="back-btn"[^>]*aria-disabled="false"/.test(docHtmlCanBack),
+    'canGoBack=true must emit aria-disabled="false"'
+  );
+  assert.ok(
+    /id="back-btn"[^>]*aria-disabled="true"/.test(docHtmlNoBack),
+    'canGoBack=false must emit aria-disabled="true"'
+  );
+  // Disabled-state style uses color (not opacity) so focus ring contrast
+  // is preserved when the button is both focused and disabled.
+  assert.ok(
+    docHtmlCanBack.includes('.nav-bar button[aria-disabled="true"]'),
+    'nav-bar must style disabled state via aria-disabled selector'
+  );
+  assert.ok(
+    !/\.nav-bar button\[aria-disabled="true"\]\s*\{[^}]*opacity:/.test(docHtmlCanBack),
+    'disabled back-btn must not use opacity (kills focus ring contrast)'
+  );
+
+  // (10) document body wrapped in exactly one <main> landmark.
+  assert.strictEqual(
+    (docHtmlCanBack.match(/<main[>\s]/g) ?? []).length, 1,
+    'document template must contain exactly one <main> landmark'
+  );
+  assert.ok(
+    /<main>\s*\n?\s*<p>Content<\/p>\s*<\/main>/.test(docHtmlCanBack),
+    'document <main> must directly wrap the sanitized content'
+  );
+
+  // (11) error: all three errorTypes must preserve
+  //      <main>…<h1>…<p role="alert">…</main> parametrically.
+  //      h1 lives OUTSIDE role="alert" (JAWS heading-list regression guard).
+  const errorCases = [
+    ['network', 'Network Error'],
+    ['notfound', 'Document Not Found'],
+    ['server', 'Server Error'],
+  ] as const;
+  for (const [errorType, title] of errorCases) {
+    const errHtml = buildErrorHtml(TEST_CSP_SOURCE, errorType, TEST_NONCE);
+    assert.strictEqual(
+      (errHtml.match(/<main[>\s]/g) ?? []).length, 1,
+      `error(${errorType}): exactly one <main> landmark required`
+    );
+    assert.ok(
+      errHtml.includes(`<h1>${title}</h1>`),
+      `error(${errorType}): <h1> must contain the error title`
+    );
+    // role="alert" is on a <p>, not the <h1> or a wrapping <div>.
+    assert.ok(
+      /<p role="alert">/.test(errHtml),
+      `error(${errorType}): role="alert" must live on a <p> element`
+    );
+    assert.ok(
+      !/<h1[^>]*role="alert"/.test(errHtml),
+      `error(${errorType}): <h1> must NOT carry role="alert"`
+    );
+    assert.ok(
+      !/<div role="alert">/.test(errHtml),
+      `error(${errorType}): role="alert" must not wrap the heading in a div`
+    );
+    // Footer GitHub link must carry descriptive aria-label.
+    assert.ok(
+      errHtml.includes('aria-label="View Git ID Switcher on GitHub"'),
+      `error(${errorType}): GitHub link must carry descriptive aria-label`
+    );
+  }
+
+  // (9) loading status: aria-live + aria-atomic AND status <p> must NOT be
+  //     aria-hidden (spinner is hidden, status is announced — the contract
+  //     is a two-sided split).
+  assert.ok(
+    /role="status"[^>]*aria-live="polite"[^>]*aria-atomic="true"/.test(loadingHtml),
+    'loading status must have aria-live="polite" and aria-atomic="true"'
+  );
+  assert.ok(
+    !/<p[^>]*aria-hidden/.test(loadingHtml),
+    'loading status <p> must NOT be aria-hidden (it is the announced region)'
+  );
+  assert.ok(
+    /<main class="loading">/.test(loadingHtml),
+    'loading template must use <main class="loading"> landmark'
+  );
+
+  // (12) document footer GitHub link aria-label
+  assert.ok(
+    docHtmlCanBack.includes('aria-label="View Git ID Switcher on GitHub"'),
+    'document footer GitHub link must carry descriptive aria-label'
+  );
+
+  // (13) current-path aria-current="page"
+  assert.ok(
+    /class="current-path" aria-current="page"/.test(docHtmlCanBack),
+    'nav-bar current-path must carry aria-current="page"'
+  );
+
+  // (5) :focus-visible — document must bind BOTH a and button into a single
+  // SSOT selector (regression guard: if one gets dropped, this fails).
+  assert.match(
+    docHtmlCanBack,
+    /a:focus-visible\s*,\s*\n?\s*button:focus-visible\s*\{[\s\S]*?outline:\s*2px solid var\(--vscode-focusBorder\)/,
+    'document template must bind a + button to :focus-visible SSOT rule'
+  );
+  const errorHtmlNetwork = buildErrorHtml(TEST_CSP_SOURCE, 'network', TEST_NONCE);
+  assert.match(
+    errorHtmlNetwork, /a:focus-visible\s*\{[\s\S]*?outline:\s*2px solid var\(--vscode-focusBorder\)/,
+    'error template must define a:focus-visible outline'
+  );
+
+  // (6)(7) forced-colors media query — extract the block body first, then
+  //        assert on its inner contents so greedy matches cannot leak across
+  //        the `}` boundary into unrelated rules.
+  const forcedColorsBlock = (html: string): string => {
+    const m = /@media \(forced-colors: active\)\s*\{((?:[^{}]|\{[^{}]*\})*)\}/.exec(html);
+    return m?.[1] ?? '';
+  };
+  const docForced = forcedColorsBlock(docHtmlCanBack);
+  assert.ok(docForced.length > 0, 'document template must declare forced-colors media query');
+  assert.match(
+    docForced, /tr:nth-child\(even\)[\s\S]*?background-color:\s*Canvas/,
+    'document forced-colors: nth-child(even) must reset to Canvas'
+  );
+  assert.match(
+    docForced, /\bth\b[\s\S]*?background-color:\s*Canvas/,
+    'document forced-colors: th must also reset to Canvas (parity with zebra)'
+  );
+  assert.match(
+    docForced, /outline-color:\s*Highlight/,
+    'document forced-colors: focus outline must use Highlight'
+  );
+  const errorForced = forcedColorsBlock(errorHtmlNetwork);
+  assert.match(
+    errorForced, /outline-color:\s*Highlight/,
+    'error forced-colors: focus outline must use Highlight'
+  );
+
+  // (1) Keyboard policy: Space on <a> must NOT be synthesised as
+  //     activation (WCAG 3.2.5). Native Enter on <a> and Enter/Space on
+  //     <button> flow through the click listener alone.
+  assert.ok(
+    !docHtmlCanBack.includes("addEventListener('keydown'"),
+    'linkInterceptScript must NOT register a keydown listener (Space on <a> is page scroll)'
+  );
+  // Back button guard: must read aria-disabled, not the [disabled] attribute.
+  assert.ok(
+    docHtmlCanBack.includes("getAttribute('aria-disabled')"),
+    'back-btn handler must guard on aria-disabled state'
+  );
+  // The back-btn click path must be reached before the generic <a> fallback.
+  assert.ok(
+    /closest\(['"]#back-btn['"]\)[\s\S]*closest\(['"]a['"]\)/.test(docHtmlCanBack),
+    'back-btn branch must precede the generic <a> branch in click handler'
+  );
+
+  console.log('  Issue-00188 a11y improvements passed!');
+}
+
+// ============================================================================
 // Test Runner
 // ============================================================================
 
@@ -986,6 +1189,10 @@ export function runHtmlTemplatesTests(): void {
     // Lang Attribute Tests
     console.log('\n--- Lang Attribute Tests ---');
     testLangAttributes();
+
+    // Issue-00188 A11y Improvements
+    console.log('\n--- Issue-00188 A11y Improvements ---');
+    testIssue00188A11yImprovements();
 
     console.log('\n========================================');
     console.log('   All HTML template tests passed!     ');

--- a/extensions/git-id-switcher/src/ui/htmlTemplates.ts
+++ b/extensions/git-id-switcher/src/ui/htmlTemplates.ts
@@ -268,22 +268,48 @@ export function buildDocumentHtml(
   nonce: string,
   canGoBack: boolean
 ): string {
-  // Script to intercept link clicks and send messages to extension
+  // Script to intercept link clicks / keyboard activation and back button.
+  //
+  // Keyboard policy for <a>: only Enter activates. Native <a> already fires
+  // a synthetic click on Enter, so the click listener covers it with zero
+  // extra code. Space is intentionally NOT handled — on <a> Space performs
+  // page scroll per the ARIA Authoring Practices, and synthesising
+  // navigation there would break user expectations (WCAG 3.2.5 Change on
+  // Request). The back button is a <button>, where both Enter and Space
+  // DO fire a native click, so its activation also flows through the
+  // click listener.
+  //
+  // Why aria-disabled on back-btn (not [disabled]): Safari/VoiceOver remove
+  // focus from [disabled] buttons entirely, trapping keyboard users who
+  // tab-land on the nav bar. aria-disabled keeps the button in the focus
+  // order and we guard the click handler instead.
   const linkInterceptScript = `
     (function() {
       const vscode = acquireVsCodeApi();
 
       document.addEventListener('click', function(e) {
-        const link = e.target.closest('a');
-        if (!link) return;
+        // Back button takes precedence: if the click path traverses the
+        // back button, handle it first so link-in-button edge cases (a
+        // sanitizer future-regression adding <a> inside the button) cannot
+        // bypass the aria-disabled guard below.
+        const backBtn = e.target.closest && e.target.closest('#back-btn');
+        if (backBtn) {
+          if (backBtn.getAttribute('aria-disabled') === 'true') {
+            e.preventDefault();
+            return;
+          }
+          e.preventDefault();
+          vscode.postMessage({ command: 'back' });
+          return;
+        }
 
+        const link = e.target.closest && e.target.closest('a');
+        if (!link) return;
         const href = link.getAttribute('href');
         if (!href) return;
 
-        // Prevent default navigation
         e.preventDefault();
 
-        // Handle anchor links (scroll within page)
         if (href.startsWith('#')) {
           const target = document.getElementById(href.slice(1));
           if (target) {
@@ -292,16 +318,7 @@ export function buildDocumentHtml(
           return;
         }
 
-        // Send navigation request to extension
-        vscode.postMessage({
-          command: 'navigate',
-          href: href
-        });
-      });
-
-      // Handle back button
-      document.getElementById('back-btn')?.addEventListener('click', function() {
-        vscode.postMessage({ command: 'back' });
+        vscode.postMessage({ command: 'navigate', href: href });
       });
     })();
   `;
@@ -398,14 +415,47 @@ export function buildDocumentHtml(
     .nav-bar button:hover {
       background: var(--vscode-button-secondaryHoverBackground);
     }
-    .nav-bar button:disabled {
-      opacity: 0.5;
+    /* aria-disabled is used instead of the [disabled] attribute so
+       Safari/VoiceOver keep the button in the focus order (Issue-00188).
+       Uses a theme-aware foreground color instead of opacity so the
+       focus-visible outline retains full contrast (WCAG 1.4.11) when
+       the button is both focused and disabled. */
+    .nav-bar button[aria-disabled="true"] {
+      color: var(--vscode-disabledForeground, var(--vscode-descriptionForeground));
       cursor: not-allowed;
     }
     .nav-bar .current-path {
       margin-left: var(--gis-space-md);
       color: var(--vscode-descriptionForeground);
       font-size: var(--gis-font-sm);
+    }
+    /* WCAG 2.4.7 Focus Visible: a single SSOT focus ring shared by
+       every focusable element in the document template. Uses VS Code
+       theme tokens so it adapts to light/dark/high-contrast themes. */
+    a:focus-visible,
+    button:focus-visible {
+      outline: 2px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
+    }
+    /* Forced-colors (Windows High Contrast) overrides.
+       - The nth-child(even) zebra uses a theme background that collapses to
+         Canvas in forced-colors, flattening rows. Explicitly reset to
+         Canvas so rows keep the system background rather than an opaque
+         panel color that would fight cell borders.
+       - Focus outlines must use the system Highlight color per WCAG 1.4.3. */
+    @media (forced-colors: active) {
+      /* Both th and zebra rows share --vscode-textCodeBlock-background
+         in the default theme; under forced-colors that token collapses and
+         can fight cell borders. Flatten them to Canvas so the system
+         palette drives row/cell backgrounds uniformly. */
+      tr:nth-child(even),
+      th {
+        background-color: Canvas;
+      }
+      a:focus-visible,
+      button:focus-visible {
+        outline-color: Highlight;
+      }
     }
     .footer {
       margin-top: var(--gis-pad-body-lg);
@@ -426,13 +476,19 @@ export function buildDocumentHtml(
       margin: 0 auto;
     }`;
 
+  // aria-disabled (not [disabled]) preserves tab focus under Safari/VoiceOver.
+  // The ← glyph lives inside an aria-hidden span so AT announces only the
+  // button's aria-label ("Go back") instead of reading the arrow as a
+  // standalone token before the word "Back".
   const body = `  <nav class="nav-bar" aria-label="Document navigation">
-    <button id="back-btn" ${canGoBack ? '' : 'disabled'}>← Back</button>
-    <span class="current-path">${escapeHtmlEntities(currentPath)}</span>
+    <button id="back-btn" type="button" aria-label="Go back" aria-disabled="${canGoBack ? 'false' : 'true'}"><span aria-hidden="true">← </span>Back</button>
+    <span class="current-path" aria-current="page">${escapeHtmlEntities(currentPath)}</span>
   </nav>
-  ${content}
+  <main>
+${content}
+  </main>
   <footer class="footer">
-    <a href="https://github.com/nullvariant/nullvariant-vscode-extensions/tree/main/extensions/git-id-switcher#readme">View on GitHub</a>
+    <a href="https://github.com/nullvariant/nullvariant-vscode-extensions/tree/main/extensions/git-id-switcher#readme" aria-label="View Git ID Switcher on GitHub">View on GitHub</a>
     <a href="https://marketplace.visualstudio.com/items?itemName=nullvariant.git-id-switcher">VS Code Marketplace</a>
   </footer>
   <script nonce="${nonce}">${linkInterceptScript}</script>`;
@@ -479,10 +535,13 @@ export function buildLoadingHtml(cspSource: string, nonce: string): string {
       margin-top: var(--gis-space-md);
     }`;
 
-  const body = `  <div class="loading">
+  // aria-live="polite" + aria-atomic complements role="status" for AT stacks
+  // (older NVDA, some mobile readers) that miss the implicit live region on
+  // elements rendered during initial document parse.
+  const body = `  <main class="loading">
     <div class="spinner" aria-hidden="true"></div>
-    <p role="status">Loading documentation...</p>
-  </div>`;
+    <p role="status" aria-live="polite" aria-atomic="true">Loading documentation...</p>
+  </main>`;
 
   return buildHtmlShell({
     cspSource,
@@ -533,11 +592,29 @@ export function buildErrorHtml(
     }
     h1 {
       color: var(--vscode-errorForeground);
+    }
+    /* WCAG 2.4.7 Focus Visible — error template has no other focusable
+       controls but still needs a visible focus ring on the fallback link. */
+    a:focus-visible {
+      outline: 2px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
+    }
+    @media (forced-colors: active) {
+      a:focus-visible {
+        outline-color: Highlight;
+      }
     }`;
 
-  const body = `  <h1>${msg.title}</h1>
-  <p>${msg.body}</p>
-  <p><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/tree/main/extensions/git-id-switcher#readme">View on GitHub</a></p>`;
+  // role="alert" wraps only the body <p>, not the <h1>. Putting a heading
+  // inside role="alert" causes JAWS to drop it from the heading list and
+  // some AT to re-read the title as both "alert" and "heading level 1".
+  // The <h1> remains the landmark heading; the alert announces only the
+  // detail message, which is the part that needs to interrupt the user.
+  const body = `  <main>
+    <h1>${msg.title}</h1>
+    <p role="alert">${msg.body}</p>
+    <p><a href="https://github.com/nullvariant/nullvariant-vscode-extensions/tree/main/extensions/git-id-switcher#readme" aria-label="View Git ID Switcher on GitHub">View on GitHub</a></p>
+  </main>`;
 
   return buildHtmlShell({
     cspSource,


### PR DESCRIPTION
## Summary
- Address WCAG keyboard/focus/landmarks/forced-colors gaps across the document / loading / error Webview templates.
- `back-btn` migrated to `aria-disabled` so Safari/VoiceOver keep it in tab order; disabled state uses theme color instead of opacity to preserve focus-ring contrast (WCAG 1.4.11).
- `Space` on `<a>` is intentionally NOT synthesised — native page-scroll is preserved (WCAG 3.2.5). Enter on `<a>` and Enter/Space on `<button>` already flow through the existing click listener.
- Content wrapped in `<main>` landmarks (WCAG 2.4.1). Error `<h1>` lifted out of `role="alert"` so JAWS keeps it in the heading list; only the detail `<p>` carries the alert.
- Loading status gains `aria-live="polite" aria-atomic="true"` for older NVDA / mobile AT. Decorative arrow on back-btn wrapped in `aria-hidden` span with `aria-label="Go back"`.
- SSOT `:focus-visible` rule on `--vscode-focusBorder`; `@media (forced-colors: active)` flattens both `tr:nth-child(even)` and `th` to `Canvas` and forces `outline-color: Highlight` for Windows High Contrast.

## Quality review
Parallel a11y / security / test reviewers were run. All actionable findings were folded into this PR:
- a11y: Space activation removed, `<h1>` lifted from `role="alert"`, forced-colors `th` reset added, opacity replaced with color for disabled state.
- tests: both aria-disabled directions, SSOT focus-visible rule, Space-keydown negative assertion, parametric error types, forced-colors block extraction.
- security: no Critical/Medium findings.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint -- --max-warnings=0`
- [x] `npm run test:coverage` — `htmlTemplates.ts` retains 100% statement/branch/function/line coverage
- [ ] Manual verification: NVDA / VoiceOver announcement on document / loading / error
- [ ] Manual verification: Windows High Contrast (forced-colors) rendering of tables and focus ring