### PR TITLE
refactor(git-id-switcher): narrow htmlTemplates ESLint exception to csp.ts only

### DIFF
--- a/extensions/git-id-switcher/eslint.config.mjs
+++ b/extensions/git-id-switcher/eslint.config.mjs
@@ -160,7 +160,7 @@ export default [
     },
   },
   {
-    files: ["**/validators/common.ts", "**/core/constants.ts"],
+    files: ["**/validators/common.ts", "**/core/constants.ts", "**/ui/htmlTemplates/csp.ts"],
     rules: {
       "no-restricted-syntax": "off",
       "no-magic-numbers": "off",
@@ -186,7 +186,6 @@ export default [
       "**/ui/documentationInternal.ts",
       "**/ui/documentationPublic.ts",
       "**/ui/webview.ts",
-      "**/ui/htmlTemplates/**",
     ],
     rules: {
       "no-magic-numbers": "off",

--- a/extensions/git-id-switcher/src/ui/htmlTemplates/csp.ts
+++ b/extensions/git-id-switcher/src/ui/htmlTemplates/csp.ts
@@ -114,6 +114,16 @@ export function coerceLang(lang: string): string {
 }
 
 /**
+ * Detects the `</style` substring (case-insensitive) in a raw-text element
+ * context. HTML5 raw-text elements (`<style>`, `<script>`) terminate at the
+ * first occurrence of their own closing tag — any `</style` inside a `<style>`
+ * block therefore breaks out of the element and re-enters HTML context,
+ * enabling attribute injection. Used by `buildHtmlShell` to fail-closed on
+ * `extraStyles` before interpolation.
+ */
+export const STYLE_CLOSE_PATTERN = /<\/style/i;
+
+/**
  * Build Content Security Policy header value
  *
  * Defense-in-depth:

--- a/extensions/git-id-switcher/src/ui/htmlTemplates/shell.ts
+++ b/extensions/git-id-switcher/src/ui/htmlTemplates/shell.ts
@@ -21,6 +21,7 @@ import { escapeHtmlEntities } from '../documentationInternal';
 import { getBaseStyles } from './baseStyles';
 import {
   CspValidationError,
+  STYLE_CLOSE_PATTERN,
   assertValidLang,
   assertValidNonce,
   buildCspString,
@@ -112,7 +113,7 @@ export function buildHtmlShell(opts: Readonly<HtmlShellOptions>): string {
   // brand. `body` is deliberately NOT covered here because document.ts
   // legitimately embeds a `</script>` closing tag and `body` has a separate
   // trust boundary (`SanitizedHtml` on `buildDocumentHtml#content`).
-  if (/<\/style/i.test(opts.extraStyles)) {
+  if (STYLE_CLOSE_PATTERN.test(opts.extraStyles)) {
     throw new CspValidationError('buildHtmlShell: extraStyles contains </style sequence');
   }
 


### PR DESCRIPTION
## Summary

- Remove the blanket `**/ui/htmlTemplates/**` exemption from the temporary `no-magic-numbers` / `no-restricted-syntax` override block
- Promote `csp.ts` to the permanent pattern-constants exemption alongside `validators/common.ts` and `core/constants.ts`
- Extract the inline `</style>` breakout regex from `shell.ts` into `STYLE_CLOSE_PATTERN` in `csp.ts` so `shell.ts` no longer needs an exemption

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint .` passes with zero warnings
- [x] `npm run test:coverage` passes with 100% statement coverage
- [x] Verified all 9 htmlTemplates files pass lint without the blanket exemption