### PR TITLE
security(git-id-switcher): externalize linkInterceptScript and add href scheme allowlist

### DIFF
--- a/extensions/git-id-switcher/src/test/documentation.test.ts
+++ b/extensions/git-id-switcher/src/test/documentation.test.ts
@@ -515,15 +515,36 @@ function testClassifyUrl(): void {
   const directNonMdResult = classifyUrl('script.js', 'docs/README.md');
   assert.strictEqual(directNonMdResult.type, 'external', 'Direct non-.md filename should be external');
 
-  // Non-http/https URLs with :// (ftp, file, ssh, etc.) - hits final fallback return
-  const ftpResult = classifyUrl('ftp://files.example.com/data', 'docs/README.md');
-  assert.strictEqual(ftpResult.type, 'external', 'FTP links should be external');
+  // Non-http/https URLs with :// — rejected as dangerous schemes (defense-in-depth)
+  const sftpResult = classifyUrl('sftp://files.example.com/data', 'docs/README.md');
+  assert.strictEqual(sftpResult.type, 'rejected', 'SFTP links should be rejected');
 
   const fileResult = classifyUrl('file:///local/path', 'docs/README.md');
-  assert.strictEqual(fileResult.type, 'external', 'File protocol links should be external');
+  assert.strictEqual(fileResult.type, 'rejected', 'File protocol links should be rejected');
 
   const sshResult = classifyUrl('ssh://git@github.com/repo', 'docs/README.md');
-  assert.strictEqual(sshResult.type, 'external', 'SSH links should be external');
+  assert.strictEqual(sshResult.type, 'rejected', 'SSH links should be rejected');
+
+  // Dangerous schemes without :// — rejected by colon-before-slash guard
+  const jsResult = classifyUrl('javascript:alert(1)', 'docs/README.md');
+  assert.strictEqual(jsResult.type, 'rejected', 'javascript: scheme should be rejected');
+
+  const dataResult = classifyUrl('data:text/html,<h1>XSS</h1>', 'docs/README.md');
+  assert.strictEqual(dataResult.type, 'rejected', 'data: scheme should be rejected');
+
+  const vscodeResResult = classifyUrl('vscode-resource://extension/path', 'docs/README.md');
+  assert.strictEqual(vscodeResResult.type, 'rejected', 'vscode-resource: scheme should be rejected');
+
+  // Case-insensitive scheme rejection
+  const jsUpperResult = classifyUrl('JAVASCRIPT:alert(1)', 'docs/README.md');
+  assert.strictEqual(jsUpperResult.type, 'rejected', 'Upper-case JAVASCRIPT: should be rejected');
+
+  const dataMixedResult = classifyUrl('Data:text/html,test', 'docs/README.md');
+  assert.strictEqual(dataMixedResult.type, 'rejected', 'Mixed-case Data: should be rejected');
+
+  // Edge case: colon in relative path with ./ prefix is a valid filename, not a scheme
+  const colonInPath = classifyUrl('./file:name.md', 'docs/README.md');
+  assert.strictEqual(colonInPath.type, 'internal-md', 'Relative path with colon should be treated as internal md');
 
   console.log('  classifyUrl passed!');
 }

--- a/extensions/git-id-switcher/src/test/htmlTemplates.test.ts
+++ b/extensions/git-id-switcher/src/test/htmlTemplates.test.ts
@@ -27,9 +27,15 @@
  * ## Lang Attribute Tests - 1 test function:
  * 12. testLangAttributes - lang attribute presence across all templates
  *
- * Total: 12 test functions
+ * ## Link Intercept Tests (Issue-00195) - 3 test functions:
+ * 13. testIsHrefAllowed - href scheme allowlist validation
+ * 14. testAllowedHrefSchemes - Allowlist constant pinning
+ * 15. testBuildLinkInterceptScript - Script structure and security guards
+ *
+ * Total: 15 test functions
  * Coverage: buildCspString, getBaseStyles, buildDocumentHtml,
