### PR TITLE
fix(ci): add pre-commit-ci[bot] to DCO exclude pattern

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -36,4 +36,4 @@ jobs:
         run: |
           echo 'dco-check==0.5.0 --hash=sha256:3c027d2d47b5cbb03f7e2a25ec8ffb56d8a33c49563c8fcd2cef443ebf3cff0d' > /tmp/requirements-dco.txt
           pip install --require-hashes --no-deps -r /tmp/requirements-dco.txt
-          dco-check --exclude-pattern '(dependabot|renovate)\[bot\]'
+          dco-check --exclude-pattern '(dependabot|renovate|pre-commit-ci)\[bot\]'


### PR DESCRIPTION
## Summary

- Add `pre-commit-ci` to the DCO check bot exclusion pattern in `.github/workflows/dco.yml`
- pre-commit-ci[bot] commits do not include `Signed-off-by` trailers, causing DCO Check to fail on autoupdate PRs (e.g. #500)

## Context

The existing exclude pattern covered `dependabot[bot]` and `renovate[bot]` but not `pre-commit-ci[bot]`. All three are automated bots that cannot sign off commits.

## Test plan

- [x] After merge, re-run DCO Check on #500 to verify it passes