### PR TITLE
chore(deps): ignore diff in Renovate — v9 breaks mocha transitive

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,5 @@
       "automerge": false
     }
   ],
-  "ignoreDeps": ["@types/vscode"]
+  "ignoreDeps": ["@types/vscode", "diff"]
 }


### PR DESCRIPTION
## Summary

Add `diff` to Renovate's `ignoreDeps` list. The `diff` package is a transitive dependency of mocha (which requires `^7.0.0`) and is only present in `overrides` to pin it above a known advisory threshold (`^8.0.3`).

## Why

Renovate PR #471 proposed bumping the override to `^9.0.0`. diff v9 drops CommonJS support, which causes npm to stop placing `node_modules/diff` entirely — resulting in `Cannot find module 'diff'` errors during the E2E test suite on all three OS targets (ubuntu/macos/windows).

Since diff is not a direct dependency and the current v8 pin already addresses the known advisory, Renovate should not propose further updates until mocha itself adopts a compatible newer diff.

## Test plan

- [ ] Renovate does not re-open a diff update PR after this merges