- *           buildLoadingHtml, buildErrorHtml
+ *           buildLoadingHtml, buildErrorHtml, isHrefAllowed,
+ *           buildLinkInterceptScript, ALLOWED_HREF_SCHEMES
  */
 
 import * as assert from 'node:assert';
@@ -37,15 +43,18 @@ import {
   type BodyClass,
   type ErrorType,
   type SanitizedHtml,
+  ALLOWED_HREF_SCHEMES,
   assertValidLang,
   assertValidNonce,
   buildCspString,
   buildHtmlShell,
+  buildLinkInterceptScript,
   CspValidationError,
   getBaseStyles,
   buildDocumentHtml,
   buildLoadingHtml,
   buildErrorHtml,
+  isHrefAllowed,
 } from '../ui/htmlTemplates';
 
 /**
@@ -1349,6 +1358,9 @@ function testBarrelReExportSurface(): void {
   assert.strictEqual(typeof buildDocumentHtml, 'function', 'buildDocumentHtml must be re-exported');
   assert.strictEqual(typeof buildLoadingHtml, 'function', 'buildLoadingHtml must be re-exported');
   assert.strictEqual(typeof buildErrorHtml, 'function', 'buildErrorHtml must be re-exported');
+  assert.strictEqual(typeof buildLinkInterceptScript, 'function', 'buildLinkInterceptScript must be re-exported');
+  assert.strictEqual(typeof isHrefAllowed, 'function', 'isHrefAllowed must be re-exported');
+  assert.ok(Array.isArray(ALLOWED_HREF_SCHEMES), 'ALLOWED_HREF_SCHEMES must be re-exported');
   assert.ok(
     CspValidationError.prototype instanceof Error,
     'CspValidationError must extend Error'
@@ -1432,6 +1444,130 @@ function testBuildHtmlShellExtraStylesGuard(): void {
 }
 
 // ============================================================================
+// Link Intercept Tests (Issue-00195)
+// ============================================================================
+
+/**
+ * Test `isHrefAllowed` — the host-side mirror of the client-side scheme
+ * allowlist. Verifies that only safe href values pass through.
+ */
+function testIsHrefAllowed(): void {
+  console.log('Testing isHrefAllowed...');
+
+  // Allowed: anchor links
+  assert.strictEqual(isHrefAllowed('#section'), true, '#section should be allowed');
+  assert.strictEqual(isHrefAllowed('#'), true, '# alone should be allowed');
+
+  // Allowed: relative paths
+  assert.strictEqual(isHrefAllowed('./file.md'), true, 'Relative ./file.md should be allowed');
+  assert.strictEqual(isHrefAllowed('../parent/file.md'), true, 'Relative ../parent should be allowed');
+  assert.strictEqual(isHrefAllowed('file.md'), true, 'Bare filename should be allowed');
+  assert.strictEqual(isHrefAllowed('docs/README.md'), true, 'Path without ./ should be allowed');
+
+  // Allowed: http(s) absolute URLs
+  assert.strictEqual(isHrefAllowed('https://example.com'), true, 'https should be allowed');
+  assert.strictEqual(isHrefAllowed('http://example.com'), true, 'http should be allowed');
+  assert.strictEqual(isHrefAllowed('https://github.com/user/repo'), true, 'https with path should be allowed');
+
+  // Rejected: javascript: scheme
+  assert.strictEqual(isHrefAllowed('javascript:alert(1)'), false, 'javascript: should be rejected');
+  assert.strictEqual(isHrefAllowed('javascript:void(0)'), false, 'javascript:void(0) should be rejected');
+
+  // Rejected: data: scheme
+  assert.strictEqual(isHrefAllowed('data:text/html,<h1>XSS</h1>'), false, 'data: should be rejected');
+  assert.strictEqual(isHrefAllowed('data:application/pdf;base64,abc'), false, 'data:application should be rejected');
+
+  // Rejected: file: scheme
+  assert.strictEqual(isHrefAllowed('file:///etc/passwd'), false, 'file:/// should be rejected');
+
+  // Rejected: vscode-resource: scheme
+  assert.strictEqual(isHrefAllowed('vscode-resource://extension/path'), false, 'vscode-resource: should be rejected');
+
+  // Rejected: insecure/dangerous protocol schemes
+  assert.strictEqual(isHrefAllowed('sftp://files.example.com'), false, 'sftp:// should be rejected');
+  assert.strictEqual(isHrefAllowed('ssh://git@github.com/repo'), false, 'ssh:// should be rejected');
+
+  // Rejected: malformed URLs
+  assert.strictEqual(isHrefAllowed('ht!tp://bad'), false, 'Malformed URL should be rejected');
+
+  // Rejected: case-insensitive scheme detection
+  assert.strictEqual(isHrefAllowed('JAVASCRIPT:alert(1)'), false, 'Upper-case JAVASCRIPT: should be rejected');
+  assert.strictEqual(isHrefAllowed('JavaScript:void(0)'), false, 'Mixed-case JavaScript: should be rejected');
+  assert.strictEqual(isHrefAllowed('DATA:text/html,test'), false, 'Upper-case DATA: should be rejected');
+
+  // Edge case: empty href is a relative path (harmless no-op)
+  assert.strictEqual(isHrefAllowed(''), true, 'Empty href is a relative path (no scheme)');
+
+  console.log('  isHrefAllowed passed!');
+}
+
+/**
+ * Test `ALLOWED_HREF_SCHEMES` constant — pin the allowlist so additions
+ * require a conscious decision (new schemes widen the attack surface).
+ */
+function testAllowedHrefSchemes(): void {
+  console.log('Testing ALLOWED_HREF_SCHEMES...');
+
+  assert.deepStrictEqual(
+    [...ALLOWED_HREF_SCHEMES],
+    ['http:', 'https:'],
+    'ALLOWED_HREF_SCHEMES must contain exactly http: and https:'
+  );
+
+  console.log('  ALLOWED_HREF_SCHEMES passed!');
+}
+
+/**
+ * Test `buildLinkInterceptScript` — verifies the generated script string
+ * contains the expected security guards and structural elements.
+ */
+function testBuildLinkInterceptScript(): void {
+  console.log('Testing buildLinkInterceptScript...');
+
+  const script = buildLinkInterceptScript();
+
+  // Must be a self-invoking function
+  assert.ok(script.includes('(function()'), 'Script must be IIFE');
+
+  // Must contain the scheme allowlist
+  assert.ok(script.includes("'http:'"), 'Script must include http: in allowlist');
+  assert.ok(script.includes("'https:'"), 'Script must include https: in allowlist');
+
+  // Must contain the isHrefSafe guard
+  assert.ok(script.includes('isHrefSafe'), 'Script must include isHrefSafe guard');
+
+  // Must check isHrefSafe before postMessage navigate
+  assert.ok(
+    /isHrefSafe[\s\S]*postMessage\(\{[\s\S]*command:\s*['"]navigate['"]/.test(script),
+    'isHrefSafe check must precede navigate postMessage'
+  );
+
+  // Must NOT register a keydown listener (WCAG 3.2.5)
+  assert.ok(
+    !script.includes("addEventListener('keydown'"),
+    'Script must NOT register keydown listener'
+  );
+
+  // Back button must use aria-disabled guard
+  assert.ok(
+    script.includes("getAttribute('aria-disabled')"),
+    'Script must guard back-btn on aria-disabled'
+  );
+
+  // Anchor scroll must move focus for AT users (tabindex + focus)
+  assert.ok(
+    script.includes("setAttribute('tabindex'"),
+    'Anchor scroll must set tabindex for AT focus'
+  );
+  assert.ok(
+    script.includes('.focus('),
+    'Anchor scroll must call focus() for AT reading position'
+  );
+
+  console.log('  buildLinkInterceptScript passed!');
+}
+
+// ============================================================================
 // Test Runner
 // ============================================================================
 
@@ -1488,6 +1624,12 @@ export function runHtmlTemplatesTests(): void {
     //A11y Improvements
     console.log('\n---A11y Improvements ---');
     testIssue00188A11yImprovements();
+
+    // Link Intercept Tests (Issue-00195)
+    console.log('\n--- Link Intercept Tests ---');
+    testIsHrefAllowed();
+    testAllowedHrefSchemes();
+    testBuildLinkInterceptScript();
 
     console.log('\n========================================');
     console.log('   All HTML template tests passed!     ');

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -9,10 +9,13 @@
  * allowing them to be tested in isolation without VS Code environment.
  */
 
-// Type-only import: erased at runtime. htmlTemplates.ts has a runtime
-// import of `escapeHtmlEntities` from this file, so promoting this to a
-// value import would create a real circular dependency. Keep `import type`.
+// Type-only import: erased at runtime. htmlTemplates/document.ts has a
+// runtime import of `escapeHtmlEntities` from this file, so importing from
+// the barrel (`./htmlTemplates`) would create a circular dependency.
+// Keep `import type` for the type, and import `isHrefAllowed` directly
+// from `linkIntercept.ts` (which has no dependency on this file).
 import type { SanitizedHtml } from './htmlTemplates';
+import { isHrefAllowed } from './htmlTemplates/linkIntercept';
 
 // ============================================================================
 // Constants
@@ -259,14 +262,20 @@ export function resolveRelativePath(basePath: string, relativePath: string): str
 }
 
 /**
- * Classify a URL and determine how to handle it
+ * Classify a URL and determine how to handle it.
+ *
+ * SECURITY: Dangerous schemes (`javascript:`, `data:`, `file:`,
+ * `vscode-resource:`, etc.) are rejected with type `'rejected'` so the
+ * caller never passes them to `vscode.env.openExternal`. This is
+ * defense-in-depth alongside the client-side allowlist in
+ * `linkIntercept.ts`. // defense-in-depth
  *
  * @param href - The href value from a link
  * @param currentPath - Current document path for relative resolution
  * @returns Classification with resolved path if applicable
  */
 export function classifyUrl(href: string, currentPath: string): {
-  type: 'internal-md' | 'anchor' | 'external';
+  type: 'internal-md' | 'anchor' | 'external' | 'rejected';
   resolvedPath?: string;
 } {
   // Anchor links
@@ -274,24 +283,27 @@ export function classifyUrl(href: string, currentPath: string): {
     return { type: 'anchor' };
   }
 
-  // Absolute URLs (external)
+  // Delegate scheme validation to the SSOT allowlist (linkIntercept.ts).
+  // isHrefAllowed returns true for anchors (handled above), http(s),
+  // and relative paths — false for everything else. // defense-in-depth
+  if (!isHrefAllowed(href)) {
+    return { type: 'rejected' };
+  }
+
+  // Absolute URLs (external) — only http(s) reach here
   if (href.startsWith('http://') || href.startsWith('https://')) {
     return { type: 'external' };
   }
 
-  // Relative paths
-  if (href.startsWith('./') || href.startsWith('../') || !href.includes('://')) {
-    const resolved = resolveRelativePath(currentPath, href);
+  // Relative paths — safe to resolve
+  const resolved = resolveRelativePath(currentPath, href);
 
-    // Check if it's a markdown file (internal navigation)
-    if (resolved.endsWith('.md')) {
-      return { type: 'internal-md', resolvedPath: resolved };
-    }
-
-    // Non-markdown files - treat as external (open on GitHub)
-    return { type: 'external' };
+  // Check if it's a markdown file (internal navigation)
+  if (resolved.endsWith('.md')) {
+    return { type: 'internal-md', resolvedPath: resolved };
   }
 
+  // Non-markdown files - treat as external (open on GitHub)
   return { type: 'external' };
 }
 

--- a/extensions/git-id-switcher/src/ui/documentationPublic.ts
+++ b/extensions/git-id-switcher/src/ui/documentationPublic.ts
@@ -274,6 +274,15 @@ async function handleNavigation(
       // Anchor links are handled in the Webview JS
       break;
     }
+
+    case 'rejected': {
+      // Dangerous scheme (javascript:, data:, file:, etc.) — silently
+      // dropped. The client-side allowlist should have already blocked
+      // this, so arrival here means either the allowlist was bypassed or
+      // a new code path was added without the client guard.
+      // defense-in-depth
+      break;
+    }
   }
 }
 

--- a/extensions/git-id-switcher/src/ui/htmlTemplates/document.ts
+++ b/extensions/git-id-switcher/src/ui/htmlTemplates/document.ts
@@ -18,6 +18,7 @@ import {
   getFocusVisibleForcedColorsRule,
   getFocusVisibleRule,
 } from './baseStyles';
+import { buildLinkInterceptScript } from './linkIntercept';
 import { buildHtmlShell } from './shell';
 import { type SanitizedHtml } from './types';
 
@@ -46,60 +47,7 @@ export function buildDocumentHtml(
   nonce: string,
   canGoBack: boolean
 ): string {
-  // Script to intercept link clicks / keyboard activation and back button.
-  //
-  // Keyboard policy for <a>: only Enter activates. Native <a> already fires
-  // a synthetic click on Enter, so the click listener covers it with zero
-  // extra code. Space is intentionally NOT handled — on <a> Space performs
-  // page scroll per the ARIA Authoring Practices, and synthesising
-  // navigation there would break user expectations (WCAG 3.2.5 Change on
-  // Request). The back button is a <button>, where both Enter and Space
-  // DO fire a native click, so its activation also flows through the
-  // click listener.
-  //
-  // Why aria-disabled on back-btn (not [disabled]): Safari/VoiceOver remove
-  // focus from [disabled] buttons entirely, trapping keyboard users who
-  // tab-land on the nav bar. aria-disabled keeps the button in the focus
-  // order and we guard the click handler instead.
-  const linkInterceptScript = `
-    (function() {
-      const vscode = acquireVsCodeApi();
-
-      document.addEventListener('click', function(e) {
-        // Back button takes precedence: if the click path traverses the
-        // back button, handle it first so link-in-button edge cases (a
-        // sanitizer future-regression adding <a> inside the button) cannot
-        // bypass the aria-disabled guard below.
-        const backBtn = e.target.closest && e.target.closest('#back-btn');
-        if (backBtn) {
-          if (backBtn.getAttribute('aria-disabled') === 'true') {
-            e.preventDefault();
-            return;
-          }
-          e.preventDefault();
-          vscode.postMessage({ command: 'back' });
-          return;
-        }
-
-        const link = e.target.closest && e.target.closest('a');
-        if (!link) return;
-        const href = link.getAttribute('href');
-        if (!href) return;
-
-        e.preventDefault();
-
-        if (href.startsWith('#')) {
-          const target = document.getElementById(href.slice(1));
-          if (target) {
-            target.scrollIntoView({ behavior: 'smooth' });
-          }
-          return;
-        }
-
-        vscode.postMessage({ command: 'navigate', href: href });
-      });
-    })();
-  `;
+  const linkInterceptScript = buildLinkInterceptScript();
 
   const extraStyles = `    /* External link indicator.
        The "/ <alt-text>" syntax (CSS Generated Content L3) provides the

--- a/extensions/git-id-switcher/src/ui/htmlTemplates/index.ts
+++ b/extensions/git-id-switcher/src/ui/htmlTemplates/index.ts
@@ -21,5 +21,10 @@ export {
 export { getBaseStyles } from './baseStyles';
 export { buildHtmlShell } from './shell';
 export { buildDocumentHtml } from './document';
+export {
+  ALLOWED_HREF_SCHEMES,
+  buildLinkInterceptScript,
+  isHrefAllowed,
+} from './linkIntercept';
 export { buildLoadingHtml } from './loading';
 export { type ErrorType, buildErrorHtml } from './error';

--- a/extensions/git-id-switcher/src/ui/htmlTemplates/linkIntercept.ts
+++ b/extensions/git-id-switcher/src/ui/htmlTemplates/linkIntercept.ts
@@ -1,0 +1,149 @@
+/**
+ * Webview Link Intercept Script
+ *
+ * Client-side JavaScript injected into the webview via `<script nonce>`.
+ * Intercepts link clicks and back-button presses, posting messages to the
+ * extension host. Extracted from document.ts (Issue-00195) so the security
+ * logic (href scheme allowlist) is isolated and testable.
+ *
+ * SECURITY: Only `http:`, `https:`, and relative paths (no `://`) are
+ * forwarded to the extension host. Dangerous schemes (`javascript:`,
+ * `data:`, `file:`, `vscode-resource:`, etc.) are silently dropped at the
+ * client boundary before `postMessage` — defense-in-depth alongside the
+ * host-side `classifyUrl` reject.
+ *
+ * @author Null;Variant
+ * @license MIT
+ */
+
+/**
+ * Href schemes that are safe to forward to the extension host.
+ * Everything else is silently dropped.
+ *
+ * Exported for testing only — not part of the webview runtime (the script
+ * string embeds a copy of the list as a JS literal).
+ */
+export const ALLOWED_HREF_SCHEMES = ['http:', 'https:'] as const;
+
+/**
+ * Check whether an href value is safe to forward to the extension host.
+ *
+ * Allowed:
+ *  - Anchor links (`#…`)
+ *  - Relative paths (no `://` substring)
+ *  - `http:` / `https:` absolute URLs
+ *
+ * Rejected (returns `false`):
+ *  - `javascript:`, `data:`, `file:`, `vscode-resource:`, or any other
+ *    scheme not in the allowlist.
+ *
+ * Exported so the host-side code and tests can reuse the same logic.
+ */
+export function isHrefAllowed(href: string): boolean {
+  // Anchor links are always safe (handled in-page, never posted).
+  if (href.startsWith('#')) {
+    return true;
+  }
+
+  // No scheme separator → relative path → safe, unless a colon appears
+  // before the first slash (scheme-like prefix without double-slash that
+  // browsers still interpret, e.g. `javascript:alert(1)`).
+  if (!href.includes('://')) {
+    const colonIndex = href.indexOf(':');
+    if (colonIndex === -1) return true;
+    const slashIndex = href.indexOf('/');
+    // Colon with no slash at all, or colon before first slash → scheme
+    return slashIndex !== -1 && colonIndex > slashIndex;
+  }
+
+  // Absolute URL — only http(s) allowed.
+  try {
+    const url = new URL(href);
+    return (ALLOWED_HREF_SCHEMES as readonly string[]).includes(url.protocol);
+  } catch {
+    // Malformed URL → reject.
+    return false;
+  }
+}
+
+/**
+ * Build the link-intercept `<script>` body for injection into the webview.
+ *
+ * The returned string is a self-invoking function that:
+ *  1. Acquires the VS Code API.
+ *  2. Listens for `click` events on `<a>` and the back button.
+ *  3. Validates `href` against a scheme allowlist before posting.
+ *
+ * Keyboard policy: only Enter activates `<a>` (native click fires on
+ * Enter). Space is intentionally NOT handled — per ARIA Authoring
+ * Practices, Space on `<a>` performs page scroll; synthesising navigation
+ * would violate WCAG 3.2.5 (Change on Request). The back `<button>`
+ * fires native click on both Enter and Space.
+ *
+ * Why `aria-disabled` on back-btn (not `[disabled]`): Safari/VoiceOver
+ * removes focus from `[disabled]` buttons entirely, trapping keyboard
+ * users who tab to the nav bar.
+ */
+export function buildLinkInterceptScript(): string {
+  return `
+    (function() {
+      var ALLOWED_SCHEMES = ['http:', 'https:'];
+
+      function isHrefSafe(href) {
+        if (href.startsWith('#')) return true;
+        if (!href.includes('://')) {
+          var colonIdx = href.indexOf(':');
+          if (colonIdx === -1) return true;
+          var slashIdx = href.indexOf('/');
+          return slashIdx !== -1 && colonIdx > slashIdx;
+        }
+        try {
+          var url = new URL(href);
+          return ALLOWED_SCHEMES.indexOf(url.protocol) !== -1;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      var vscode = acquireVsCodeApi();
+
+      document.addEventListener('click', function(e) {
+        var backBtn = e.target.closest && e.target.closest('#back-btn');
+        if (backBtn) {
+          if (backBtn.getAttribute('aria-disabled') === 'true') {
+            e.preventDefault();
+            return;
+          }
+          e.preventDefault();
+          vscode.postMessage({ command: 'back' });
+          return;
+        }
+
+        var link = e.target.closest && e.target.closest('a');
+        if (!link) return;
+        var href = link.getAttribute('href');
+        if (!href) return;
+
+        e.preventDefault();
+
+        if (href.startsWith('#')) {
+          var target = document.getElementById(href.slice(1));
+          if (target) {
+            target.scrollIntoView({ behavior: 'smooth' });
+            // Move AT reading position to the scroll target so
+            // screen-reader users land at the anchored section.
+            if (!target.getAttribute('tabindex')) {
+              target.setAttribute('tabindex', '-1');
+            }
+            target.focus({ preventScroll: true });
+          }
+          return;
+        }
+
+        if (!isHrefSafe(href)) return;
+
+        vscode.postMessage({ command: 'navigate', href: href });
+      });
+    })();
+  `;
+}


### PR DESCRIPTION
## Summary

- Extract inline 36-line link-intercept script from `document.ts` into dedicated `linkIntercept.ts` module
- Add client-side href scheme allowlist (`http:`/`https:`/relative paths only) — dangerous schemes (`javascript:`, `data:`, `file:`, `vscode-resource:`) silently dropped before `postMessage`
- Host-side `classifyUrl` delegates scheme validation to shared `isHrefAllowed` SSOT, returns `'rejected'` for dangerous schemes (defense-in-depth)
- Anchor scroll now moves AT focus via `tabindex="-1"` + `focus()` for screen-reader users

## Changed files

| File | Change |
|------|--------|
| `src/ui/htmlTemplates/linkIntercept.ts` | NEW — extracted script + `isHrefAllowed` + `buildLinkInterceptScript` |
| `src/ui/htmlTemplates/document.ts` | Inline script replaced with `buildLinkInterceptScript()` call |
| `src/ui/htmlTemplates/index.ts` | Added barrel exports for new module |
| `src/ui/documentationInternal.ts` | `classifyUrl` delegates to `isHrefAllowed` SSOT, added `'rejected'` type |
| `src/ui/documentationPublic.ts` | `handleNavigation` handles `'rejected'` case (silent drop) |
| `src/test/htmlTemplates.test.ts` | New tests: `isHrefAllowed`, `ALLOWED_HREF_SCHEMES`, `buildLinkInterceptScript` |
| `src/test/documentation.test.ts` | Updated `classifyUrl` tests for `'rejected'` type + dangerous schemes |

## Test plan

- [x] TypeScript compile (`tsc --noEmit`) passes
- [x] ESLint (`--max-warnings=0`) passes
- [x] All unit tests pass
- [x] Statement coverage 100% maintained
- [x] `javascript:`, `data:`, `file:`, `vscode-resource:` schemes rejected by both client and host
- [x] Case-insensitive scheme rejection (`JAVASCRIPT:`, `DATA:`) tested
- [x] Empty string boundary value tested
- [x] Anchor scroll moves AT focus for screen-reader users