### PR TITLE
feat(git-id-switcher): defense-in-depth nonce/lang validation at buildHtmlShell

### DIFF
--- a/extensions/git-id-switcher/src/test/htmlTemplates.test.ts
+++ b/extensions/git-id-switcher/src/test/htmlTemplates.test.ts
@@ -35,6 +35,8 @@
 import * as assert from 'node:assert';
 import {
   type SanitizedHtml,
+  assertValidLang,
+  assertValidNonce,
   buildCspString,
   CspValidationError,
   getBaseStyles,
@@ -173,7 +175,12 @@ function testBuildCspStringValidation(): void {
   // future rewording that conflates the two parameters is caught.
   // The `CspValidationError:` prefix (Issue-00236) lets renderWithFallback
   // narrow its catch via `instanceof` instead of swallowing every throw.
-  const NONCE_ERR = /^CspValidationError: buildCspString: nonce /;
+  // Nonce validation was de-duplicated into assertValidNonce (Issue-00191
+  // SSOT consolidation), so the error prefix is `assertValidNonce:` rather
+  // than `buildCspString:`. The Issue-00236 scrub invariant (static message,
+  // no attacker bytes) and the `instanceof CspValidationError` narrowing
+  // used by renderWithFallback remain unchanged.
+  const NONCE_ERR = /^CspValidationError: assertValidNonce: nonce /;
   const SOURCE_ERR = /^CspValidationError: buildCspString: cspSource /;
 
   // Nonce breakout and boundary payloads.
@@ -713,33 +720,191 @@ function testBuildDocumentHtmlNavigation(): void {
 function testBuildDocumentHtmlContentEscaping(): void {
   console.log('Testing buildDocumentHtml (escaping)...');
 
-  // Locale with XSS payload should be escaped
+  // Issue-00191: XSS payloads in `locale` no longer rely on downstream
+  // escaping — they are rejected fail-closed at the shell boundary via
+  // assertValidLang. This is strictly stronger than escaping because the
+  // error surfaces immediately instead of depending on the escaper staying
+  // correct forever.
+  assert.throws(
+    () =>
+      buildDocumentHtml(
+        TEST_CSP_SOURCE,
+        asSanitizedHtml('<p>Safe content</p>'),
+        '"><script>alert(1)</script>',
+        'docs/README.md',
+        TEST_NONCE,
+        false
+      ),
+    (err: unknown) => err instanceof CspValidationError,
+    'Locale XSS payload must throw CspValidationError at the shell boundary'
+  );
+
+  // Path still flows through escapeHtmlEntities (it is markdown-derived
+  // free text, not an allowlisted attribute) so the escape contract on
+  // that field must keep working.
   const html = buildDocumentHtml(
     TEST_CSP_SOURCE,
     asSanitizedHtml('<p>Safe content</p>'),
-    '"><script>alert(1)</script>',
+    'en',
     'docs/<script>alert(2)</script>.md',
     TEST_NONCE,
     false
   );
-
-  // Locale should be escaped in lang attribute
-  assert.ok(
-    !html.includes('lang=""><script>'),
-    'Locale XSS payload should be escaped'
-  );
-  assert.ok(
-    html.includes('&lt;script&gt;'),
-    'Script tags in locale should be HTML-escaped'
-  );
-
-  // Path should be escaped in display
   assert.ok(
     html.includes('&lt;script&gt;alert(2)&lt;/script&gt;'),
     'Script tags in path should be HTML-escaped'
   );
 
   console.log('  buildDocumentHtml (escaping) passed!');
+}
+
+/**
+ * Issue-00191: defense-in-depth validation of nonce / lang at the
+ * buildHtmlShell boundary via the exported assertValid* helpers.
+ *
+ * Covered:
+ *  - assertValidNonce rejects the same breakout payloads as buildCspString
+ *    (quote, angle bracket, semicolon, whitespace, length floor)
+ *  - assertValidLang rejects XSS payloads and accepts every entry in
+ *    SUPPORTED_LOCALES (including `x-*` private-use tags)
+ *  - assertValidLang's errors are scrubbed (no attacker bytes in message)
+ *  - buildDocumentHtml propagates nonce rejection to the shell boundary
+ *  - buildLoadingHtml / buildErrorHtml also validate nonce at the shell
+ */
+function testShellInputValidation(): void {
+  console.log('Testing buildHtmlShell input validation (Issue-00191)...');
+
+  // --- assertValidNonce ---
+  const badNonces = [
+    `${TEST_NONCE}"`,
+    `${TEST_NONCE}>`,
+    `${TEST_NONCE}<script>`,
+    `${TEST_NONCE} `,
+    `${TEST_NONCE};`,
+    `${TEST_NONCE}\n`,
+    `${TEST_NONCE}\r`,              // CR
+    `${TEST_NONCE}\t`,              // tab
+    `${TEST_NONCE}\u00A0`,          // NBSP
+    `${TEST_NONCE}\u2028`,          // line separator (JS-specific hazard)
+    `${TEST_NONCE}\u0000`,          // NUL
+    'tooShort',
+    '',
+  ];
+  for (const bad of badNonces) {
+    assert.throws(
+      () => assertValidNonce(bad),
+      (err: unknown) => err instanceof CspValidationError,
+      `assertValidNonce must reject: ${JSON.stringify(bad)}`
+    );
+  }
+  assert.doesNotThrow(
+    () => assertValidNonce(TEST_NONCE),
+    'assertValidNonce must accept a valid 24-char base64 nonce'
+  );
+
+  // --- assertValidLang happy path ---
+  // Every entry in the extension's SUPPORTED_LOCALES must pass. Hardcoded
+  // rather than imported so a future accidental narrowing of LANG_PATTERN
+  // that silently drops `x-*` tags is caught here even if the import path
+  // changes.
+  const validLangs = [
+    'en', 'ja', 'zh-CN', 'zh-TW', 'ko', 'de', 'fr', 'es', 'it', 'pt-BR',
+    'ru', 'pl', 'tr', 'uk', 'cs', 'hu', 'bg',
+    'ain', 'ryu', 'haw', 'eo', 'tlh', 'tok',
+    'x-pirate', 'x-shakespeare', 'x-lolcat',
+  ];
+  for (const good of validLangs) {
+    assert.doesNotThrow(
+      () => assertValidLang(good),
+      `assertValidLang must accept SUPPORTED_LOCALES entry: ${good}`
+    );
+  }
+
+  // --- assertValidLang rejection ---
+  const badLangs = [
+    '"><script>alert(1)</script>',
+    'en"',
+    'en>',
+    'en ',
+    'en;',
+    'en\n',
+    'a',                 // 1-char primary subtag (not x-*)
+    'toolong',           // 7-char primary subtag
+    'en-',               // trailing hyphen
+    'en--US',            // empty subtag between hyphens
+    '',                  // empty (coerce happens in shell, not here)
+    'x',                 // bare x without private-use subtag
+    'x-',                // trailing hyphen after x
+    'en\u0000',          // NUL smuggling
+    'en\u00A0',          // NBSP
+    'en\r\n',            // CRLF
+    'en\u2028',          // line separator
+  ];
+  for (const bad of badLangs) {
+    assert.throws(
+      () => assertValidLang(bad),
+      (err: unknown) => err instanceof CspValidationError,
+      `assertValidLang must reject: ${JSON.stringify(bad)}`
+    );
+  }
+
+  // --- scrub contract: message must not echo attacker bytes ---
+  const SCRUB_SENTINEL = 'LEAK_SENTINEL_LANG_ZZZ';
+  try {
+    assertValidLang(`"><script>${SCRUB_SENTINEL}`);
+    assert.fail('expected throw');
+  } catch (error) {
+    assert.ok(error instanceof CspValidationError);
+    assert.ok(
+      !error.message.includes(SCRUB_SENTINEL),
+      'assertValidLang error must not echo raw lang input'
+    );
+  }
+
+  // --- buildDocumentHtml propagates nonce rejection ---
+  assert.throws(
+    () =>
+      buildDocumentHtml(
+        TEST_CSP_SOURCE,
+        asSanitizedHtml('<p>x</p>'),
+        'en',
+        'docs/README.md',
+        `${TEST_NONCE}"><script>`,
+        false
+      ),
+    (err: unknown) => err instanceof CspValidationError,
+    'buildDocumentHtml must reject nonce breakout at the shell boundary'
+  );
+
+  // --- buildLoadingHtml / buildErrorHtml also validate nonce ---
+  assert.throws(
+    () => buildLoadingHtml(TEST_CSP_SOURCE, 'short'),
+    (err: unknown) => err instanceof CspValidationError,
+    'buildLoadingHtml must reject malformed nonce'
+  );
+  assert.throws(
+    () => buildErrorHtml(TEST_CSP_SOURCE, 'network', 'short'),
+    (err: unknown) => err instanceof CspValidationError,
+    'buildErrorHtml must reject malformed nonce'
+  );
+
+  // --- empty lang is coerced to 'en' inside the shell ---
+  // Passed through buildDocumentHtml to exercise the shell path, not the
+  // raw assertValidLang (which stays fail-closed on empty).
+  const coercedHtml = buildDocumentHtml(
+    TEST_CSP_SOURCE,
+    asSanitizedHtml('<p>x</p>'),
+    '',
+    'docs/README.md',
+    TEST_NONCE,
+    false
+  );
+  assert.ok(
+    coercedHtml.includes('<html lang="en">'),
+    'Empty locale must be coerced to lang="en" at the shell boundary'
+  );
+
+  console.log('  buildHtmlShell input validation passed!');
 }
 
 // ============================================================================
@@ -1167,6 +1332,7 @@ export function runHtmlTemplatesTests(): void {
     testBuildDocumentHtmlStructure();
     testBuildDocumentHtmlNavigation();
     testBuildDocumentHtmlContentEscaping();
+    testShellInputValidation();
     testAllTemplatesCssQuality();
 
     // Cross-Template Invariants

--- a/extensions/git-id-switcher/src/ui/htmlTemplates.ts
+++ b/extensions/git-id-switcher/src/ui/htmlTemplates.ts
@@ -84,6 +84,90 @@ const NONCE_PATTERN = /^[A-Za-z0-9+/=_-]{22,}$/;
 const CSP_SOURCE_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:[A-Za-z0-9%*._/:-]+$/;
 
 /**
+ * BCP 47 language tag (subset). Accepts either:
+ *  - a 2-3 letter primary subtag optionally followed by `-<2-8 alphanumeric>`
+ *    subtags (covers `en`, `ja`, `zh-CN`, `pt-BR`, `ain`, `tlh`, …), or
+ *  - an `x-…` private-use tag whose subtags are 1-16 alphanumeric
+ *    (covers SUPPORTED_LOCALES entries `x-pirate`, `x-shakespeare`,
+ *    `x-lolcat`). The subtag length is intentionally wider than RFC 5646's
+ *    8-char limit to accommodate the extension's own whimsy locales without
+ *    spamming governance. Private-use is enumerated explicitly because the
+ *    single-letter `x` primary subtag does not fit the general form.
+ *
+ * Fullmatch forbids quotes, angle brackets, whitespace, etc. that could
+ * break the `<html lang>` attribute. Kept deliberately stricter than the
+ * full RFC 5646 grammar — we do not need extlang / grandfathered forms.
+ */
+const LANG_PATTERN = /^(?:[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*|x(?:-[a-zA-Z0-9]{1,16})+)$/;
+
+/**
+ * SSOT allowlist for body class identifiers consumed by `buildHtmlShell`.
+ * The tuple is declared `as const` so the `BodyClass` type below can be
+ * derived from it — adding a new template means widening this one array
+ * and the compile-time union follows automatically (no dual-definition
+ * drift, core-values #2).
+ */
+const VALID_BODY_CLASSES = new Set([
+  'gis-doc',
+  'gis-loading',
+  'gis-error',
+] as const);
+
+/**
+ * Compile-time allowlist for the body class identifier on `<body>`, derived
+ * from `VALID_BODY_CLASSES` so the runtime set and the type stay in lockstep.
+ * The only values that may reach `buildHtmlShell` come from template
+ * functions inside this file, so a literal union plus a runtime allowlist
+ * check is strictly stronger than escaping an arbitrary `string`: even a
+ * future refactor that accidentally forwards external input fails at both
+ * compile time and the trust boundary.
+ */
+export type BodyClass =
+  typeof VALID_BODY_CLASSES extends ReadonlySet<infer T> ? T : never;
+
+/**
+ * Validate a CSP nonce at the trust boundary. Used by both `buildCspString`
+ * (where the nonce is interpolated into the CSP `content` attribute) and
+ * `buildHtmlShell` (where it is interpolated into `<style nonce>` /
+ * `<script nonce>` attributes). Exported so the webview layer can assert at
+ * the generation site in addition to the consumption site — defense-in-depth
+ * per Issue-00191.
+ *
+ * @throws {CspValidationError} with a scrubbed, static message (Issue-00236
+ *   contract: never echo attacker-controlled bytes back through error logs).
+ */
+export function assertValidNonce(nonce: string): void {
+  if (!NONCE_PATTERN.test(nonce)) {
+    throw new CspValidationError('assertValidNonce: nonce contains disallowed characters');
+  }
+}
+
+/**
+ * Validate a BCP 47 language tag for interpolation into `<html lang="…">`.
+ * Exported for defense-in-depth alongside `assertValidNonce`. Callers that
+ * may legitimately receive an empty locale (e.g. bootstrap before i18n is
+ * ready) should pass the empty string through `coerceLang` first rather than
+ * duplicating the fallback logic.
+ *
+ * @throws {CspValidationError} with a static, scrubbed message.
+ */
+export function assertValidLang(lang: string): void {
+  if (!LANG_PATTERN.test(lang)) {
+    throw new CspValidationError('assertValidLang: lang is not a valid BCP 47 tag');
+  }
+}
+
+/**
+ * Coerce a possibly-empty locale to a safe default before validation. Kept
+ * separate from `assertValidLang` so that the validator remains fail-closed
+ * for *all* callers — only the shell, which owns the rendering contract,
+ * opts into the fallback.
+ */
+function coerceLang(lang: string): string {
+  return lang === '' ? 'en' : lang;
+}
+
+/**
  * Build Content Security Policy header value
  *
  * Defense-in-depth:
@@ -103,9 +187,11 @@ const CSP_SOURCE_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:[A-Za-z0-9%*._/:-]+$/;
  * @throws {CspValidationError} if `nonce` or `cspSource` fails format validation
  */
 export function buildCspString(cspSource: string, nonce: string): string {
-  if (!NONCE_PATTERN.test(nonce)) {
-    throw new CspValidationError('buildCspString: nonce contains disallowed characters');
-  }
+  // Delegate to assertValidNonce — single source of truth for nonce format.
+  // The thrown CspValidationError keeps the Issue-00236 scrub invariant
+  // (static message, no attacker bytes) and `renderWithFallback` narrows on
+  // `instanceof CspValidationError`, not on the prefix string.
+  assertValidNonce(nonce);
   if (!CSP_SOURCE_PATTERN.test(cspSource)) {
     throw new CspValidationError('buildCspString: cspSource has unexpected format');
   }
@@ -197,17 +283,24 @@ export function getBaseStyles(): string {
 interface HtmlShellOptions {
   readonly cspSource: string;
   readonly nonce: string;
+  /**
+   * BCP 47 language tag or the empty string. Empty is coerced to `'en'`
+   * inside `buildHtmlShell` before validation; any other non-conforming
+   * value throws `CspValidationError`.
+   */
   readonly lang: string;
   readonly title: string;
   /** Full CSS content placed inside the single <style nonce> block. */
   readonly styles: string;
   /**
-   * Body class identifier (e.g. "gis-doc"). Template-specific body CSS MUST
-   * be scoped by this class so that template overrides raise specificity
-   * beyond the base `body` rule in getBaseStyles(), making cascade order
-   * irrelevant (Issue-00189).
+   * Body class identifier. Compile-time restricted to the `BodyClass` union
+   * and runtime-checked against `VALID_BODY_CLASSES` so a future caller that
+   * erases the type cannot inject attacker-controlled bytes into the `<body
+   * class>` attribute (Issue-00191). Template-specific body CSS MUST be
+   * scoped by this class so template overrides raise specificity beyond the
+   * base `body` rule in getBaseStyles() (Issue-00189).
    */
-  readonly bodyClass: string;
+  readonly bodyClass: BodyClass;
   /** Raw HTML inserted between <body> and </body> (may include <script>). */
   readonly body: string;
 }
@@ -220,10 +313,32 @@ interface HtmlShellOptions {
  * a11y fixes happen in exactly one place.
  */
 function buildHtmlShell(opts: Readonly<HtmlShellOptions>): string {
+  // Defense-in-depth: validate every attribute-interpolated input at the
+  // shell boundary, not just at the caller that generates it. nonce and lang
+  // land in attribute context (`<style nonce>`, `<html lang>`), where a
+  // single stray `"` or `>` permits breakout; bodyClass is allowlist-checked
+  // because it is under our compile-time control (Issue-00191).
+  assertValidNonce(opts.nonce);
+  const lang = coerceLang(opts.lang);
+  assertValidLang(lang);
+  // Defense-in-depth: the BodyClass union makes this branch unreachable
+  // under the normal type contract, but the runtime allowlist guards against
+  // a future caller that erases the type.
+  /* c8 ignore start */
+  if (!VALID_BODY_CLASSES.has(opts.bodyClass)) {
+    throw new CspValidationError('buildHtmlShell: bodyClass is not in the allowlist');
+  }
+  /* c8 ignore stop */
+
   const csp = buildCspString(opts.cspSource, opts.nonce);
 
+  // lang and bodyClass are post-validation fixed-shape values, so the
+  // escapeHtmlEntities wrapper is redundant — the allowlist IS the escape.
+  // Removing the call makes the trust boundary explicit: if `lang` ever
+  // flows in without passing assertValidLang, the failure is structural
+  // rather than silently masked by a downstream escaper.
   return `<!DOCTYPE html>
-<html lang="${escapeHtmlEntities(opts.lang)}">
+<html lang="${lang}">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="${csp}">
@@ -233,7 +348,7 @@ function buildHtmlShell(opts: Readonly<HtmlShellOptions>): string {
     ${opts.styles}
   </style>
 </head>
-<body class="${escapeHtmlEntities(opts.bodyClass)}">
+<body class="${opts.bodyClass}">
 ${opts.body}
 </body>
 </html>`;


### PR DESCRIPTION
## Summary

- Add `assertValidNonce` / `assertValidLang` helpers used by `buildHtmlShell` to reject attribute-breakout payloads fail-closed at the trust boundary, not just at the generator side.
- `buildCspString` now delegates nonce validation to `assertValidNonce` (SSOT). `bodyClass` becomes a literal union derived from `VALID_BODY_CLASSES` so the runtime set and the compile-time type share one source.
- Empty locale is coerced to `'en'` at the shell boundary only; `assertValidLang` itself stays fail-closed for direct callers. `lang` / `bodyClass` drop the redundant `escapeHtmlEntities` wrapper now that the allowlist IS the trust boundary.

## Test plan

- [x] `npm run compile` — clean
- [x] `npm run lint -- --max-warnings=0` — clean
- [x] `npm run test:unit` — all HTML template tests pass including new `testShellInputValidation` covering ASCII breakout, Unicode/control smuggling (NBSP, LS, NUL, CR/LF, tab), BCP47 edge cases (double hyphen, trailing hyphen, bare `x`), nonce propagation through all three templates, and empty-locale coercion
- [x] `npm run test:coverage` — `htmlTemplates.ts` holds at 100% statements / 100% branches / 100% functions / 100% lines

## Notes

- The `CspValidationError` message prefix for nonce validation changes from `buildCspString: nonce ...` to `assertValidNonce: nonce ...` as part of the SSOT consolidation. The Issue-00236 scrub invariant (static message, no attacker bytes) and `renderWithFallback`'s `instanceof CspValidationError` narrowing are both unchanged. The existing error regex in `testBuildCspStringValidation` has been updated accordingly.
- The runtime `VALID_BODY_CLASSES.has` guard inside `buildHtmlShell` is marked `/* c8 ignore */` because the `BodyClass` union makes the branch unreachable under the normal type contract. The guard exists as defense-in-depth against a future caller that erases the type.