### PR TITLE
fix: guide Windows users to use ~/.ssh/ format for SSH key paths

### DIFF
--- a/extensions/git-id-switcher/CHANGELOG.md
+++ b/extensions/git-id-switcher/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.6] - 2026-05-13
+
+### Fixed
+
+- **Windows SSH key path validation** ([#492](https://github.com/nullvariant/nullvariant-vscode-extensions/issues/492)): Windows users entering drive letter paths (`C:/...` or `C:\...`) now receive a clear error message guiding them to use the cross-platform `~/.ssh/` format instead of a generic "Invalid SSH key path" error
+- **Config schema consistency**: `configSchema.ts` now rejects Windows drive letter paths at the schema level, consistent with all other validation layers
+
+### Changed
+
+- **Localization**: Added SSH key path guidance message in all 17 supported languages
+
 ## [0.19.5] - 2026-05-09
 
 ### Added

--- a/extensions/git-id-switcher/l10n/bundle.l10n.bg.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.bg.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "Имейлът е твърде дълъг (макс. {0} символа)",
   "Invalid email format": "Невалиден имейл формат",
   "Invalid SSH key path": "Невалиден път до SSH ключ",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Невалиден път до SSH ключ: използвайте формат ~/.ssh/ (напр. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Невалиден формат на път до SSH ключ",
   "SSH key path must be under ~/.ssh/ directory": "Пътят до SSH ключа трябва да бъде в директорията ~/.ssh/",
   "SSH key file validation failed": "Неуспешна валидация на SSH ключ файла",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.cs.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.cs.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "E-mail je příliš dlouhý (max {0} znaků)",
   "Invalid email format": "Neplatný formát e-mailu",
   "Invalid SSH key path": "Neplatná cesta k SSH klíči",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Neplatná cesta k SSH klíči: použijte formát ~/.ssh/ (např. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Neplatný formát cesty k SSH klíči",
   "SSH key path must be under ~/.ssh/ directory": "Cesta k SSH klíči musí být v adresáři ~/.ssh/",
   "SSH key file validation failed": "Neúspěšná validace SSH klíče",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.de.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.de.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "E-Mail ist zu lang (max. {0} Zeichen)",
   "Invalid email format": "Ungültiges E-Mail-Format",
   "Invalid SSH key path": "Ungültiger SSH-Schlüsselpfad",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Ungültiger SSH-Schlüsselpfad: Verwenden Sie das ~/.ssh/-Format (z.B. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Ungültiges SSH-Schlüsselpfad-Format",
   "SSH key path must be under ~/.ssh/ directory": "SSH-Schlüsselpfad muss im Verzeichnis ~/.ssh/ sein",
   "SSH key file validation failed": "SSH-Schlüsseldatei-Validierung fehlgeschlagen",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.es.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.es.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "El correo es demasiado largo (máx. {0} caracteres)",
   "Invalid email format": "Formato de correo electrónico inválido",
   "Invalid SSH key path": "Ruta de clave SSH inválida",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Ruta de clave SSH no válida: use el formato ~/.ssh/ (ej. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Formato de ruta de clave SSH inválido",
   "SSH key path must be under ~/.ssh/ directory": "La ruta de clave SSH debe estar en el directorio ~/.ssh/",
   "SSH key file validation failed": "Falló la validación del archivo de clave SSH",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.fr.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.fr.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "L'e-mail est trop long (max {0} caractères)",
   "Invalid email format": "Format d'e-mail invalide",
   "Invalid SSH key path": "Chemin de clé SSH invalide",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Chemin de clé SSH invalide : utilisez le format ~/.ssh/ (ex. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Format de chemin de clé SSH invalide",
   "SSH key path must be under ~/.ssh/ directory": "Le chemin de clé SSH doit être dans le répertoire ~/.ssh/",
   "SSH key file validation failed": "Échec de la validation du fichier de clé SSH",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.hu.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.hu.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "Az e-mail túl hosszú (max {0} karakter)",
   "Invalid email format": "Érvénytelen e-mail formátum",
   "Invalid SSH key path": "Érvénytelen SSH kulcs útvonal",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Érvénytelen SSH kulcs útvonal: használja a ~/.ssh/ formátumot (pl. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Érvénytelen SSH kulcs útvonal formátum",
   "SSH key path must be under ~/.ssh/ directory": "Az SSH kulcs útvonalnak a ~/.ssh/ könyvtárban kell lennie",
   "SSH key file validation failed": "Az SSH kulcs fájl ellenőrzése sikertelen",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.it.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.it.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "L'email è troppo lunga (max {0} caratteri)",
   "Invalid email format": "Formato email non valido",
   "Invalid SSH key path": "Percorso chiave SSH non valido",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Percorso chiave SSH non valido: usa il formato ~/.ssh/ (es. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Formato percorso chiave SSH non valido",
   "SSH key path must be under ~/.ssh/ directory": "Il percorso della chiave SSH deve essere nella directory ~/.ssh/",
   "SSH key file validation failed": "Validazione del file chiave SSH fallita",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.ja.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.ja.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "メールアドレスが長すぎます（最大{0}文字）",
   "Invalid email format": "メールアドレスの形式が正しくありません",
   "Invalid SSH key path": "無効なSSH鍵パスです",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "無効なSSHキーパス: ~/.ssh/ 形式を使用してください（例: ~/.ssh/id_ed25519）",
   "Invalid SSH key path format": "無効なSSH鍵パス形式です",
   "SSH key path must be under ~/.ssh/ directory": "SSH鍵のパスは ~/.ssh/ 内である必要があります",
   "SSH key file validation failed": "SSH鍵ファイルの検証に失敗しました",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.json
@@ -65,6 +65,7 @@
   "Email is too long (max {0} characters)": "Email is too long (max {0} characters)",
   "Invalid email format": "Invalid email format",
   "Invalid SSH key path": "Invalid SSH key path",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Invalid SSH key path format",
   "SSH key path must be under ~/.ssh/ directory": "SSH key path must be under ~/.ssh/ directory",
   "SSH key file validation failed": "SSH key file validation failed",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.ko.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.ko.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "이메일이 너무 깁니다 (최대 {0}자)",
   "Invalid email format": "이메일 형식이 올바르지 않습니다",
   "Invalid SSH key path": "잘못된 SSH 키 경로",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "잘못된 SSH 키 경로: ~/.ssh/ 형식을 사용하세요 (예: ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "잘못된 SSH 키 경로 형식",
   "SSH key path must be under ~/.ssh/ directory": "SSH 키 경로는 ~/.ssh/ 디렉터리 내에 있어야 합니다",
   "SSH key file validation failed": "SSH 키 파일 검증 실패",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.pl.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.pl.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "E-mail jest za długi (maks. {0} znaków)",
   "Invalid email format": "Nieprawidłowy format e-mail",
   "Invalid SSH key path": "Nieprawidłowa ścieżka klucza SSH",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Nieprawidłowa ścieżka klucza SSH: użyj formatu ~/.ssh/ (np. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Nieprawidłowy format ścieżki klucza SSH",
   "SSH key path must be under ~/.ssh/ directory": "Ścieżka klucza SSH musi być w katalogu ~/.ssh/",
   "SSH key file validation failed": "Walidacja pliku klucza SSH nie powiodła się",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.pt-BR.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.pt-BR.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "O e-mail é muito longo (máx. {0} caracteres)",
   "Invalid email format": "Formato de e-mail inválido",
   "Invalid SSH key path": "Caminho de chave SSH inválido",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Caminho de chave SSH inválido: use o formato ~/.ssh/ (ex. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Formato de caminho de chave SSH inválido",
   "SSH key path must be under ~/.ssh/ directory": "O caminho da chave SSH deve estar no diretório ~/.ssh/",
   "SSH key file validation failed": "Falha na validação do arquivo de chave SSH",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.ru.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.ru.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "Email слишком длинный (макс. {0} символов)",
   "Invalid email format": "Неверный формат email",
   "Invalid SSH key path": "Неверный путь к SSH ключу",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Неверный путь к SSH ключу: используйте формат ~/.ssh/ (например, ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Неверный формат пути SSH ключа",
   "SSH key path must be under ~/.ssh/ directory": "Путь к SSH ключу должен быть в каталоге ~/.ssh/",
   "SSH key file validation failed": "Не удалось проверить файл SSH ключа",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.tr.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.tr.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "E-posta çok uzun (maks. {0} karakter)",
   "Invalid email format": "Geçersiz e-posta formatı",
   "Invalid SSH key path": "Geçersiz SSH anahtar yolu",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Geçersiz SSH anahtar yolu: ~/.ssh/ biçimini kullanın (ör. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Geçersiz SSH anahtar yolu formatı",
   "SSH key path must be under ~/.ssh/ directory": "SSH anahtar yolu ~/.ssh/ dizininde olmalıdır",
   "SSH key file validation failed": "SSH anahtar dosyası doğrulaması başarısız",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.uk.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.uk.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "Email занадто довгий (макс. {0} символів)",
   "Invalid email format": "Невірний формат email",
   "Invalid SSH key path": "Невірний шлях до SSH ключа",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "Невірний шлях до SSH ключа: використовуйте формат ~/.ssh/ (напр. ~/.ssh/id_ed25519)",
   "Invalid SSH key path format": "Невірний формат шляху SSH ключа",
   "SSH key path must be under ~/.ssh/ directory": "Шлях до SSH ключа має бути в каталозі ~/.ssh/",
   "SSH key file validation failed": "Не вдалося перевірити файл SSH ключа",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.zh-CN.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.zh-CN.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "邮箱过长（最多{0}个字符）",
   "Invalid email format": "邮箱格式无效",
   "Invalid SSH key path": "无效的SSH密钥路径",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "无效的SSH密钥路径：请使用 ~/.ssh/ 格式（例如 ~/.ssh/id_ed25519）",
   "Invalid SSH key path format": "无效的SSH密钥路径格式",
   "SSH key path must be under ~/.ssh/ directory": "SSH密钥路径必须在 ~/.ssh/ 目录下",
   "SSH key file validation failed": "SSH密钥文件验证失败",

--- a/extensions/git-id-switcher/l10n/bundle.l10n.zh-TW.json
+++ b/extensions/git-id-switcher/l10n/bundle.l10n.zh-TW.json
@@ -66,6 +66,7 @@
   "Email is too long (max {0} characters)": "電子郵件過長（最多{0}個字元）",
   "Invalid email format": "電子郵件格式無效",
   "Invalid SSH key path": "無效的SSH金鑰路徑",
+  "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)": "無效的SSH金鑰路徑：請使用 ~/.ssh/ 格式（例如 ~/.ssh/id_ed25519）",
   "Invalid SSH key path format": "無效的SSH金鑰路徑格式",
   "SSH key path must be under ~/.ssh/ directory": "SSH金鑰路徑必須在 ~/.ssh/ 目錄下",
   "SSH key file validation failed": "SSH金鑰檔案驗證失敗",

--- a/extensions/git-id-switcher/package.json
+++ b/extensions/git-id-switcher/package.json
@@ -2,7 +2,7 @@
   "name": "git-id-switcher",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "publisher": "nullvariant",
   "icon": "images/icon.png",
   "engines": {

--- a/extensions/git-id-switcher/src/identity/configSchema.ts
+++ b/extensions/git-id-switcher/src/identity/configSchema.ts
@@ -7,8 +7,12 @@
  * @see https://json-schema.org/
  */
 
-import { isSingleGrapheme } from '../ui/displayLimits';
-import { isValidEmail, isValidHex, SSH_HOST_PATTERN } from '../validators/common';
+import { isSingleGrapheme } from "../ui/displayLimits";
+import {
+  isValidEmail,
+  isValidHex,
+  SSH_HOST_PATTERN,
+} from "../validators/common";
 import {
   PATH_MAX,
   MAX_ID_LENGTH,
@@ -21,19 +25,19 @@ import {
   MIN_GPG_KEY_LENGTH,
   MAX_GPG_KEY_LENGTH,
   DANGEROUS_PROTOTYPE_KEYS,
-} from '../core/constants';
+} from "../core/constants";
 
 /**
  * Property schema definition
  */
 interface PropertySchema {
-  type: 'string' | 'number' | 'boolean' | 'object' | 'array';
+  type: "string" | "number" | "boolean" | "object" | "array";
   description: string;
   required?: boolean;
   maxLength?: number;
   minLength?: number;
   pattern?: string;
-  format?: 'email' | 'uri' | 'date' | 'hex' | 'single-grapheme';
+  format?: "email" | "uri" | "date" | "hex" | "single-grapheme";
   minimum?: number;
   maximum?: number;
 }
@@ -45,75 +49,75 @@ interface PropertySchema {
  */
 export const IDENTITY_SCHEMA: Record<string, PropertySchema> = {
   id: {
-    type: 'string',
-    description: 'Unique identifier (alphanumeric, underscores, hyphens)',
+    type: "string",
+    description: "Unique identifier (alphanumeric, underscores, hyphens)",
     required: true,
     minLength: 1,
     maxLength: MAX_ID_LENGTH,
-    pattern: '^[a-zA-Z0-9_-]+$',
+    pattern: "^[a-zA-Z0-9_-]+$",
   },
   icon: {
-    type: 'string',
-    description: 'Display emoji (single emoji character)',
+    type: "string",
+    description: "Display emoji (single emoji character)",
     maxLength: MAX_ICON_BYTE_LENGTH, // Allow for complex composed emoji (byte length)
-    format: 'single-grapheme', // Validate as single visible character
+    format: "single-grapheme", // Validate as single visible character
   },
   name: {
-    type: 'string',
-    description: 'Git user.name (pure name without service info)',
+    type: "string",
+    description: "Git user.name (pure name without service info)",
     required: true,
     minLength: 1,
     maxLength: MAX_NAME_LENGTH,
     // Disallow control characters and shell metacharacters
     // Note: Semicolon (;) is intentionally ALLOWED - valid in names like "Null;Variant"
-    pattern: '^[^\\x00-\\x1f\\x7f`$(){}|&<>]+$',
+    pattern: "^[^\\x00-\\x1f\\x7f`$(){}|&<>]+$",
   },
   service: {
-    type: 'string',
-    description: 'Git hosting service (e.g., GitHub, GitLab, Bitbucket)',
+    type: "string",
+    description: "Git hosting service (e.g., GitHub, GitLab, Bitbucket)",
     maxLength: MAX_SERVICE_LENGTH,
     // Allow Unicode (for i18n) but block control characters and command substitution
     // Only block backtick (`) and dollar sign ($) for command injection prevention
     // Allow ampersand (&) for company names like "AT&T"
-    pattern: '^[^\\x00-\\x1f\\x7f`$]+$',
+    pattern: "^[^\\x00-\\x1f\\x7f`$]+$",
   },
   email: {
-    type: 'string',
-    description: 'Git user.email',
+    type: "string",
+    description: "Git user.email",
     required: true,
     maxLength: MAX_EMAIL_LENGTH, // RFC 5321 max email length
-    format: 'email',
+    format: "email",
   },
   description: {
-    type: 'string',
-    description: 'Optional description of this identity',
+    type: "string",
+    description: "Optional description of this identity",
     maxLength: MAX_DESCRIPTION_LENGTH,
     // Allow Unicode (for i18n) but block control characters and command substitution
     // Only block backtick (`) and dollar sign ($) for command injection prevention
     // Allow angle brackets (<>) for display formatting like "<main>"
-    pattern: '^[^\\x00-\\x1f\\x7f`$]+$',
+    pattern: "^[^\\x00-\\x1f\\x7f`$]+$",
   },
   sshKeyPath: {
-    type: 'string',
-    description: 'Path to SSH private key',
+    type: "string",
+    description: "Path to SSH private key",
     maxLength: PATH_MAX, // PATH_MAX on most systems
-    // Must be absolute path (Unix: /, ~) or Windows drive letter (C:), no dangerous chars
-    // Backslash (\) is allowed for Windows paths
-    pattern: '^([~/]|[A-Za-z]:)[^\\x00-\\x1f\\x7f`$(){}|;&<>]*$',
+    // Unix absolute path (/) or tilde path (~) only — no dangerous chars
+    // Windows drive letter paths rejected: use ~/.ssh/ for cross-platform compatibility
+    pattern: "^[~/][^\\x00-\\x1f\\x7f`$(){}|;&<>]*$",
   },
   sshHost: {
-    type: 'string',
-    description: 'SSH config host alias',
+    type: "string",
+    description: "SSH config host alias",
     maxLength: MAX_SSH_HOST_LENGTH, // DNS max length
     // DNS-safe characters only
     pattern: SSH_HOST_PATTERN,
   },
   gpgKeyId: {
-    type: 'string',
-    description: 'GPG key ID (hex)',
+    type: "string",
+    description: "GPG key ID (hex)",
     minLength: MIN_GPG_KEY_LENGTH,
     maxLength: MAX_GPG_KEY_LENGTH, // SHA-1 fingerprint length
-    format: 'hex',
+    format: "hex",
   },
 } as const;
 
@@ -142,7 +146,7 @@ function validateStringLength(
   field: string,
   value: string,
   schema: PropertySchema,
-  errors: SchemaError[]
+  errors: SchemaError[],
 ): void {
   if (schema.minLength !== undefined && value.length < schema.minLength) {
     errors.push({
@@ -168,7 +172,7 @@ function validateStringPattern(
   field: string,
   value: string,
   pattern: string,
-  errors: SchemaError[]
+  errors: SchemaError[],
 ): void {
   try {
     const regex = new RegExp(pattern);
@@ -179,12 +183,12 @@ function validateStringPattern(
         value,
       });
     }
-  /* c8 ignore start: defensive - schema patterns are hardcoded valid */
+    /* c8 ignore start: defensive - schema patterns are hardcoded valid */
   } catch {
     // SECURITY: Invalid regex pattern in schema is a programming error
     errors.push({
       field,
-      message: 'Invalid validation pattern (internal error)',
+      message: "Invalid validation pattern (internal error)",
       value: undefined,
     });
   }
@@ -198,17 +202,21 @@ function validateStringPattern(
 function validateStringFormat(
   field: string,
   value: string,
-  format: PropertySchema['format'],
-  errors: SchemaError[]
+  format: PropertySchema["format"],
+  errors: SchemaError[],
 ): void {
-  if (format === 'email' && !isValidEmail(value)) {
-    errors.push({ field, message: 'Invalid email format', value });
+  if (format === "email" && !isValidEmail(value)) {
+    errors.push({ field, message: "Invalid email format", value });
   }
-  if (format === 'hex' && !isValidHex(value)) {
-    errors.push({ field, message: 'Must be hexadecimal', value });
+  if (format === "hex" && !isValidHex(value)) {
+    errors.push({ field, message: "Must be hexadecimal", value });
   }
-  if (format === 'single-grapheme' && !isSingleGrapheme(value)) {
-    errors.push({ field, message: 'Must be a single visible character (emoji or letter)', value });
+  if (format === "single-grapheme" && !isSingleGrapheme(value)) {
+    errors.push({
+      field,
+      message: "Must be a single visible character (emoji or letter)",
+      value,
+    });
   }
 }
 
@@ -220,7 +228,7 @@ function validateStringValue(
   field: string,
   value: string,
   schema: PropertySchema,
-  errors: SchemaError[]
+  errors: SchemaError[],
 ): void {
   validateStringLength(field, value, schema, errors);
   if (schema.pattern) {
@@ -240,10 +248,14 @@ function validateNumberValue(
   field: string,
   value: number,
   schema: PropertySchema,
-  errors: SchemaError[]
+  errors: SchemaError[],
 ): void {
   if (schema.minimum !== undefined && value < schema.minimum) {
-    errors.push({ field, message: `Must be at least ${schema.minimum}`, value });
+    errors.push({
+      field,
+      message: `Must be at least ${schema.minimum}`,
+      value,
+    });
   }
   if (schema.maximum !== undefined && value > schema.maximum) {
     errors.push({ field, message: `Must be at most ${schema.maximum}`, value });
@@ -258,11 +270,11 @@ function validateProperty(
   field: string,
   value: unknown,
   schema: PropertySchema,
-  errors: SchemaError[]
+  errors: SchemaError[],
 ): void {
   // Empty string is treated as "not set" for optional fields.
   // SECURITY: Required fields (id, name, email) are still protected via else-if below.
-  if (value !== undefined && value !== null && value !== '') {
+  if (value !== undefined && value !== null && value !== "") {
     if (typeof value !== schema.type) {
       errors.push({
         field,
@@ -272,17 +284,17 @@ function validateProperty(
       return;
     }
 
-    if (schema.type === 'string' && typeof value === 'string') {
+    if (schema.type === "string" && typeof value === "string") {
       validateStringValue(field, value, schema, errors);
     }
 
     /* c8 ignore start: no number fields in current schema - reserved for future */
-    if (schema.type === 'number' && typeof value === 'number') {
+    if (schema.type === "number" && typeof value === "number") {
       validateNumberValue(field, value, schema, errors);
     }
     /* c8 ignore stop */
   } else if (schema.required) {
-    errors.push({ field, message: 'Required field is missing' });
+    errors.push({ field, message: "Required field is missing" });
   }
 }
 
@@ -298,18 +310,26 @@ function validateProperty(
  *   result.errors.forEach(e => console.error(`${e.field}: ${e.message}`));
  * }
  */
-export function validateIdentitySchema(identity: unknown): SchemaValidationResult {
+export function validateIdentitySchema(
+  identity: unknown,
+): SchemaValidationResult {
   const errors: SchemaError[] = [];
 
   // Must be an object
-  if (typeof identity !== 'object' || identity === null || Array.isArray(identity)) {
+  if (
+    typeof identity !== "object" ||
+    identity === null ||
+    Array.isArray(identity)
+  ) {
     return {
       valid: false,
-      errors: [{
-        field: 'root',
-        message: 'Identity must be an object',
-        value: identity,
-      }],
+      errors: [
+        {
+          field: "root",
+          message: "Identity must be an object",
+          value: identity,
+        },
+      ],
     };
   }
 
@@ -328,7 +348,7 @@ export function validateIdentitySchema(identity: unknown): SchemaValidationResul
     if (DANGEROUS_PROTOTYPE_KEYS.has(field)) {
       errors.push({
         field,
-        message: 'Dangerous property name rejected',
+        message: "Dangerous property name rejected",
         value: undefined,
       });
     }
@@ -338,7 +358,7 @@ export function validateIdentitySchema(identity: unknown): SchemaValidationResul
   const MAX_FIELDS = 100;
   if (objKeys.length > MAX_FIELDS) {
     errors.push({
-      field: 'root',
+      field: "root",
       message: `Object has too many fields (max ${MAX_FIELDS})`,
       value: undefined,
     });
@@ -348,7 +368,7 @@ export function validateIdentitySchema(identity: unknown): SchemaValidationResul
       if (!DANGEROUS_PROTOTYPE_KEYS.has(field) && !knownFields.has(field)) {
         errors.push({
           field,
-          message: 'Unknown field',
+          message: "Unknown field",
           value: obj[field],
         });
       }
@@ -374,13 +394,13 @@ export function validateIdentitySchema(identity: unknown): SchemaValidationResul
  * @internal
  */
 function extractIdentityId(identity: unknown): string | undefined {
-  if (typeof identity !== 'object' || identity === null) {
+  if (typeof identity !== "object" || identity === null) {
     return undefined;
   }
   // SECURITY: Use Object.hasOwn() to prevent prototype chain access
   const obj = identity as Record<string, unknown>;
-  const id = Object.hasOwn(obj, 'id') ? obj.id : undefined;
-  return typeof id === 'string' ? id : undefined;
+  const id = Object.hasOwn(obj, "id") ? obj.id : undefined;
+  return typeof id === "string" ? id : undefined;
 }
 
 /**
@@ -409,18 +429,20 @@ function checkDuplicateIds(identities: unknown[], errors: SchemaError[]): void {
  * Validate an array of identities
  */
 export function validateIdentitiesSchema(
-  identities: unknown
+  identities: unknown,
 ): SchemaValidationResult {
   const errors: SchemaError[] = [];
 
   if (!Array.isArray(identities)) {
     return {
       valid: false,
-      errors: [{
-        field: 'identities',
-        message: 'Must be an array',
-        value: identities,
-      }],
+      errors: [
+        {
+          field: "identities",
+          message: "Must be an array",
+          value: identities,
+        },
+      ],
     };
   }
 
@@ -448,13 +470,13 @@ export function validateIdentitiesSchema(
  * Get the schema for documentation purposes
  */
 export function getSchemaDocumentation(): string {
-  const lines: string[] = ['Identity Schema:'];
+  const lines: string[] = ["Identity Schema:"];
 
   for (const [field, schema] of Object.entries(IDENTITY_SCHEMA)) {
-    const required = schema.required ? ' (required)' : '';
+    const required = schema.required ? " (required)" : "";
     lines.push(
       `  ${field}${required}: ${schema.type}`,
-      `    ${schema.description}`
+      `    ${schema.description}`,
     );
 
     if (schema.maxLength) {
@@ -468,5 +490,5 @@ export function getSchemaDocumentation(): string {
     }
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
 }

--- a/extensions/git-id-switcher/src/identity/identity.ts
+++ b/extensions/git-id-switcher/src/identity/identity.ts
@@ -7,9 +7,9 @@
  * Uses vscodeLoader for testability (allows mocking in E2E tests).
  */
 
-import { getVSCode } from '../core/vscodeLoader';
-import { validateIdentitySchema } from './configSchema';
-import { securityLogger } from '../security/securityLogger';
+import { getVSCode } from "../core/vscodeLoader";
+import { validateIdentitySchema } from "./configSchema";
+import { securityLogger } from "../security/securityLogger";
 import {
   MAX_IDENTITIES,
   MAX_ID_LENGTH,
@@ -19,7 +19,7 @@ import {
   MAX_DESCRIPTION_LENGTH,
   MAX_SSH_HOST_LENGTH,
   MAX_GPG_KEY_LENGTH,
-} from '../core/constants';
+} from "../core/constants";
 import {
   isValidIdentityId,
   isValidEmail,
@@ -28,8 +28,9 @@ import {
   hasPathTraversal,
   hasDangerousCharsForPath,
   hasDangerousCharsForText,
-} from '../validators/common';
-import { isUnderSshDirectory } from '../security/pathUtils';
+  isWindowsAbsolutePath,
+} from "../validators/common";
+import { isUnderSshDirectory } from "../security/pathUtils";
 
 /**
  * Session-level flag to prevent multiple validation error notifications.
@@ -63,31 +64,31 @@ function showValidationErrorNotification(invalidCount: number): void {
   // Set flag immediately to prevent concurrent notifications
   hasShownValidationError = true;
 
-  const message = invalidCount === 1
-    ? vs.l10n.t(
-        'Git ID Switcher: 1 identity configuration is invalid and was skipped. Check the settings.'
-      )
-    : vs.l10n.t(
-        'Git ID Switcher: {0} identity configurations are invalid and were skipped. Check the settings.',
-        invalidCount
-      );
+  const message =
+    invalidCount === 1
+      ? vs.l10n.t(
+          "Git ID Switcher: 1 identity configuration is invalid and was skipped. Check the settings.",
+        )
+      : vs.l10n.t(
+          "Git ID Switcher: {0} identity configurations are invalid and were skipped. Check the settings.",
+          invalidCount,
+        );
 
   // Fire and forget: notification is non-blocking
   // Note: VS Code's Thenable doesn't have .catch(), so we use .then(onFulfilled, onRejected)
-  vs.window.showWarningMessage(message, vs.l10n.t('Open Settings'))
-    .then(
-      action => {
-        if (action) {
-          vs.commands.executeCommand(
-            'workbench.action.openSettings',
-            'gitIdSwitcher.identities'
-          );
-        }
-      },
-      () => {
-        // SECURITY: Don't let notification errors affect validation flow
+  vs.window.showWarningMessage(message, vs.l10n.t("Open Settings")).then(
+    (action) => {
+      if (action) {
+        vs.commands.executeCommand(
+          "workbench.action.openSettings",
+          "gitIdSwitcher.identities",
+        );
       }
-    );
+    },
+    () => {
+      // SECURITY: Don't let notification errors affect validation flow
+    },
+  );
 }
 
 export interface Identity {
@@ -140,7 +141,7 @@ export interface FieldMetadata {
   editable: boolean;
 
   /** Input type hint for UI */
-  inputType: 'text' | 'file' | 'email';
+  inputType: "text" | "file" | "email";
 
   /** VSCode Codicon name for UI display (e.g., 'lock', 'person', 'mail') */
   icon: string;
@@ -164,42 +165,51 @@ export interface FieldMetadata {
  * (service, icon, description, sshKeyPath, sshHost, gpgKeyId).
  */
 export const EDITABLE_FIELDS: ReadonlyArray<keyof Identity> = [
-  'id',
-  'name',
-  'email',
-  'service',
-  'icon',
-  'description',
-  'sshKeyPath',
-  'sshHost',
-  'gpgKeyId',
+  "id",
+  "name",
+  "email",
+  "service",
+  "icon",
+  "description",
+  "sshKeyPath",
+  "sshHost",
+  "gpgKeyId",
 ];
 
 /**
  * Validate SSH key path format
  *
  * Defense-in-depth validation (lightest to heaviest):
+ * - Layer 0: isWindowsAbsolutePath() - Windows drive letter rejection
  * - Layer 1: hasDangerousCharsForPath() - dangerous character detection
  * - Layer 2: hasPathTraversal() - path traversal detection
  * - Layer 3: isUnderSshDirectory() - SSH directory restriction
+ *
+ * Note: Windows path detection also exists in inputValidator.ts validateSshKeyPathFormat().
+ * This function is called from FIELD_METADATA validators (UI-layer) independently.
  *
  * @param value - The SSH key path to validate
  * @returns Error message if invalid, undefined if valid
  */
 function validateSshKeyPathForField(value: string): string | undefined {
+  // Layer 0: Windows drive letter paths — guide users to cross-platform format
+  if (isWindowsAbsolutePath(value)) {
+    return "sshKeyPath: use ~/.ssh/ format instead of drive letter paths (e.g., ~/.ssh/id_ed25519)";
+  }
+
   // Layer 1: Dangerous characters (fastest check)
   if (hasDangerousCharsForPath(value)) {
-    return 'sshKeyPath contains dangerous characters';
+    return "sshKeyPath contains dangerous characters";
   }
 
   // Layer 2: Path traversal
   if (hasPathTraversal(value)) {
-    return 'sshKeyPath: path traversal (..) is not allowed';
+    return "sshKeyPath: path traversal (..) is not allowed";
   }
 
   // Layer 3: Must be under ~/.ssh/ directory
   if (!isUnderSshDirectory(value)) {
-    return 'sshKeyPath must be under ~/.ssh/ directory';
+    return "sshKeyPath must be under ~/.ssh/ directory";
   }
 
   return undefined;
@@ -213,12 +223,12 @@ function validateSshKeyPathForField(value: string): string | undefined {
  */
 export const FIELD_METADATA: ReadonlyArray<FieldMetadata> = [
   {
-    key: 'id',
-    labelKey: 'ID',
+    key: "id",
+    labelKey: "ID",
     required: true,
     editable: true, // Editable during creation, but changing ID requires special handling
-    inputType: 'text',
-    icon: 'lock',
+    inputType: "text",
+    icon: "lock",
     maxLength: MAX_ID_LENGTH,
     validator: (value: string) =>
       isValidIdentityId(value, MAX_ID_LENGTH)
@@ -226,95 +236,103 @@ export const FIELD_METADATA: ReadonlyArray<FieldMetadata> = [
         : `ID must be 1-${MAX_ID_LENGTH} alphanumeric characters, underscores, or hyphens`,
   },
   {
-    key: 'name',
-    labelKey: 'Name',
+    key: "name",
+    labelKey: "Name",
     required: true,
     editable: true,
-    inputType: 'text',
-    icon: 'person',
+    inputType: "text",
+    icon: "person",
     maxLength: MAX_NAME_LENGTH,
     validator: (value: string) =>
-      hasDangerousCharsForText(value) ? 'Name contains invalid characters' : undefined,
-  },
-  {
-    key: 'email',
-    labelKey: 'Email',
-    required: true,
-    editable: true,
-    inputType: 'email',
-    icon: 'mail',
-    maxLength: MAX_EMAIL_LENGTH,
-    validator: (value: string) =>
-      isValidEmail(value) ? undefined : 'Invalid email format',
-  },
-  {
-    key: 'service',
-    labelKey: 'Service',
-    required: false,
-    editable: true,
-    inputType: 'text',
-    icon: 'server',
-    maxLength: MAX_SERVICE_LENGTH,
-    validator: (value: string) =>
-      hasDangerousCharsForText(value) ? 'Service contains invalid characters' : undefined,
-  },
-  {
-    key: 'icon',
-    labelKey: 'Icon',
-    required: false,
-    editable: true,
-    inputType: 'text',
-    icon: 'symbol-color',
-    // Note: Grapheme cluster validation is handled by configSchema
-    // Here we only check for dangerous characters (command injection prevention)
-    validator: (value: string) =>
-      hasDangerousCharsForText(value) ? 'Icon contains invalid characters' : undefined,
-  },
-  {
-    key: 'description',
-    labelKey: 'Description',
-    required: false,
-    editable: true,
-    inputType: 'text',
-    icon: 'note',
-    maxLength: MAX_DESCRIPTION_LENGTH,
-    validator: (value: string) =>
       hasDangerousCharsForText(value)
-        ? 'Description contains invalid characters'
+        ? "Name contains invalid characters"
         : undefined,
   },
   {
-    key: 'sshKeyPath',
-    labelKey: 'SSH Key Path',
+    key: "email",
+    labelKey: "Email",
+    required: true,
+    editable: true,
+    inputType: "email",
+    icon: "mail",
+    maxLength: MAX_EMAIL_LENGTH,
+    validator: (value: string) =>
+      isValidEmail(value) ? undefined : "Invalid email format",
+  },
+  {
+    key: "service",
+    labelKey: "Service",
     required: false,
     editable: true,
-    inputType: 'file',
-    icon: 'key',
+    inputType: "text",
+    icon: "server",
+    maxLength: MAX_SERVICE_LENGTH,
+    validator: (value: string) =>
+      hasDangerousCharsForText(value)
+        ? "Service contains invalid characters"
+        : undefined,
+  },
+  {
+    key: "icon",
+    labelKey: "Icon",
+    required: false,
+    editable: true,
+    inputType: "text",
+    icon: "symbol-color",
+    // Note: Grapheme cluster validation is handled by configSchema
+    // Here we only check for dangerous characters (command injection prevention)
+    validator: (value: string) =>
+      hasDangerousCharsForText(value)
+        ? "Icon contains invalid characters"
+        : undefined,
+  },
+  {
+    key: "description",
+    labelKey: "Description",
+    required: false,
+    editable: true,
+    inputType: "text",
+    icon: "note",
+    maxLength: MAX_DESCRIPTION_LENGTH,
+    validator: (value: string) =>
+      hasDangerousCharsForText(value)
+        ? "Description contains invalid characters"
+        : undefined,
+  },
+  {
+    key: "sshKeyPath",
+    labelKey: "SSH Key Path",
+    required: false,
+    editable: true,
+    inputType: "file",
+    icon: "key",
     validator: validateSshKeyPathForField,
   },
   {
-    key: 'sshHost',
-    labelKey: 'SSH Host',
+    key: "sshHost",
+    labelKey: "SSH Host",
     required: false,
     editable: true,
-    inputType: 'text',
-    icon: 'globe',
+    inputType: "text",
+    icon: "globe",
     maxLength: MAX_SSH_HOST_LENGTH,
     validator: (value: string) =>
       isValidSshHost(value)
         ? undefined
-        : 'SSH host must contain only alphanumeric characters, dots, underscores, and hyphens',
+        : "SSH host must contain only alphanumeric characters, dots, underscores, and hyphens",
   },
   {
-    key: 'gpgKeyId',
-    labelKey: 'GPG Key ID',
+    key: "gpgKeyId",
+    labelKey: "GPG Key ID",
     required: false,
     editable: true,
-    inputType: 'text',
-    icon: 'key',
+    inputType: "text",
+    icon: "key",
     maxLength: MAX_GPG_KEY_LENGTH,
     validator: (value: string) =>
-      isValidGpgKeyId(value) ? undefined : 'GPG key ID must be 8-40 hexadecimal characters',
+      isValidGpgKeyId(value)
+        ? undefined
+        : "GPG key ID must be 8-40 hexadecimal characters",
   },
 ];
 
@@ -324,8 +342,10 @@ export const FIELD_METADATA: ReadonlyArray<FieldMetadata> = [
  * @param key - The field key to look up
  * @returns FieldMetadata for the key, or undefined if not found
  */
-export function getFieldMetadata(key: keyof Identity): FieldMetadata | undefined {
-  return FIELD_METADATA.find(f => f.key === key);
+export function getFieldMetadata(
+  key: keyof Identity,
+): FieldMetadata | undefined {
+  return FIELD_METADATA.find((f) => f.key === key);
 }
 
 /**
@@ -343,8 +363,8 @@ export function getIdentities(): Identity[] {
   if (!vs) {
     return [];
   }
-  const config = vs.workspace.getConfiguration('gitIdSwitcher');
-  const identities = config.get<Identity[]>('identities', []);
+  const config = vs.workspace.getConfiguration("gitIdSwitcher");
+  const identities = config.get<Identity[]>("identities", []);
   return identities;
 }
 
@@ -367,16 +387,16 @@ export function getIdentitiesWithValidation(): Identity[] {
     return [];
   }
 
-  const config = vs.workspace.getConfiguration('gitIdSwitcher');
-  const rawIdentities = config.get<unknown[]>('identities', []);
+  const config = vs.workspace.getConfiguration("gitIdSwitcher");
+  const rawIdentities = config.get<unknown[]>("identities", []);
 
   // Type check: must be an array
   if (!Array.isArray(rawIdentities)) {
     // Log type error but don't show notification (configuration might be in transition)
     securityLogger.logValidationFailure(
-      'identities',
-      'Configuration must be an array',
-      typeof rawIdentities
+      "identities",
+      "Configuration must be an array",
+      typeof rawIdentities,
     );
     return [];
   }
@@ -391,9 +411,9 @@ export function getIdentitiesWithValidation(): Identity[] {
   // VS Code settings should enforce this, but defense-in-depth requires explicit check
   if (rawIdentities.length > MAX_IDENTITIES) {
     securityLogger.logValidationFailure(
-      'identities',
+      "identities",
       `Array length exceeds maximum (${MAX_IDENTITIES})`,
-      rawIdentities.length
+      rawIdentities.length,
     );
     // Cache and return empty array to fail securely (avoids repeated security log spam)
     identityCache = [];
@@ -415,7 +435,7 @@ export function getIdentitiesWithValidation(): Identity[] {
         securityLogger.logValidationFailure(
           `identities[${i}].${error.field}`,
           error.message,
-          error.value
+          error.value,
         );
       }
       continue;
@@ -432,7 +452,7 @@ export function getIdentitiesWithValidation(): Identity[] {
       securityLogger.logValidationFailure(
         `identities[${i}].id`,
         `Duplicate ID: ${id}`,
-        id
+        id,
       );
       continue;
     }
@@ -466,7 +486,7 @@ export function invalidateIdentityCache(): void {
  * Get identity by ID (with validation)
  */
 export function getIdentityById(id: string): Identity | undefined {
-  return getIdentitiesWithValidation().find(i => i.id === id);
+  return getIdentitiesWithValidation().find((i) => i.id === id);
 }
 
 /**
@@ -479,8 +499,8 @@ export function getDefaultIdentity(): Identity | undefined {
     return undefined;
   }
 
-  const config = vs.workspace.getConfiguration('gitIdSwitcher');
-  const defaultId = config.get<string>('defaultIdentity', '');
+  const config = vs.workspace.getConfiguration("gitIdSwitcher");
+  const defaultId = config.get<string>("defaultIdentity", "");
 
   const identities = getIdentitiesWithValidation();
   if (identities.length === 0) {
@@ -488,7 +508,7 @@ export function getDefaultIdentity(): Identity | undefined {
   }
 
   if (defaultId) {
-    const found = identities.find(i => i.id === defaultId);
+    const found = identities.find((i) => i.id === defaultId);
     if (found) {
       return found;
     }
@@ -549,7 +569,7 @@ export function formatGitAuthor(identity: Identity): string {
 export async function deleteIdentityFromConfig(id: string): Promise<void> {
   const vs = getVSCode();
   if (!vs) {
-    throw new Error('VS Code API not available');
+    throw new Error("VS Code API not available");
   }
 
   // Validate ID format
@@ -557,23 +577,27 @@ export async function deleteIdentityFromConfig(id: string): Promise<void> {
     throw new Error(`Invalid identity ID format: ${id}`);
   }
 
-  const config = vs.workspace.getConfiguration('gitIdSwitcher');
-  const identities = config.get<Identity[]>('identities', []);
+  const config = vs.workspace.getConfiguration("gitIdSwitcher");
+  const identities = config.get<Identity[]>("identities", []);
 
   // Find the identity to delete
-  const index = identities.findIndex(i => i.id === id);
+  const index = identities.findIndex((i) => i.id === id);
   if (index === -1) {
     throw new Error(`Identity not found: ${id}`);
   }
 
   // Remove the identity from array
-  const updatedIdentities = identities.filter(i => i.id !== id);
+  const updatedIdentities = identities.filter((i) => i.id !== id);
 
   // Update configuration
-  await config.update('identities', updatedIdentities, vs.ConfigurationTarget.Global);
+  await config.update(
+    "identities",
+    updatedIdentities,
+    vs.ConfigurationTarget.Global,
+  );
 
   // Log security event
-  securityLogger.logConfigChange('identities');
+  securityLogger.logConfigChange("identities");
 }
 
 /**
@@ -597,23 +621,23 @@ export async function deleteIdentityFromConfig(id: string): Promise<void> {
 export async function addIdentityToConfig(identity: Identity): Promise<void> {
   const vs = getVSCode();
   if (!vs) {
-    throw new Error('VS Code API not available');
+    throw new Error("VS Code API not available");
   }
 
   // Validate schema
   const validationResult = validateIdentitySchema(identity);
   if (!validationResult.valid) {
     const errorMessages = validationResult.errors
-      .map(e => `${e.field}: ${e.message}`)
-      .join(', ');
+      .map((e) => `${e.field}: ${e.message}`)
+      .join(", ");
     throw new Error(`Invalid identity schema: ${errorMessages}`);
   }
 
-  const config = vs.workspace.getConfiguration('gitIdSwitcher');
-  const identities = config.get<Identity[]>('identities', []);
+  const config = vs.workspace.getConfiguration("gitIdSwitcher");
+  const identities = config.get<Identity[]>("identities", []);
 
   // Check for duplicate ID
-  const duplicateExists = identities.some(i => i.id === identity.id);
+  const duplicateExists = identities.some((i) => i.id === identity.id);
   if (duplicateExists) {
     throw new Error(`Identity with ID already exists: ${identity.id}`);
   }
@@ -627,10 +651,14 @@ export async function addIdentityToConfig(identity: Identity): Promise<void> {
   const updatedIdentities = [...identities, identity];
 
   // Update configuration
-  await config.update('identities', updatedIdentities, vs.ConfigurationTarget.Global);
+  await config.update(
+    "identities",
+    updatedIdentities,
+    vs.ConfigurationTarget.Global,
+  );
 
   // Log security event
-  securityLogger.logConfigChange('identities');
+  securityLogger.logConfigChange("identities");
 }
 
 /**
@@ -659,11 +687,11 @@ export async function addIdentityToConfig(identity: Identity): Promise<void> {
 export async function updateIdentityInConfig(
   id: string,
   field: keyof Identity,
-  value: string | undefined
+  value: string | undefined,
 ): Promise<void> {
   const vs = getVSCode();
   if (!vs) {
-    throw new Error('VS Code API not available');
+    throw new Error("VS Code API not available");
   }
 
   // Validate ID format
@@ -672,27 +700,27 @@ export async function updateIdentityInConfig(
   }
 
   // Required fields cannot be set to undefined
-  const requiredFields: (keyof Identity)[] = ['id', 'name', 'email'];
+  const requiredFields: (keyof Identity)[] = ["id", "name", "email"];
   if (requiredFields.includes(field) && value === undefined) {
     throw new Error(`Cannot set required field to undefined: ${field}`);
   }
 
-  const config = vs.workspace.getConfiguration('gitIdSwitcher');
-  const identities = config.get<Identity[]>('identities', []);
+  const config = vs.workspace.getConfiguration("gitIdSwitcher");
+  const identities = config.get<Identity[]>("identities", []);
 
   // If changing ID, validate new ID format and check for duplicates
-  if (field === 'id' && value !== undefined && value !== id) {
+  if (field === "id" && value !== undefined && value !== id) {
     if (!isValidIdentityId(value, MAX_ID_LENGTH)) {
       throw new Error(`Invalid new identity ID format: ${value}`);
     }
-    const duplicateExists = identities.some(i => i.id === value);
+    const duplicateExists = identities.some((i) => i.id === value);
     if (duplicateExists) {
       throw new Error(`Identity with ID already exists: ${value}`);
     }
   }
 
   // Find the identity to update
-  const index = identities.findIndex(i => i.id === id);
+  const index = identities.findIndex((i) => i.id === id);
   if (index === -1) {
     throw new Error(`Identity not found: ${id}`);
   }
@@ -712,8 +740,8 @@ export async function updateIdentityInConfig(
   const validationResult = validateIdentitySchema(updatedIdentity);
   if (!validationResult.valid) {
     const errorMessages = validationResult.errors
-      .map(e => `${e.field}: ${e.message}`)
-      .join(', ');
+      .map((e) => `${e.field}: ${e.message}`)
+      .join(", ");
     throw new Error(`Invalid identity after update: ${errorMessages}`);
   }
 
@@ -722,10 +750,14 @@ export async function updateIdentityInConfig(
   updatedIdentities[index] = updatedIdentity;
 
   // Update configuration
-  await config.update('identities', updatedIdentities, vs.ConfigurationTarget.Global);
+  await config.update(
+    "identities",
+    updatedIdentities,
+    vs.ConfigurationTarget.Global,
+  );
 
   // Log security event
-  securityLogger.logConfigChange('identities');
+  securityLogger.logConfigChange("identities");
 }
 
 /**
@@ -748,11 +780,11 @@ export async function updateIdentityInConfig(
  */
 export async function moveIdentityInConfig(
   id: string,
-  direction: 'up' | 'down'
+  direction: "up" | "down",
 ): Promise<boolean> {
   const vs = getVSCode();
   if (!vs) {
-    throw new Error('VS Code API not available');
+    throw new Error("VS Code API not available");
   }
 
   // Validate ID format
@@ -760,17 +792,17 @@ export async function moveIdentityInConfig(
     throw new Error(`Invalid identity ID format: ${id}`);
   }
 
-  const config = vs.workspace.getConfiguration('gitIdSwitcher');
-  const identities = [...(config.get<Identity[]>('identities') ?? [])];
+  const config = vs.workspace.getConfiguration("gitIdSwitcher");
+  const identities = [...(config.get<Identity[]>("identities") ?? [])];
 
   // Find the identity to move
-  const currentIndex = identities.findIndex(i => i.id === id);
+  const currentIndex = identities.findIndex((i) => i.id === id);
   if (currentIndex === -1) {
     throw new Error(`Identity not found: ${id}`);
   }
 
   // Calculate new index
-  const newIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+  const newIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
 
   // Boundary check: return false if cannot move
   if (newIndex < 0 || newIndex >= identities.length) {
@@ -778,14 +810,16 @@ export async function moveIdentityInConfig(
   }
 
   // Swap identities
-  [identities[currentIndex], identities[newIndex]] =
-    [identities[newIndex], identities[currentIndex]];
+  [identities[currentIndex], identities[newIndex]] = [
+    identities[newIndex],
+    identities[currentIndex],
+  ];
 
   // Update configuration
-  await config.update('identities', identities, vs.ConfigurationTarget.Global);
+  await config.update("identities", identities, vs.ConfigurationTarget.Global);
 
   // Log security event
-  securityLogger.logConfigChange('identities');
+  securityLogger.logConfigChange("identities");
 
   return true;
 }

--- a/extensions/git-id-switcher/src/identity/inputValidator.ts
+++ b/extensions/git-id-switcher/src/identity/inputValidator.ts
@@ -8,7 +8,7 @@
  * @see https://cwe.mitre.org/data/definitions/78.html
  */
 
-import { Identity } from './identity';
+import { Identity } from "./identity";
 import {
   isValidEmail,
   hasPathTraversal,
@@ -18,7 +18,7 @@ import {
   SSH_HOST_REGEX,
   DANGEROUS_PATTERNS,
   isWindowsAbsolutePath,
-} from '../validators/common';
+} from "../validators/common";
 import {
   MAX_ID_LENGTH,
   MAX_EMAIL_LENGTH,
@@ -27,7 +27,7 @@ import {
   MAX_SERVICE_LENGTH,
   MAX_DESCRIPTION_LENGTH,
   MAX_ICON_BYTE_LENGTH,
-} from '../core/constants';
+} from "../core/constants";
 
 export interface ValidationResult {
   valid: boolean;
@@ -49,7 +49,7 @@ export interface ValidationResult {
 export function validateFieldForDangerousPatterns(
   value: string | undefined,
   fieldName: string,
-  errors: string[]
+  errors: string[],
 ): void {
   if (!value) {
     return;
@@ -77,19 +77,24 @@ export function validateFieldForDangerousPatterns(
  * @param email - The email to validate
  * @param errors - Array to accumulate validation errors
  */
-export function validateEmailField(email: string | undefined, errors: string[]): void {
+export function validateEmailField(
+  email: string | undefined,
+  errors: string[],
+): void {
   if (!email) {
     return;
   }
 
   if (!isValidEmail(email)) {
-    errors.push('email: invalid email format');
+    errors.push("email: invalid email format");
   }
 
   // Additional length check (RFC 5321)
   // Note: isValidEmail already checks for 254 chars, but identity config allows 320
   if (email.length > MAX_EMAIL_LENGTH) {
-    errors.push(`email: exceeds maximum length (${MAX_EMAIL_LENGTH} characters)`);
+    errors.push(
+      `email: exceeds maximum length (${MAX_EMAIL_LENGTH} characters)`,
+    );
   }
 }
 
@@ -112,57 +117,77 @@ export function validateEmailField(email: string | undefined, errors: string[]):
  */
 export function validateSshKeyPathFormat(
   sshKeyPath: string | undefined,
-  errors: string[]
+  errors: string[],
 ): void {
   if (!sshKeyPath) {
     return;
   }
 
-  // Must start with /, ~, or Windows drive letter (C:\)
-  const isUnixAbsolute = sshKeyPath.startsWith('/');
-  const isTildePath = sshKeyPath.startsWith('~');
+  // Windows drive letter paths are not supported — use ~/.ssh/ format
+  if (isWindowsAbsolutePath(sshKeyPath)) {
+    errors.push(
+      "sshKeyPath: use ~/.ssh/ format instead of drive letter paths (e.g., ~/.ssh/id_ed25519)",
+    );
+    return;
+  }
 
-  if (!isUnixAbsolute && !isTildePath && !isWindowsAbsolutePath(sshKeyPath)) {
-    errors.push('sshKeyPath: must be an absolute path or start with ~');
+  // Must start with / or ~
+  const isUnixAbsolute = sshKeyPath.startsWith("/");
+  const isTildePath = sshKeyPath.startsWith("~");
+
+  if (!isUnixAbsolute && !isTildePath) {
+    errors.push(
+      "sshKeyPath: must be an absolute path (/) or start with ~ (e.g., ~/.ssh/id_ed25519)",
+    );
   }
 
   // No path traversal
   if (hasPathTraversal(sshKeyPath)) {
-    errors.push('sshKeyPath: path traversal (..) is not allowed');
+    errors.push("sshKeyPath: path traversal (..) is not allowed");
   }
 
   // No dangerous characters in path
-  validateFieldForDangerousPatterns(sshKeyPath, 'sshKeyPath', errors);
+  validateFieldForDangerousPatterns(sshKeyPath, "sshKeyPath", errors);
 }
 
 /**
  * Validate GPG key ID
  */
-export function validateGpgKeyId(gpgKeyId: string | undefined, errors: string[]): void {
+export function validateGpgKeyId(
+  gpgKeyId: string | undefined,
+  errors: string[],
+): void {
   if (!gpgKeyId) {
     return;
   }
 
   if (!GPG_KEY_REGEX.test(gpgKeyId)) {
-    errors.push('gpgKeyId: must be 8-40 hexadecimal characters');
+    errors.push("gpgKeyId: must be 8-40 hexadecimal characters");
   }
 }
 
 /**
  * Validate SSH host alias
  */
-export function validateSshHost(sshHost: string | undefined, errors: string[]): void {
+export function validateSshHost(
+  sshHost: string | undefined,
+  errors: string[],
+): void {
   if (!sshHost) {
     return;
   }
 
   if (!SSH_HOST_REGEX.test(sshHost)) {
-    errors.push('sshHost: must contain only alphanumeric characters, dots, underscores, and hyphens');
+    errors.push(
+      "sshHost: must contain only alphanumeric characters, dots, underscores, and hyphens",
+    );
   }
 
   // DNS maximum label length
   if (sshHost.length > MAX_SSH_HOST_LENGTH) {
-    errors.push(`sshHost: exceeds maximum length (${MAX_SSH_HOST_LENGTH} characters)`);
+    errors.push(
+      `sshHost: exceeds maximum length (${MAX_SSH_HOST_LENGTH} characters)`,
+    );
   }
 }
 
@@ -189,26 +214,32 @@ export function validateIdentity(identity: Identity): ValidationResult {
 
   // Required fields
   if (!identity.id) {
-    errors.push('id is required');
+    errors.push("id is required");
   }
   if (!identity.name) {
-    errors.push('name is required');
+    errors.push("name is required");
   }
   if (!identity.email) {
-    errors.push('email is required');
+    errors.push("email is required");
   }
 
   // ID validation (alphanumeric, underscores, hyphens only)
   if (identity.id && !isValidIdentityId(identity.id, MAX_ID_LENGTH)) {
-    errors.push(`id: must be 1-${MAX_ID_LENGTH} alphanumeric characters, underscores, or hyphens`);
+    errors.push(
+      `id: must be 1-${MAX_ID_LENGTH} alphanumeric characters, underscores, or hyphens`,
+    );
   }
 
   // Text field validation (dangerous patterns)
-  validateFieldForDangerousPatterns(identity.name, 'name', errors);
-  validateFieldForDangerousPatterns(identity.email, 'email', errors);
-  validateFieldForDangerousPatterns(identity.service, 'service', errors);
-  validateFieldForDangerousPatterns(identity.description, 'description', errors);
-  validateFieldForDangerousPatterns(identity.icon, 'icon', errors);
+  validateFieldForDangerousPatterns(identity.name, "name", errors);
+  validateFieldForDangerousPatterns(identity.email, "email", errors);
+  validateFieldForDangerousPatterns(identity.service, "service", errors);
+  validateFieldForDangerousPatterns(
+    identity.description,
+    "description",
+    errors,
+  );
+  validateFieldForDangerousPatterns(identity.icon, "icon", errors);
 
   // Format-specific validation
   validateEmailField(identity.email, errors);
@@ -221,14 +252,21 @@ export function validateIdentity(identity: Identity): ValidationResult {
     errors.push(`name: exceeds maximum length (${MAX_NAME_LENGTH} characters)`);
   }
   if (identity.service && identity.service.length > MAX_SERVICE_LENGTH) {
-    errors.push(`service: exceeds maximum length (${MAX_SERVICE_LENGTH} characters)`);
+    errors.push(
+      `service: exceeds maximum length (${MAX_SERVICE_LENGTH} characters)`,
+    );
   }
-  if (identity.description && identity.description.length > MAX_DESCRIPTION_LENGTH) {
-    errors.push(`description: exceeds maximum length (${MAX_DESCRIPTION_LENGTH} characters)`);
+  if (
+    identity.description &&
+    identity.description.length > MAX_DESCRIPTION_LENGTH
+  ) {
+    errors.push(
+      `description: exceeds maximum length (${MAX_DESCRIPTION_LENGTH} characters)`,
+    );
   }
   if (identity.icon && identity.icon.length > MAX_ICON_BYTE_LENGTH) {
     // MAX_ICON_BYTE_LENGTH allows for complex composed emoji (e.g., family emoji with ZWJ sequences)
-    errors.push('icon: exceeds maximum length');
+    errors.push("icon: exceeds maximum length");
   }
 
   return {
@@ -247,10 +285,10 @@ export function validateIdentities(identities: Identity[]): ValidationResult {
   const errors: string[] = [];
 
   // Check for duplicate IDs
-  const ids = identities.map(i => i.id);
+  const ids = identities.map((i) => i.id);
   const uniqueIds = new Set(ids);
   if (ids.length !== uniqueIds.size) {
-    errors.push('Duplicate identity IDs found');
+    errors.push("Duplicate identity IDs found");
   }
 
   // Validate each identity
@@ -258,7 +296,9 @@ export function validateIdentities(identities: Identity[]): ValidationResult {
     const result = validateIdentity(identity);
     if (!result.valid) {
       for (const error of result.errors) {
-        errors.push(`identities[${index}] (${identity.id || 'unknown'}): ${error}`);
+        errors.push(
+          `identities[${index}] (${identity.id || "unknown"}): ${error}`,
+        );
       }
     }
   }

--- a/extensions/git-id-switcher/src/ssh/sshAgent.ts
+++ b/extensions/git-id-switcher/src/ssh/sshAgent.ts
@@ -8,18 +8,19 @@
  * @see https://owasp.org/www-community/attacks/Command_Injection
  */
 
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
-import * as vscode from 'vscode';
-import { Identity, getIdentitiesWithValidation } from '../identity/identity';
-import { sshAgentExec, sshKeygenExec } from '../security/secureExec';
-import { isShellSafePath } from '../identity/inputValidator';
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { Identity, getIdentitiesWithValidation } from "../identity/identity";
+import { sshAgentExec, sshKeygenExec } from "../security/secureExec";
+import { isShellSafePath } from "../identity/inputValidator";
+import { isWindowsAbsolutePath } from "../validators/common";
 import {
   normalizeAndValidatePath,
   validateSshKeyPath,
-} from '../security/pathUtils';
-import { createSecurityViolationError, wrapError } from '../core/errors';
-import { securityLogger } from '../security/securityLogger';
+} from "../security/pathUtils";
+import { createSecurityViolationError, wrapError } from "../core/errors";
+import { securityLogger } from "../security/securityLogger";
 
 /**
  * Maximum allowed SSH key file size (1MB)
@@ -52,14 +53,14 @@ const OWNER_EXECUTE_BIT = 0o100;
  * These are the standard formats supported by ssh-add
  */
 const VALID_SSH_KEY_HEADERS = [
-  '-----BEGIN OPENSSH PRIVATE KEY-----',      // OpenSSH format (modern)
-  '-----BEGIN RSA PRIVATE KEY-----',          // RSA PEM format
-  '-----BEGIN DSA PRIVATE KEY-----',          // DSA PEM format
-  '-----BEGIN EC PRIVATE KEY-----',           // EC PEM format
-  '-----BEGIN PRIVATE KEY-----',              // PKCS#8 unencrypted
-  '-----BEGIN ENCRYPTED PRIVATE KEY-----',    // PKCS#8 encrypted
-  'PuTTY-User-Key-File-2:',                   // PuTTY PPK v2
-  'PuTTY-User-Key-File-3:',                   // PuTTY PPK v3
+  "-----BEGIN OPENSSH PRIVATE KEY-----", // OpenSSH format (modern)
+  "-----BEGIN RSA PRIVATE KEY-----", // RSA PEM format
+  "-----BEGIN DSA PRIVATE KEY-----", // DSA PEM format
+  "-----BEGIN EC PRIVATE KEY-----", // EC PEM format
+  "-----BEGIN PRIVATE KEY-----", // PKCS#8 unencrypted
+  "-----BEGIN ENCRYPTED PRIVATE KEY-----", // PKCS#8 encrypted
+  "PuTTY-User-Key-File-2:", // PuTTY PPK v2
+  "PuTTY-User-Key-File-3:", // PuTTY PPK v3
 ] as const;
 
 /**
@@ -95,23 +96,29 @@ function isBasenameMatch(comment: string, basename: string): boolean {
     return true;
   }
   // Path match: comment ends with /<basename>
-  if (comment.endsWith('/' + basename) || comment.endsWith('\\' + basename)) {
+  if (comment.endsWith("/" + basename) || comment.endsWith("\\" + basename)) {
     return true;
   }
   // Space-separated match: comment starts with <basename> followed by space
   // (ssh-keygen comments like "id_ed25519 user@host")
-  if (comment.startsWith(basename + ' ')) {
+  if (comment.startsWith(basename + " ")) {
     return true;
   }
   // Path + space match: comment contains /<basename> followed by space
   // (full path with additional comment like "/home/user/.ssh/id_ed25519 user@host")
-  if (comment.includes('/' + basename + ' ') || comment.includes('\\' + basename + ' ')) {
+  if (
+    comment.includes("/" + basename + " ") ||
+    comment.includes("\\" + basename + " ")
+  ) {
     return true;
   }
   // Token match: basename appears as a standalone space-delimited token
   // defense-in-depth: handles fallback case where listSshKeys() uses entire
   // ssh-add -l line as comment (e.g., "256 SHA256:xxx id_ed25519 (unknown)")
-  if (comment.includes(' ' + basename + ' ') || comment.endsWith(' ' + basename)) {
+  if (
+    comment.includes(" " + basename + " ") ||
+    comment.endsWith(" " + basename)
+  ) {
     return true;
   }
   return false;
@@ -137,6 +144,16 @@ export interface SshKeyInfo {
  * @throws Error if path is invalid or insecure
  */
 function expandPath(keyPath: string): string {
+  // defense-in-depth: called directly by keyFileExists without validateKeyPathOrThrow
+  if (isWindowsAbsolutePath(keyPath)) {
+    throw createSecurityViolationError(
+      vscode.l10n.t(
+        "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)",
+      ),
+      { field: "sshKeyPath", context: { reason: "Windows drive letter path" } },
+    );
+  }
+
   const result = validateSshKeyPath(keyPath, {
     resolveSymlinks: true,
     requireExists: false, // Don't require existence for all operations
@@ -144,8 +161,8 @@ function expandPath(keyPath: string): string {
 
   if (!result.valid) {
     // SECURITY: Don't expose the actual path or detailed reason to users
-    throw createSecurityViolationError(vscode.l10n.t('Invalid SSH key path'), {
-      field: 'sshKeyPath',
+    throw createSecurityViolationError(vscode.l10n.t("Invalid SSH key path"), {
+      field: "sshKeyPath",
       context: { reason: result.reason },
     });
   }
@@ -163,12 +180,21 @@ function expandPath(keyPath: string): string {
  * @throws SecurityViolationError if path is potentially dangerous
  */
 function validateKeyPathOrThrow(keyPath: string): void {
+  if (isWindowsAbsolutePath(keyPath)) {
+    throw createSecurityViolationError(
+      vscode.l10n.t(
+        "Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)",
+      ),
+      { field: "sshKeyPath", context: { reason: "Windows drive letter path" } },
+    );
+  }
+
   // Use both legacy validation and new secure validation
   if (!isShellSafePath(keyPath)) {
     // SECURITY: Don't include the actual path in error message to prevent information leakage
-    throw createSecurityViolationError(vscode.l10n.t('Invalid SSH key path'), {
-      field: 'sshKeyPath',
-      context: { check: 'legacy' },
+    throw createSecurityViolationError(vscode.l10n.t("Invalid SSH key path"), {
+      field: "sshKeyPath",
+      context: { check: "legacy" },
     });
   }
 
@@ -176,8 +202,8 @@ function validateKeyPathOrThrow(keyPath: string): void {
   const result = normalizeAndValidatePath(keyPath);
   if (!result.valid) {
     // SECURITY: Only log the reason internally, don't expose to users
-    throw createSecurityViolationError(vscode.l10n.t('Invalid SSH key path'), {
-      field: 'sshKeyPath',
+    throw createSecurityViolationError(vscode.l10n.t("Invalid SSH key path"), {
+      field: "sshKeyPath",
       context: { reason: result.reason },
     });
   }
@@ -188,7 +214,7 @@ function validateKeyPathOrThrow(keyPath: string): void {
  * @param token Optional cancellation token for aborting the operation
  */
 export async function listSshKeys(
-  token?: vscode.CancellationToken
+  token?: vscode.CancellationToken,
 ): Promise<SshKeyInfo[]> {
   if (token?.isCancellationRequested) {
     return [];
@@ -196,27 +222,31 @@ export async function listSshKeys(
 
   try {
     // SECURITY: Using sshAgentExec with array args
-    const { stdout } = await sshAgentExec(['-l']);
+    const { stdout } = await sshAgentExec(["-l"]);
 
     if (token?.isCancellationRequested) {
       return [];
     }
 
-    const lines = stdout.trim().split('\n').filter(line => line.length > 0);
+    const lines = stdout
+      .trim()
+      .split("\n")
+      .filter((line) => line.length > 0);
 
-    return lines.map(line => {
+    return lines.map((line) => {
       // Format: "256 SHA256:xxx comment (type)"
       // SECURITY: Use split-based parsing to avoid ReDoS (SonarQube S5852)
       const parts = line.split(/\s+/);
       if (parts.length >= 4) {
         // Extract type from last part: "(type)" -> "type"
-        const lastPart = parts.at(-1) ?? '';
-        const typeMatch = lastPart.startsWith('(') && lastPart.endsWith(')')
-          ? lastPart.slice(1, -1)
-          : null;
+        const lastPart = parts.at(-1) ?? "";
+        const typeMatch =
+          lastPart.startsWith("(") && lastPart.endsWith(")")
+            ? lastPart.slice(1, -1)
+            : null;
         if (typeMatch && /^\w+$/.test(typeMatch)) {
           // Comment is everything between fingerprint and type
-          const comment = parts.slice(2, -1).join(' ');
+          const comment = parts.slice(2, -1).join(" ");
           return {
             fingerprint: parts[1],
             comment,
@@ -225,9 +255,9 @@ export async function listSshKeys(
         }
       }
       return {
-        fingerprint: '',
+        fingerprint: "",
         comment: line,
-        type: 'unknown',
+        type: "unknown",
       };
     });
   } catch {
@@ -258,11 +288,11 @@ export async function addSshKey(keyPath: string): Promise<void> {
   const fileValidation = await validateKeyFileBeforeAddToAgent(expandedPath);
   if (!fileValidation.valid) {
     throw createSecurityViolationError(
-      vscode.l10n.t('SSH key file validation failed'),
+      vscode.l10n.t("SSH key file validation failed"),
       {
-        field: 'sshKeyPath',
+        field: "sshKeyPath",
         context: { reason: fileValidation.reason },
-      }
+      },
     );
   }
 
@@ -271,10 +301,10 @@ export async function addSshKey(keyPath: string): Promise<void> {
 
   try {
     // eslint-disable-next-line unicorn/prefer-ternary -- security-critical: each branch has distinct SECURITY comments
-    if (platform === 'darwin') {
+    if (platform === "darwin") {
       // macOS: Use Keychain integration
       // SECURITY: Using sshAgentExec with array args prevents injection
-      await sshAgentExec(['--apple-use-keychain', expandedPath]);
+      await sshAgentExec(["--apple-use-keychain", expandedPath]);
     } else {
       // Windows, Linux and others
       // SECURITY: Path is passed as a single array element, not interpolated
@@ -282,8 +312,8 @@ export async function addSshKey(keyPath: string): Promise<void> {
     }
   } catch (error) {
     // SECURITY: Wrap error to hide internal details from users
-    throw wrapError(error, vscode.l10n.t('Failed to add SSH key'), {
-      field: 'sshKeyPath',
+    throw wrapError(error, vscode.l10n.t("Failed to add SSH key"), {
+      field: "sshKeyPath",
       context: { platform },
     });
   }
@@ -302,7 +332,7 @@ export async function removeSshKey(keyPath: string): Promise<void> {
 
   try {
     // SECURITY: Using sshAgentExec with array args
-    await sshAgentExec(['-d', expandedPath]);
+    await sshAgentExec(["-d", expandedPath]);
   } catch {
     // Ignore errors (key might not be loaded)
   }
@@ -316,11 +346,11 @@ export async function removeSshKey(keyPath: string): Promise<void> {
 export async function removeAllIdentityKeys(): Promise<void> {
   const identities = getIdentitiesWithValidation();
   const removePromises = identities
-    .filter(identity => identity.sshKeyPath)
-    .map(identity =>
+    .filter((identity) => identity.sshKeyPath)
+    .map((identity) =>
       removeSshKey(identity.sshKeyPath!).catch(() => {
         // Ignore individual errors
-      })
+      }),
     );
 
   await Promise.all(removePromises);
@@ -331,7 +361,9 @@ export async function removeAllIdentityKeys(): Promise<void> {
  *
  * Removes all identity keys and adds only the selected one
  */
-export async function switchToIdentitySshKey(identity: Identity): Promise<void> {
+export async function switchToIdentitySshKey(
+  identity: Identity,
+): Promise<void> {
   if (!identity.sshKeyPath) {
     // No SSH key configured for this identity
     return;
@@ -363,7 +395,7 @@ export async function checkKeyLoadedInAgent(keyPath: string): Promise<boolean> {
   // (ssh-add uses the key path as comment by default)
   // defense-in-depth: use exact/word-boundary matching to prevent
   // partial matches (e.g., "id_rsa" matching "id_rsa_work")
-  return keys.some(key => {
+  return keys.some((key) => {
     const keyPathBasename = path.basename(expandedPath);
     return isBasenameMatch(key.comment, keyPathBasename);
   });
@@ -374,7 +406,7 @@ export async function checkKeyLoadedInAgent(keyPath: string): Promise<boolean> {
  * @param token Optional cancellation token for aborting the operation
  */
 export async function detectCurrentIdentityFromSsh(
-  token?: vscode.CancellationToken
+  token?: vscode.CancellationToken,
 ): Promise<Identity | undefined> {
   if (token?.isCancellationRequested) {
     return undefined;
@@ -399,7 +431,9 @@ export async function detectCurrentIdentityFromSsh(
 
     const keyPathBasename = path.basename(expandPath(identity.sshKeyPath));
     // defense-in-depth: exact/word-boundary matching (see isBasenameMatch)
-    const isLoaded = keys.some(key => isBasenameMatch(key.comment, keyPathBasename));
+    const isLoaded = keys.some((key) =>
+      isBasenameMatch(key.comment, keyPathBasename),
+    );
     if (isLoaded) {
       return identity;
     }
@@ -413,7 +447,9 @@ export async function detectCurrentIdentityFromSsh(
  *
  * SECURITY: Path is validated before use
  */
-export async function getKeyFingerprint(keyPath: string): Promise<string | undefined> {
+export async function getKeyFingerprint(
+  keyPath: string,
+): Promise<string | undefined> {
   // SECURITY: Validate path before use
   validateKeyPathOrThrow(keyPath);
 
@@ -421,7 +457,7 @@ export async function getKeyFingerprint(keyPath: string): Promise<string | undef
 
   try {
     // SECURITY: Using sshKeygenExec with array args
-    const { stdout } = await sshKeygenExec(['-lf', expandedPath]);
+    const { stdout } = await sshKeygenExec(["-lf", expandedPath]);
     // SECURITY: Use split-based parsing to avoid ReDoS (SonarQube S5852)
     const parts = stdout.trim().split(/\s+/);
     return parts.length >= 2 ? parts[1] : undefined;
@@ -471,9 +507,14 @@ export interface KeyFileValidationResult {
 async function validateSshKeyFormat(filePath: string): Promise<boolean> {
   let fileHandle: Awaited<ReturnType<typeof fs.open>> | null = null;
   try {
-    fileHandle = await fs.open(filePath, 'r');
+    fileHandle = await fs.open(filePath, "r");
     const buffer = Buffer.alloc(FORMAT_CHECK_BYTES);
-    const { bytesRead } = await fileHandle.read(buffer, 0, FORMAT_CHECK_BYTES, 0);
+    const { bytesRead } = await fileHandle.read(
+      buffer,
+      0,
+      FORMAT_CHECK_BYTES,
+      0,
+    );
 
     if (bytesRead === 0) {
       return false;
@@ -483,24 +524,24 @@ async function validateSshKeyFormat(filePath: string): Promise<boolean> {
     // PuTTY format headers are ASCII-compatible, so UTF-8 should work
     let header: string;
     try {
-      header = buffer.subarray(0, bytesRead).toString('utf8').trimStart();
+      header = buffer.subarray(0, bytesRead).toString("utf8").trimStart();
     } catch {
       // Fallback to Latin-1 if UTF-8 decoding fails (shouldn't happen for valid SSH keys)
-      header = buffer.subarray(0, bytesRead).toString('latin1').trimStart();
+      header = buffer.subarray(0, bytesRead).toString("latin1").trimStart();
     }
 
     // Check if the file starts with any valid SSH key header
     // Note: PuTTY format headers are ASCII, so UTF-8 decoding works fine
-    return VALID_SSH_KEY_HEADERS.some(validHeader =>
-      header.startsWith(validHeader)
+    return VALID_SSH_KEY_HEADERS.some((validHeader) =>
+      header.startsWith(validHeader),
     );
   } catch (error) {
     // SECURITY: Log read errors for security audit
     // If we can't read the file, it's not a valid key
     securityLogger.logValidationFailure(
-      'ssh-key-format',
-      'Failed to read file for format validation',
-      error instanceof Error ? error.name : 'unknown'
+      "ssh-key-format",
+      "Failed to read file for format validation",
+      error instanceof Error ? error.name : "unknown",
     );
     return false;
   } finally {
@@ -511,9 +552,9 @@ async function validateSshKeyFormat(filePath: string): Promise<boolean> {
       } catch (closeError) {
         // Log but don't throw - we're in cleanup
         securityLogger.logValidationFailure(
-          'ssh-key-format',
-          'Failed to close file handle',
-          closeError instanceof Error ? closeError.name : 'unknown'
+          "ssh-key-format",
+          "Failed to close file handle",
+          closeError instanceof Error ? closeError.name : "unknown",
         );
       }
     }
@@ -525,45 +566,50 @@ async function validateSshKeyFormat(filePath: string): Promise<boolean> {
  * @internal
  */
 function handleFileStatError(error: unknown): KeyFileValidationResult {
-  const errorName = error instanceof Error ? error.name : 'unknown';
+  const errorName = error instanceof Error ? error.name : "unknown";
   const errorCode = (error as NodeJS.ErrnoException)?.code;
 
-  if (errorCode === 'ENOENT') {
-    securityLogger.logValidationFailure('ssh-key-file', 'File does not exist');
-    return { valid: false, reason: 'file_not_found' };
+  if (errorCode === "ENOENT") {
+    securityLogger.logValidationFailure("ssh-key-file", "File does not exist");
+    return { valid: false, reason: "file_not_found" };
   }
 
-  if (errorCode === 'EACCES' || errorCode === 'EPERM') {
-    securityLogger.logValidationFailure('ssh-key-file', 'File access denied');
-    return { valid: false, reason: 'access_denied' };
+  if (errorCode === "EACCES" || errorCode === "EPERM") {
+    securityLogger.logValidationFailure("ssh-key-file", "File access denied");
+    return { valid: false, reason: "access_denied" };
   }
 
   securityLogger.logValidationFailure(
-    'ssh-key-file',
-    `File stat failed: ${errorName} (${errorCode ?? 'unknown'})`
+    "ssh-key-file",
+    `File stat failed: ${errorName} (${errorCode ?? "unknown"})`,
   );
-  return { valid: false, reason: 'stat_error' };
+  return { valid: false, reason: "stat_error" };
 }
 
 /**
  * Validate file type (must be regular file).
  * @internal
  */
-function validateKeyFileType(stats: Awaited<ReturnType<typeof fs.stat>>): KeyFileValidationResult | null {
+function validateKeyFileType(
+  stats: Awaited<ReturnType<typeof fs.stat>>,
+): KeyFileValidationResult | null {
   if (stats.isFile()) {
     return null; // Valid
   }
 
   if (stats.isDirectory()) {
     securityLogger.logValidationFailure(
-      'ssh-key-file',
-      'Path points to a directory, not a file'
+      "ssh-key-file",
+      "Path points to a directory, not a file",
     );
-    return { valid: false, reason: 'is_directory' };
+    return { valid: false, reason: "is_directory" };
   }
 
-  securityLogger.logValidationFailure('ssh-key-file', 'Path is not a regular file');
-  return { valid: false, reason: 'not_regular_file' };
+  securityLogger.logValidationFailure(
+    "ssh-key-file",
+    "Path is not a regular file",
+  );
+  return { valid: false, reason: "not_regular_file" };
 }
 
 /**
@@ -573,18 +619,18 @@ function validateKeyFileType(stats: Awaited<ReturnType<typeof fs.stat>>): KeyFil
 function validateKeyFileSize(size: number): KeyFileValidationResult | null {
   if (size < MIN_SSH_KEY_FILE_SIZE) {
     securityLogger.logValidationFailure(
-      'ssh-key-file',
-      `File size ${size} is below minimum ${MIN_SSH_KEY_FILE_SIZE}`
+      "ssh-key-file",
+      `File size ${size} is below minimum ${MIN_SSH_KEY_FILE_SIZE}`,
     );
-    return { valid: false, reason: 'file_too_small' };
+    return { valid: false, reason: "file_too_small" };
   }
 
   if (size > MAX_SSH_KEY_FILE_SIZE) {
     securityLogger.logValidationFailure(
-      'ssh-key-file',
-      `File size ${size} exceeds maximum ${MAX_SSH_KEY_FILE_SIZE}`
+      "ssh-key-file",
+      `File size ${size} exceeds maximum ${MAX_SSH_KEY_FILE_SIZE}`,
     );
-    return { valid: false, reason: 'file_too_large' };
+    return { valid: false, reason: "file_too_large" };
   }
 
   return null; // Valid
@@ -594,30 +640,34 @@ function validateKeyFileSize(size: number): KeyFileValidationResult | null {
  * Validate file permissions (Unix only).
  * @internal
  */
-function validateKeyFilePermissions(mode: number): KeyFileValidationResult | null {
+function validateKeyFilePermissions(
+  mode: number,
+): KeyFileValidationResult | null {
   // Skip on Windows (uses ACL-based permissions)
-  if (process.platform === 'win32') {
+  if (process.platform === "win32") {
     return null;
   }
 
   const modeString = (mode & 0o777).toString(8); // eslint-disable-line no-bitwise -- file permission extraction
 
   // Check if group or others have any permissions
-  if ((mode & INSECURE_PERMISSION_BITS) !== 0) { // eslint-disable-line no-bitwise -- permission check
+  if ((mode & INSECURE_PERMISSION_BITS) !== 0) {
+    // eslint-disable-line no-bitwise -- permission check
     securityLogger.logValidationFailure(
-      'ssh-key-file',
-      `Insecure permissions: ${modeString} (group/others have access)`
+      "ssh-key-file",
+      `Insecure permissions: ${modeString} (group/others have access)`,
     );
-    return { valid: false, reason: 'insecure_permissions' };
+    return { valid: false, reason: "insecure_permissions" };
   }
 
   // Check if owner execute bit is set (SSH keys should not be executable)
-  if ((mode & OWNER_EXECUTE_BIT) !== 0) { // eslint-disable-line no-bitwise -- permission check
+  if ((mode & OWNER_EXECUTE_BIT) !== 0) {
+    // eslint-disable-line no-bitwise -- permission check
     securityLogger.logValidationFailure(
-      'ssh-key-file',
-      `Insecure permissions: ${modeString} (owner execute bit set)`
+      "ssh-key-file",
+      `Insecure permissions: ${modeString} (owner execute bit set)`,
     );
-    return { valid: false, reason: 'insecure_permissions' };
+    return { valid: false, reason: "insecure_permissions" };
   }
 
   return null; // Valid
@@ -644,7 +694,7 @@ function validateKeyFilePermissions(mode: number): KeyFileValidationResult | nul
  * @returns Validation result
  */
 async function validateKeyFileBeforeAddToAgent(
-  expandedPath: string
+  expandedPath: string,
 ): Promise<KeyFileValidationResult> {
   try {
     // Get file stats
@@ -671,25 +721,26 @@ async function validateKeyFileBeforeAddToAgent(
     const isValidFormat = await validateSshKeyFormat(expandedPath);
     if (!isValidFormat) {
       securityLogger.logValidationFailure(
-        'ssh-key-file',
-        'File does not have a valid SSH private key format'
+        "ssh-key-file",
+        "File does not have a valid SSH private key format",
       );
-      return { valid: false, reason: 'invalid_format' };
+      return { valid: false, reason: "invalid_format" };
     }
 
     return { valid: true };
   } catch (error) {
     // SECURITY: Log unexpected errors with details for security audit
-    const errorName = error instanceof Error ? error.name : 'unknown';
+    const errorName = error instanceof Error ? error.name : "unknown";
     const errorMessage = error instanceof Error ? error.message : String(error);
-    const truncatedMessage = errorMessage.length > 100
-      ? errorMessage.slice(0, 100) + '...[truncated]'
-      : errorMessage;
+    const truncatedMessage =
+      errorMessage.length > 100
+        ? errorMessage.slice(0, 100) + "...[truncated]"
+        : errorMessage;
     securityLogger.logValidationFailure(
-      'ssh-key-file',
+      "ssh-key-file",
       `Unexpected error during validation: ${errorName}`,
-      truncatedMessage
+      truncatedMessage,
     );
-    return { valid: false, reason: 'validation_error' };
+    return { valid: false, reason: "validation_error" };
   }
 }

--- a/extensions/git-id-switcher/src/ssh/sshAgent.ts
+++ b/extensions/git-id-switcher/src/ssh/sshAgent.ts
@@ -651,8 +651,8 @@ function validateKeyFilePermissions(
   const modeString = (mode & 0o777).toString(8); // eslint-disable-line no-bitwise -- file permission extraction
 
   // Check if group or others have any permissions
+  // eslint-disable-next-line no-bitwise -- permission bit extraction
   if ((mode & INSECURE_PERMISSION_BITS) !== 0) {
-    // eslint-disable-line no-bitwise -- permission check
     securityLogger.logValidationFailure(
       "ssh-key-file",
       `Insecure permissions: ${modeString} (group/others have access)`,
@@ -661,8 +661,8 @@ function validateKeyFilePermissions(
   }
 
   // Check if owner execute bit is set (SSH keys should not be executable)
+  // eslint-disable-next-line no-bitwise -- permission bit extraction
   if ((mode & OWNER_EXECUTE_BIT) !== 0) {
-    // eslint-disable-line no-bitwise -- permission check
     securityLogger.logValidationFailure(
       "ssh-key-file",
       `Insecure permissions: ${modeString} (owner execute bit set)`,

--- a/extensions/git-id-switcher/src/test/configSchema.test.ts
+++ b/extensions/git-id-switcher/src/test/configSchema.test.ts
@@ -10,13 +10,13 @@
  * - Schema validation edge cases
  */
 
-import * as assert from 'node:assert';
+import * as assert from "node:assert";
 import {
   validateIdentitySchema,
   validateIdentitiesSchema,
   getSchemaDocumentation,
   IDENTITY_SCHEMA,
-} from '../identity/configSchema';
+} from "../identity/configSchema";
 
 /**
  * Test empty string handling for required fields
@@ -25,66 +25,88 @@ import {
  * Empty string should be treated as "missing" and trigger a required field error.
  */
 function testRequiredFieldsEmptyString(): void {
-  console.log('Testing required fields with empty string...');
+  console.log("Testing required fields with empty string...");
 
   // Test 1: Empty string for 'id' should fail
   {
     const identity = {
-      id: '',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "",
+      name: "Test User",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Empty id should fail validation');
+    assert.strictEqual(result.valid, false, "Empty id should fail validation");
     assert.ok(
-      result.errors.some(e => e.field === 'id' && e.message.includes('Required')),
-      'Error should indicate id is required'
+      result.errors.some(
+        (e) => e.field === "id" && e.message.includes("Required"),
+      ),
+      "Error should indicate id is required",
     );
   }
 
   // Test 2: Empty string for 'name' should fail
   {
     const identity = {
-      id: 'test',
-      name: '',
-      email: 'test@example.com',
+      id: "test",
+      name: "",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Empty name should fail validation');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Empty name should fail validation",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'name' && e.message.includes('Required')),
-      'Error should indicate name is required'
+      result.errors.some(
+        (e) => e.field === "name" && e.message.includes("Required"),
+      ),
+      "Error should indicate name is required",
     );
   }
 
   // Test 3: Empty string for 'email' should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: '',
+      id: "test",
+      name: "Test User",
+      email: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Empty email should fail validation');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Empty email should fail validation",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'email' && e.message.includes('Required')),
-      'Error should indicate email is required'
+      result.errors.some(
+        (e) => e.field === "email" && e.message.includes("Required"),
+      ),
+      "Error should indicate email is required",
     );
   }
 
   // Test 4: All required fields empty should fail with multiple errors
   {
     const identity = {
-      id: '',
-      name: '',
-      email: '',
+      id: "",
+      name: "",
+      email: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'All empty required fields should fail');
-    assert.strictEqual(result.errors.length, 3, 'Should have 3 errors for 3 required fields');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "All empty required fields should fail",
+    );
+    assert.strictEqual(
+      result.errors.length,
+      3,
+      "Should have 3 errors for 3 required fields",
+    );
   }
 
-  console.log('  Required fields empty string tests passed!');
+  console.log("  Required fields empty string tests passed!");
 }
 
 /**
@@ -94,105 +116,145 @@ function testRequiredFieldsEmptyString(): void {
  * This allows default config with "" values to pass validation without errors.
  */
 function testOptionalFieldsEmptyString(): void {
-  console.log('Testing optional fields with empty string...');
+  console.log("Testing optional fields with empty string...");
 
   // Test 1: Empty string for 'service' should pass (treated as not set)
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      service: '',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      service: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Empty service should pass (treated as not set)');
-    assert.strictEqual(result.errors.length, 0, 'No errors for empty service');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Empty service should pass (treated as not set)",
+    );
+    assert.strictEqual(result.errors.length, 0, "No errors for empty service");
   }
 
   // Test 2: Empty string for 'sshKeyPath' should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshKeyPath: '',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Empty sshKeyPath should pass (treated as not set)');
-    assert.strictEqual(result.errors.length, 0, 'No errors for empty sshKeyPath');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Empty sshKeyPath should pass (treated as not set)",
+    );
+    assert.strictEqual(
+      result.errors.length,
+      0,
+      "No errors for empty sshKeyPath",
+    );
   }
 
   // Test 3: Empty string for 'sshHost' should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshHost: '',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshHost: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Empty sshHost should pass (treated as not set)');
-    assert.strictEqual(result.errors.length, 0, 'No errors for empty sshHost');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Empty sshHost should pass (treated as not set)",
+    );
+    assert.strictEqual(result.errors.length, 0, "No errors for empty sshHost");
   }
 
   // Test 4: Empty string for 'gpgKeyId' should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: '',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Empty gpgKeyId should pass (treated as not set)');
-    assert.strictEqual(result.errors.length, 0, 'No errors for empty gpgKeyId');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Empty gpgKeyId should pass (treated as not set)",
+    );
+    assert.strictEqual(result.errors.length, 0, "No errors for empty gpgKeyId");
   }
 
   // Test 5: Empty string for 'description' should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      description: '',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      description: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Empty description should pass (treated as not set)');
-    assert.strictEqual(result.errors.length, 0, 'No errors for empty description');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Empty description should pass (treated as not set)",
+    );
+    assert.strictEqual(
+      result.errors.length,
+      0,
+      "No errors for empty description",
+    );
   }
 
   // Test 6: Empty string for 'icon' should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      icon: '',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      icon: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Empty icon should pass (treated as not set)');
-    assert.strictEqual(result.errors.length, 0, 'No errors for empty icon');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Empty icon should pass (treated as not set)",
+    );
+    assert.strictEqual(result.errors.length, 0, "No errors for empty icon");
   }
 
   // Test 7: All optional fields empty should pass (default config scenario)
   {
     const identity = {
-      id: 'example',
-      name: 'Example User',
-      email: 'example@example.com',
-      service: '',
-      sshKeyPath: '',
-      sshHost: '',
-      gpgKeyId: '',
-      description: '',
-      icon: '',
+      id: "example",
+      name: "Example User",
+      email: "example@example.com",
+      service: "",
+      sshKeyPath: "",
+      sshHost: "",
+      gpgKeyId: "",
+      description: "",
+      icon: "",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'All empty optional fields should pass');
-    assert.strictEqual(result.errors.length, 0, 'No errors when all optional fields are empty');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "All empty optional fields should pass",
+    );
+    assert.strictEqual(
+      result.errors.length,
+      0,
+      "No errors when all optional fields are empty",
+    );
   }
 
-  console.log('  Optional fields empty string tests passed!');
+  console.log("  Optional fields empty string tests passed!");
 }
 
 /**
@@ -202,60 +264,72 @@ function testOptionalFieldsEmptyString(): void {
  * even when the empty string check is in place.
  */
 function testMaliciousValueRejection(): void {
-  console.log('Testing malicious value rejection...');
+  console.log("Testing malicious value rejection...");
 
   // Test 1: Command injection in sshKeyPath should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshKeyPath: '$(rm -rf /)',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "$(rm -rf /)",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Command injection in sshKeyPath should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Command injection in sshKeyPath should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'sshKeyPath'),
-      'Error should mention sshKeyPath field'
+      result.errors.some((e) => e.field === "sshKeyPath"),
+      "Error should mention sshKeyPath field",
     );
   }
 
   // Test 2: Backtick injection in name should fail
   {
     const identity = {
-      id: 'test',
-      name: 'test`id`',
-      email: 'test@example.com',
+      id: "test",
+      name: "test`id`",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Backtick injection in name should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Backtick injection in name should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'name'),
-      'Error should mention name field'
+      result.errors.some((e) => e.field === "name"),
+      "Error should mention name field",
     );
   }
 
   // Test 3: Pipe command in name should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test | cat /etc/passwd',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test | cat /etc/passwd",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Pipe command in name should fail');
+    assert.strictEqual(result.valid, false, "Pipe command in name should fail");
   }
 
   // Test 4: Command substitution in service should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      service: '$(whoami)',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      service: "$(whoami)",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Command substitution in service should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Command substitution in service should fail",
+    );
   }
 
   // Test 5: Ampersand in description should PASS (display-only field, never passed to shell)
@@ -263,13 +337,17 @@ function testMaliciousValueRejection(): void {
   // Therefore, shell metacharacters like & are safe and allowed for usability (e.g., "AT&T")
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      description: 'Test & description with ampersand',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      description: "Test & description with ampersand",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Ampersand in description should pass (display-only field)');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Ampersand in description should pass (display-only field)",
+    );
   }
 
   // Test 6: Path traversal in sshKeyPath
@@ -278,78 +356,114 @@ function testMaliciousValueRejection(): void {
   // This is by design: configSchema handles format validation, validation.ts handles security
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshKeyPath: '/home/../etc/passwd',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "/home/../etc/passwd",
     };
     const result = validateIdentitySchema(identity);
     // configSchema.ts allows this because pattern only checks for dangerous chars
     // The path traversal check is in validation.ts
-    assert.strictEqual(result.valid, true, 'configSchema does not check path traversal (validation.ts does)');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "configSchema does not check path traversal (validation.ts does)",
+    );
   }
 
   // Test 7: Relative path in sshKeyPath should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshKeyPath: 'relative/path/key',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "relative/path/key",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Relative path in sshKeyPath should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Relative path in sshKeyPath should fail",
+    );
   }
 
-  // Test 7.1: Windows absolute path in sshKeyPath should pass
+  // Test 7.1: Windows absolute path in sshKeyPath should fail (use ~/.ssh/ format)
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
       sshKeyPath: String.raw`C:\Users\test\.ssh\id_rsa`,
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Windows absolute path in sshKeyPath should pass');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Windows absolute path in sshKeyPath should fail",
+    );
   }
 
-  // Test 7.2: Windows lowercase drive letter should pass
+  // Test 7.2: Windows lowercase drive letter should fail (use ~/.ssh/ format)
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
       sshKeyPath: String.raw`d:\keys\work_key`,
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Windows lowercase drive letter should pass');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Windows lowercase drive letter should fail",
+    );
+  }
+
+  // Test 7.3: Windows forward-slash path should fail (use ~/.ssh/ format)
+  {
+    const identity = {
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "C:/Users/test/.ssh/id_rsa",
+    };
+    const result = validateIdentitySchema(identity);
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Windows forward-slash path in sshKeyPath should fail",
+    );
   }
 
   // Test 8: Invalid sshHost format should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshHost: '-invalid-start',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshHost: "-invalid-start",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Invalid sshHost format should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Invalid sshHost format should fail",
+    );
   }
 
   // Test 9: Non-hex gpgKeyId should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'not-hex-value',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "not-hex-value",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Non-hex gpgKeyId should fail');
+    assert.strictEqual(result.valid, false, "Non-hex gpgKeyId should fail");
   }
 
-  console.log('  Malicious value rejection tests passed!');
+  console.log("  Malicious value rejection tests passed!");
 }
 
 /**
@@ -359,324 +473,384 @@ function testMaliciousValueRejection(): void {
  * This behavior is outside current scope but worth documenting via tests.
  */
 function testWhitespaceHandling(): void {
-  console.log('Testing whitespace handling...');
+  console.log("Testing whitespace handling...");
 
   // Test 1: Whitespace-only service (passes pattern, may be UX issue but not security)
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      service: '   ',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      service: "   ",
     };
     const result = validateIdentitySchema(identity);
     // Current behavior: whitespace passes pattern validation
     // This is noted as potential UX improvement in PRD but not a security issue
-    assert.strictEqual(result.valid, true, 'Whitespace-only service passes current pattern');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Whitespace-only service passes current pattern",
+    );
   }
 
   // Test 2: Whitespace-only id should fail (still needs to match pattern)
   {
     const identity = {
-      id: '   ',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "   ",
+      name: "Test User",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Whitespace-only id should fail pattern check');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Whitespace-only id should fail pattern check",
+    );
   }
 
-  console.log('  Whitespace handling tests passed!');
+  console.log("  Whitespace handling tests passed!");
 }
 
 /**
  * Test validateIdentitySchema edge cases
  */
 function testValidateIdentitySchemaEdgeCases(): void {
-  console.log('Testing validateIdentitySchema edge cases...');
+  console.log("Testing validateIdentitySchema edge cases...");
 
   // Test 1: null input should fail
   {
     const result = validateIdentitySchema(null);
-    assert.strictEqual(result.valid, false, 'null input should fail');
+    assert.strictEqual(result.valid, false, "null input should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'root'),
-      'Error should mention root for null input'
+      result.errors.some((e) => e.field === "root"),
+      "Error should mention root for null input",
     );
   }
 
   // Test 2: undefined input should fail
   {
     const result = validateIdentitySchema(undefined);
-    assert.strictEqual(result.valid, false, 'undefined input should fail');
+    assert.strictEqual(result.valid, false, "undefined input should fail");
   }
 
   // Test 3: Array input should fail
   {
     const result = validateIdentitySchema([]);
-    assert.strictEqual(result.valid, false, 'Array input should fail');
+    assert.strictEqual(result.valid, false, "Array input should fail");
   }
 
   // Test 4: Primitive input should fail
   {
-    const result = validateIdentitySchema('string');
-    assert.strictEqual(result.valid, false, 'String input should fail');
+    const result = validateIdentitySchema("string");
+    assert.strictEqual(result.valid, false, "String input should fail");
   }
 
   // Test 5: Unknown field should be flagged
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      unknownField: 'value',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      unknownField: "value",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Unknown field should fail');
+    assert.strictEqual(result.valid, false, "Unknown field should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'unknownField' && e.message.includes('Unknown')),
-      'Error should mention unknown field'
+      result.errors.some(
+        (e) => e.field === "unknownField" && e.message.includes("Unknown"),
+      ),
+      "Error should mention unknown field",
     );
   }
 
   // Test 6: Too many fields should fail (DoS protection)
   {
     const identity: Record<string, unknown> = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
     };
     // Add 101 unknown fields
     for (let i = 0; i < 101; i++) {
-      identity[`field${i}`] = 'value';
+      identity[`field${i}`] = "value";
     }
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Too many fields should fail');
+    assert.strictEqual(result.valid, false, "Too many fields should fail");
     assert.ok(
-      result.errors.some(e => e.message.includes('too many fields')),
-      'Error should mention too many fields'
+      result.errors.some((e) => e.message.includes("too many fields")),
+      "Error should mention too many fields",
     );
   }
 
   // Test 7: Valid identity with all fields should pass
   {
     const identity = {
-      id: 'work',
-      icon: '👔',
-      name: 'John Doe',
-      service: 'GitHub',
-      email: 'john@company.com',
-      description: 'Work account',
-      sshKeyPath: '~/.ssh/id_work',
-      sshHost: 'github.com-work',
-      gpgKeyId: 'ABCD1234',
+      id: "work",
+      icon: "👔",
+      name: "John Doe",
+      service: "GitHub",
+      email: "john@company.com",
+      description: "Work account",
+      sshKeyPath: "~/.ssh/id_work",
+      sshHost: "github.com-work",
+      gpgKeyId: "ABCD1234",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Valid identity with all fields should pass');
-    assert.strictEqual(result.errors.length, 0, 'No errors for valid identity');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Valid identity with all fields should pass",
+    );
+    assert.strictEqual(result.errors.length, 0, "No errors for valid identity");
   }
 
   // Test 8: null value in optional field should be treated as not set
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
       service: null,
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'null in optional field should pass (treated as not set)');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "null in optional field should pass (treated as not set)",
+    );
   }
 
   // Test 9: undefined value in optional field should be treated as not set
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
       service: undefined,
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'undefined in optional field should pass (treated as not set)');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "undefined in optional field should pass (treated as not set)",
+    );
   }
 
   // Test 10: null value in required field should fail
   {
     const identity = {
-      id: 'test',
+      id: "test",
       name: null,
-      email: 'test@example.com',
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'null in required field should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "null in required field should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'name' && e.message.includes('Required')),
-      'Error should indicate name is required'
+      result.errors.some(
+        (e) => e.field === "name" && e.message.includes("Required"),
+      ),
+      "Error should indicate name is required",
     );
   }
 
-  console.log('  validateIdentitySchema edge cases tests passed!');
+  console.log("  validateIdentitySchema edge cases tests passed!");
 }
 
 /**
  * Test validateIdentitiesSchema
  */
 function testValidateIdentitiesSchema(): void {
-  console.log('Testing validateIdentitiesSchema...');
+  console.log("Testing validateIdentitiesSchema...");
 
   // Test 1: Empty array should pass
   {
     const result = validateIdentitiesSchema([]);
-    assert.strictEqual(result.valid, true, 'Empty array should pass');
+    assert.strictEqual(result.valid, true, "Empty array should pass");
   }
 
   // Test 2: Non-array input should fail
   {
     const result = validateIdentitiesSchema({});
-    assert.strictEqual(result.valid, false, 'Non-array input should fail');
+    assert.strictEqual(result.valid, false, "Non-array input should fail");
   }
 
   // Test 3: Array with valid identities should pass
   {
     const identities = [
-      { id: 'personal', name: 'John', email: 'john@example.com' },
-      { id: 'work', name: 'John Work', email: 'john@company.com' },
+      { id: "personal", name: "John", email: "john@example.com" },
+      { id: "work", name: "John Work", email: "john@company.com" },
     ];
     const result = validateIdentitiesSchema(identities);
-    assert.strictEqual(result.valid, true, 'Valid identities array should pass');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Valid identities array should pass",
+    );
   }
 
   // Test 4: Duplicate IDs should fail
   {
     const identities = [
-      { id: 'same', name: 'John', email: 'john@example.com' },
-      { id: 'same', name: 'Jane', email: 'jane@example.com' },
+      { id: "same", name: "John", email: "john@example.com" },
+      { id: "same", name: "Jane", email: "jane@example.com" },
     ];
     const result = validateIdentitiesSchema(identities);
-    assert.strictEqual(result.valid, false, 'Duplicate IDs should fail');
+    assert.strictEqual(result.valid, false, "Duplicate IDs should fail");
     assert.ok(
-      result.errors.some(e => e.message.includes('Duplicate')),
-      'Error should mention duplicate'
+      result.errors.some((e) => e.message.includes("Duplicate")),
+      "Error should mention duplicate",
     );
   }
 
   // Test 5: Array with one invalid identity should fail
   {
     const identities = [
-      { id: 'valid', name: 'John', email: 'john@example.com' },
-      { id: 'invalid', name: 'Test$(rm -rf /)', email: 'test@example.com' },
+      { id: "valid", name: "John", email: "john@example.com" },
+      { id: "invalid", name: "Test$(rm -rf /)", email: "test@example.com" },
     ];
     const result = validateIdentitiesSchema(identities);
-    assert.strictEqual(result.valid, false, 'Array with invalid identity should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Array with invalid identity should fail",
+    );
   }
 
   // Test 6: Array with empty string in optional field should pass
   {
     const identities = [
       {
-        id: 'test',
-        name: 'Test User',
-        email: 'test@example.com',
-        service: '',
-        sshKeyPath: '',
+        id: "test",
+        name: "Test User",
+        email: "test@example.com",
+        service: "",
+        sshKeyPath: "",
       },
     ];
     const result = validateIdentitiesSchema(identities);
-    assert.strictEqual(result.valid, true, 'Array with empty optional fields should pass');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Array with empty optional fields should pass",
+    );
   }
 
   // Test 7: Array with non-object elements should fail (covers extractIdentityId edge case)
   {
     const identities = [
-      'not-an-object',
+      "not-an-object",
       42,
       null,
-      { id: 'valid', name: 'Valid User', email: 'valid@example.com' },
+      { id: "valid", name: "Valid User", email: "valid@example.com" },
     ];
     const result = validateIdentitiesSchema(identities);
-    assert.strictEqual(result.valid, false, 'Array with non-object elements should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Array with non-object elements should fail",
+    );
   }
 
   // Test 8: Array with identity missing id (covers checkDuplicateIds undefined-id path)
   {
     const identities = [
-      { name: 'No ID User', email: 'noid@example.com' },
-      { id: 'valid', name: 'Valid User', email: 'valid@example.com' },
+      { name: "No ID User", email: "noid@example.com" },
+      { id: "valid", name: "Valid User", email: "valid@example.com" },
     ];
     const result = validateIdentitiesSchema(identities);
     // Should fail because first identity is missing required 'id'
-    assert.strictEqual(result.valid, false, 'Identity missing id should fail');
+    assert.strictEqual(result.valid, false, "Identity missing id should fail");
     // But should not crash in duplicate ID detection
     assert.ok(
-      result.errors.some(e => e.message.includes('Required')),
-      'Error should indicate required field is missing'
+      result.errors.some((e) => e.message.includes("Required")),
+      "Error should indicate required field is missing",
     );
   }
 
-  console.log('  validateIdentitiesSchema tests passed!');
+  console.log("  validateIdentitiesSchema tests passed!");
 }
 
 /**
  * Test getSchemaDocumentation
  */
 function testGetSchemaDocumentation(): void {
-  console.log('Testing getSchemaDocumentation...');
+  console.log("Testing getSchemaDocumentation...");
 
   const doc = getSchemaDocumentation();
 
   // Test 1: Should return a string
   {
-    assert.strictEqual(typeof doc, 'string', 'Should return a string');
+    assert.strictEqual(typeof doc, "string", "Should return a string");
   }
 
   // Test 2: Should include all field names
   {
     const fieldNames = Object.keys(IDENTITY_SCHEMA);
     for (const field of fieldNames) {
-      assert.ok(doc.includes(field), `Documentation should include field: ${field}`);
+      assert.ok(
+        doc.includes(field),
+        `Documentation should include field: ${field}`,
+      );
     }
   }
 
   // Test 3: Should indicate required fields
   {
-    assert.ok(doc.includes('(required)'), 'Documentation should indicate required fields');
+    assert.ok(
+      doc.includes("(required)"),
+      "Documentation should indicate required fields",
+    );
   }
 
   // Test 4: Should include type information
   {
-    assert.ok(doc.includes('string'), 'Documentation should include type information');
+    assert.ok(
+      doc.includes("string"),
+      "Documentation should include type information",
+    );
   }
 
-  console.log('  getSchemaDocumentation tests passed!');
+  console.log("  getSchemaDocumentation tests passed!");
 }
 
 /**
  * Test IDENTITY_SCHEMA structure
  */
 function testIdentitySchemaStructure(): void {
-  console.log('Testing IDENTITY_SCHEMA structure...');
+  console.log("Testing IDENTITY_SCHEMA structure...");
 
   // Test 1: Required fields should be marked
   {
-    const requiredFields = ['id', 'name', 'email'];
+    const requiredFields = ["id", "name", "email"];
     for (const field of requiredFields) {
       assert.ok(IDENTITY_SCHEMA[field], `Schema should have field: ${field}`);
       assert.strictEqual(
         IDENTITY_SCHEMA[field].required,
         true,
-        `${field} should be marked as required`
+        `${field} should be marked as required`,
       );
     }
   }
 
   // Test 2: Optional fields should not be marked as required
   {
-    const optionalFields = ['icon', 'service', 'description', 'sshKeyPath', 'sshHost', 'gpgKeyId'];
+    const optionalFields = [
+      "icon",
+      "service",
+      "description",
+      "sshKeyPath",
+      "sshHost",
+      "gpgKeyId",
+    ];
     for (const field of optionalFields) {
       assert.ok(IDENTITY_SCHEMA[field], `Schema should have field: ${field}`);
       assert.ok(
         !IDENTITY_SCHEMA[field].required,
-        `${field} should not be marked as required`
+        `${field} should not be marked as required`,
       );
     }
   }
@@ -695,309 +869,357 @@ function testIdentitySchemaStructure(): void {
       if (schema.pattern) {
         assert.doesNotThrow(
           () => new RegExp(schema.pattern as string),
-          `${field} pattern should be valid regex`
+          `${field} pattern should be valid regex`,
         );
       }
     }
   }
 
-  console.log('  IDENTITY_SCHEMA structure tests passed!');
+  console.log("  IDENTITY_SCHEMA structure tests passed!");
 }
 
 /**
  * Test length constraints (minLength, maxLength)
  */
 function testLengthConstraints(): void {
-  console.log('Testing length constraints...');
+  console.log("Testing length constraints...");
 
   // Test 1: gpgKeyId too short (minLength: 8) should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'ABCD', // Only 4 chars, needs 8
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "ABCD", // Only 4 chars, needs 8
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'gpgKeyId too short should fail');
+    assert.strictEqual(result.valid, false, "gpgKeyId too short should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'gpgKeyId' && e.message.includes('at least')),
-      'Error should mention minimum length'
+      result.errors.some(
+        (e) => e.field === "gpgKeyId" && e.message.includes("at least"),
+      ),
+      "Error should mention minimum length",
     );
   }
 
   // Test 2: gpgKeyId at minimum length (8) should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'ABCD1234', // Exactly 8 chars
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "ABCD1234", // Exactly 8 chars
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'gpgKeyId at minimum length should pass');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "gpgKeyId at minimum length should pass",
+    );
   }
 
   // Test 3: gpgKeyId too long (maxLength: 40) should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'A'.repeat(41), // 41 chars, max is 40
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "A".repeat(41), // 41 chars, max is 40
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'gpgKeyId too long should fail');
+    assert.strictEqual(result.valid, false, "gpgKeyId too long should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'gpgKeyId' && e.message.includes('maximum')),
-      'Error should mention maximum length'
+      result.errors.some(
+        (e) => e.field === "gpgKeyId" && e.message.includes("maximum"),
+      ),
+      "Error should mention maximum length",
     );
   }
 
   // Test 4: id too long (maxLength: 64) should fail
   {
     const identity = {
-      id: 'a'.repeat(65), // 65 chars, max is 64
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "a".repeat(65), // 65 chars, max is 64
+      name: "Test User",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'id too long should fail');
+    assert.strictEqual(result.valid, false, "id too long should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'id'),
-      'Error should mention id field'
+      result.errors.some((e) => e.field === "id"),
+      "Error should mention id field",
     );
   }
 
   // Test 5: name too long (maxLength: 256) should fail
   {
     const identity = {
-      id: 'test',
-      name: 'a'.repeat(257), // 257 chars, max is 256
-      email: 'test@example.com',
+      id: "test",
+      name: "a".repeat(257), // 257 chars, max is 256
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'name too long should fail');
+    assert.strictEqual(result.valid, false, "name too long should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'name' && e.message.includes('maximum')),
-      'Error should mention maximum length for name'
+      result.errors.some(
+        (e) => e.field === "name" && e.message.includes("maximum"),
+      ),
+      "Error should mention maximum length for name",
     );
   }
 
   // Test 6: email too long (maxLength: 320) should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'a'.repeat(310) + '@example.com', // Over 320 chars
+      id: "test",
+      name: "Test User",
+      email: "a".repeat(310) + "@example.com", // Over 320 chars
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'email too long should fail');
+    assert.strictEqual(result.valid, false, "email too long should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'email' && e.message.includes('maximum')),
-      'Error should mention maximum length for email'
+      result.errors.some(
+        (e) => e.field === "email" && e.message.includes("maximum"),
+      ),
+      "Error should mention maximum length for email",
     );
   }
 
   // Test 7: description too long (maxLength: 500) should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      description: 'a'.repeat(501), // 501 chars, max is 500
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      description: "a".repeat(501), // 501 chars, max is 500
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'description too long should fail');
+    assert.strictEqual(result.valid, false, "description too long should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'description' && e.message.includes('maximum')),
-      'Error should mention maximum length for description'
+      result.errors.some(
+        (e) => e.field === "description" && e.message.includes("maximum"),
+      ),
+      "Error should mention maximum length for description",
     );
   }
 
   // Test 8: sshHost too long (maxLength: 253) should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshHost: 'a'.repeat(254), // 254 chars, max is 253
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshHost: "a".repeat(254), // 254 chars, max is 253
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'sshHost too long should fail');
+    assert.strictEqual(result.valid, false, "sshHost too long should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'sshHost' && e.message.includes('maximum')),
-      'Error should mention maximum length for sshHost'
+      result.errors.some(
+        (e) => e.field === "sshHost" && e.message.includes("maximum"),
+      ),
+      "Error should mention maximum length for sshHost",
     );
   }
 
   // Test 9: service too long (maxLength: 64) should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      service: 'a'.repeat(65), // 65 chars, max is 64
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      service: "a".repeat(65), // 65 chars, max is 64
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'service too long should fail');
+    assert.strictEqual(result.valid, false, "service too long should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'service' && e.message.includes('maximum')),
-      'Error should mention maximum length for service'
+      result.errors.some(
+        (e) => e.field === "service" && e.message.includes("maximum"),
+      ),
+      "Error should mention maximum length for service",
     );
   }
 
   // Test 10: Boundary test - id at exactly maxLength (64) should pass
   {
     const identity = {
-      id: 'a'.repeat(64), // Exactly 64 chars
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "a".repeat(64), // Exactly 64 chars
+      name: "Test User",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'id at exactly maxLength should pass');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "id at exactly maxLength should pass",
+    );
   }
 
   // Test 11: Boundary test - gpgKeyId at exactly maxLength (40) should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'A'.repeat(40), // Exactly 40 hex chars (SHA-1 fingerprint)
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "A".repeat(40), // Exactly 40 hex chars (SHA-1 fingerprint)
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'gpgKeyId at exactly maxLength should pass');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "gpgKeyId at exactly maxLength should pass",
+    );
   }
 
   // Test 12: Boundary test - sshHost at exactly maxLength (253) should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshHost: 'a'.repeat(253), // Exactly 253 chars (DNS max)
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshHost: "a".repeat(253), // Exactly 253 chars (DNS max)
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'sshHost at exactly maxLength should pass');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "sshHost at exactly maxLength should pass",
+    );
   }
 
-  console.log('  Length constraints tests passed!');
+  console.log("  Length constraints tests passed!");
 }
 
 /**
  * Test format validation (email, hex, single-grapheme)
  */
 function testFormatValidation(): void {
-  console.log('Testing format validation...');
+  console.log("Testing format validation...");
 
   // Test 1: Invalid email format should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'not-an-email',
+      id: "test",
+      name: "Test User",
+      email: "not-an-email",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Invalid email format should fail');
+    assert.strictEqual(result.valid, false, "Invalid email format should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'email' && e.message.includes('Invalid email')),
-      'Error should mention invalid email format'
+      result.errors.some(
+        (e) => e.field === "email" && e.message.includes("Invalid email"),
+      ),
+      "Error should mention invalid email format",
     );
   }
 
   // Test 2: Valid email format should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'user@example.com',
+      id: "test",
+      name: "Test User",
+      email: "user@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Valid email format should pass');
+    assert.strictEqual(result.valid, true, "Valid email format should pass");
   }
 
   // Test 3: gpgKeyId with non-hex characters should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'GHIJKLMN', // G-N are not hex
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "GHIJKLMN", // G-N are not hex
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Non-hex gpgKeyId should fail');
+    assert.strictEqual(result.valid, false, "Non-hex gpgKeyId should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'gpgKeyId' && e.message.includes('hexadecimal')),
-      'Error should mention hexadecimal requirement'
+      result.errors.some(
+        (e) => e.field === "gpgKeyId" && e.message.includes("hexadecimal"),
+      ),
+      "Error should mention hexadecimal requirement",
     );
   }
 
   // Test 4: Valid hex gpgKeyId should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'ABCDEF12',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "ABCDEF12",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Valid hex gpgKeyId should pass');
+    assert.strictEqual(result.valid, true, "Valid hex gpgKeyId should pass");
   }
 
   // Test 5: Single grapheme icon should pass
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      icon: '👔',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      icon: "👔",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Single grapheme icon should pass');
+    assert.strictEqual(result.valid, true, "Single grapheme icon should pass");
   }
 
   // Test 6: Multiple grapheme icon should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      icon: '👔👔', // Two emojis
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      icon: "👔👔", // Two emojis
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Multiple grapheme icon should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Multiple grapheme icon should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'icon' && e.message.includes('single')),
-      'Error should mention single character requirement'
+      result.errors.some(
+        (e) => e.field === "icon" && e.message.includes("single"),
+      ),
+      "Error should mention single character requirement",
     );
   }
 
   // Test 7: Complex composed emoji (ZWJ sequence) should pass as single grapheme
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      icon: '👨‍👩‍👧', // Family emoji (ZWJ sequence, single grapheme)
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      icon: "👨‍👩‍👧", // Family emoji (ZWJ sequence, single grapheme)
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'ZWJ composed emoji should pass as single grapheme');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "ZWJ composed emoji should pass as single grapheme",
+    );
   }
 
   // Test 8: Flag emoji should pass as single grapheme
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      icon: '🇯🇵', // Japan flag (regional indicator sequence)
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      icon: "🇯🇵", // Japan flag (regional indicator sequence)
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Flag emoji should pass as single grapheme');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Flag emoji should pass as single grapheme",
+    );
   }
 
-  console.log('  Format validation tests passed!');
+  console.log("  Format validation tests passed!");
 }
 
 /**
@@ -1007,138 +1229,168 @@ function testFormatValidation(): void {
  * must be explicitly rejected to prevent prototype pollution attacks.
  */
 function testPrototypePollutionPrevention(): void {
-  console.log('Testing prototype pollution prevention...');
+  console.log("Testing prototype pollution prevention...");
 
   // Test 1: __proto__ key should be rejected
   {
     // Use Object.create(null) to ensure __proto__ is an own property
     // (object literal __proto__ sets the prototype, not an own property)
     const obj = Object.create(null);
-    obj.id = 'test';
-    obj.name = 'Test User';
-    obj.email = 'test@example.com';
-    obj['__proto__'] = { admin: true };
+    obj.id = "test";
+    obj.name = "Test User";
+    obj.email = "test@example.com";
+    obj["__proto__"] = { admin: true };
 
     const result = validateIdentitySchema(obj);
-    assert.strictEqual(result.valid, false, '__proto__ key should fail validation');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "__proto__ key should fail validation",
+    );
     assert.ok(
-      result.errors.some(e => e.field === '__proto__' && e.message.includes('Dangerous')),
-      'Error should mention dangerous property name for __proto__'
+      result.errors.some(
+        (e) => e.field === "__proto__" && e.message.includes("Dangerous"),
+      ),
+      "Error should mention dangerous property name for __proto__",
     );
   }
 
   // Test 2: constructor key should be rejected
   {
     const obj = Object.create(null);
-    obj.id = 'test';
-    obj.name = 'Test User';
-    obj.email = 'test@example.com';
-    obj['constructor'] = { prototype: { admin: true } };
+    obj.id = "test";
+    obj.name = "Test User";
+    obj.email = "test@example.com";
+    obj["constructor"] = { prototype: { admin: true } };
 
     const result = validateIdentitySchema(obj);
-    assert.strictEqual(result.valid, false, 'constructor key should fail validation');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "constructor key should fail validation",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'constructor' && e.message.includes('Dangerous')),
-      'Error should mention dangerous property name for constructor'
+      result.errors.some(
+        (e) => e.field === "constructor" && e.message.includes("Dangerous"),
+      ),
+      "Error should mention dangerous property name for constructor",
     );
   }
 
   // Test 3: prototype key should be rejected
   {
     const obj = Object.create(null);
-    obj.id = 'test';
-    obj.name = 'Test User';
-    obj.email = 'test@example.com';
-    obj['prototype'] = { admin: true };
+    obj.id = "test";
+    obj.name = "Test User";
+    obj.email = "test@example.com";
+    obj["prototype"] = { admin: true };
 
     const result = validateIdentitySchema(obj);
-    assert.strictEqual(result.valid, false, 'prototype key should fail validation');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "prototype key should fail validation",
+    );
     assert.ok(
-      result.errors.some(e => e.field === 'prototype' && e.message.includes('Dangerous')),
-      'Error should mention dangerous property name for prototype'
+      result.errors.some(
+        (e) => e.field === "prototype" && e.message.includes("Dangerous"),
+      ),
+      "Error should mention dangerous property name for prototype",
     );
   }
 
   // Test 4: JSON.parse with __proto__ should be rejected
   {
-    const parsed = JSON.parse('{"id":"test","name":"Test","email":"t@e.com","__proto__":{"polluted":true}}');
+    const parsed = JSON.parse(
+      '{"id":"test","name":"Test","email":"t@e.com","__proto__":{"polluted":true}}',
+    );
     const result = validateIdentitySchema(parsed);
-    assert.strictEqual(result.valid, false, 'JSON.parse __proto__ should fail');
+    assert.strictEqual(result.valid, false, "JSON.parse __proto__ should fail");
     assert.ok(
-      result.errors.some(e => e.field === '__proto__'),
-      'Error should flag __proto__ from JSON.parse'
+      result.errors.some((e) => e.field === "__proto__"),
+      "Error should flag __proto__ from JSON.parse",
     );
   }
 
   // Test 5: Value of dangerous key should not be exposed in error
   {
     const obj = Object.create(null);
-    obj.id = 'test';
-    obj.name = 'Test User';
-    obj.email = 'test@example.com';
-    obj['__proto__'] = 'malicious-payload';
+    obj.id = "test";
+    obj.name = "Test User";
+    obj.email = "test@example.com";
+    obj["__proto__"] = "malicious-payload";
 
     const result = validateIdentitySchema(obj);
-    const protoError = result.errors.find(e => e.field === '__proto__');
-    assert.ok(protoError, 'Should have __proto__ error');
-    assert.strictEqual(protoError?.value, undefined, 'Value of dangerous key should not be exposed');
+    const protoError = result.errors.find((e) => e.field === "__proto__");
+    assert.ok(protoError, "Should have __proto__ error");
+    assert.strictEqual(
+      protoError?.value,
+      undefined,
+      "Value of dangerous key should not be exposed",
+    );
   }
 
   // Test 6: Normal valid identity should still pass (regression check)
   {
     const identity = {
-      id: 'valid',
-      name: 'Valid User',
-      email: 'valid@example.com',
+      id: "valid",
+      name: "Valid User",
+      email: "valid@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, true, 'Normal identity should still pass after pollution check');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Normal identity should still pass after pollution check",
+    );
   }
 
-  console.log('  Prototype pollution prevention tests passed!');
+  console.log("  Prototype pollution prevention tests passed!");
 }
 
 /**
  * Test type validation
  */
 function testTypeValidation(): void {
-  console.log('Testing type validation...');
+  console.log("Testing type validation...");
 
   // Test 1: Wrong type for id should fail
   {
     const identity = {
       id: 123, // Should be string
-      name: 'Test User',
-      email: 'test@example.com',
+      name: "Test User",
+      email: "test@example.com",
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Number id should fail');
+    assert.strictEqual(result.valid, false, "Number id should fail");
     assert.ok(
-      result.errors.some(e => e.field === 'id' && e.message.includes('Expected string')),
-      'Error should indicate type mismatch'
+      result.errors.some(
+        (e) => e.field === "id" && e.message.includes("Expected string"),
+      ),
+      "Error should indicate type mismatch",
     );
   }
 
   // Test 2: Wrong type for optional field should fail
   {
     const identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
       icon: 123, // Should be string
     };
     const result = validateIdentitySchema(identity);
-    assert.strictEqual(result.valid, false, 'Number icon should fail');
+    assert.strictEqual(result.valid, false, "Number icon should fail");
   }
 
-  console.log('  Type validation tests passed!');
+  console.log("  Type validation tests passed!");
 }
 
 /**
  * Run all configSchema tests
  */
 export function runConfigSchemaTests(): void {
-  console.log('\n=== Config Schema Tests ===\n');
+  console.log("\n=== Config Schema Tests ===\n");
 
   try {
     testRequiredFieldsEmptyString();
@@ -1154,10 +1406,10 @@ export function runConfigSchemaTests(): void {
     testTypeValidation();
     testPrototypePollutionPrevention();
 
-    console.log('\n  All configSchema tests passed!\n');
+    console.log("\n  All configSchema tests passed!\n");
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error('\n  Test failed:', errorMessage);
+    console.error("\n  Test failed:", errorMessage);
     throw error;
   }
 }

--- a/extensions/git-id-switcher/src/test/e2e/identityManager.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/identityManager.test.ts
@@ -37,34 +37,45 @@
  * UI interactions require VS Code window API.
  */
 
-import * as assert from 'node:assert';
-import * as path from 'node:path';
-import { showEditProfileFlow, showAddIdentityForm } from '../../ui/identityManager';
-import { _setMockVSCode, _resetCache } from '../../core/vscodeLoader';
-import { invalidateIdentityCache, type Identity } from '../../identity/identity';
-import { MAX_IDENTITIES, MAX_ID_LENGTH, MAX_NAME_LENGTH, MAX_EMAIL_LENGTH, MAX_SSH_HOST_LENGTH } from '../../core/constants';
+import * as assert from "node:assert";
+import {
+  showEditProfileFlow,
+  showAddIdentityForm,
+} from "../../ui/identityManager";
+import { _setMockVSCode, _resetCache } from "../../core/vscodeLoader";
+import {
+  invalidateIdentityCache,
+  type Identity,
+} from "../../identity/identity";
+import {
+  MAX_IDENTITIES,
+  MAX_ID_LENGTH,
+  MAX_NAME_LENGTH,
+  MAX_EMAIL_LENGTH,
+  MAX_SSH_HOST_LENGTH,
+} from "../../core/constants";
 
 /**
  * Test identity fixtures
  */
 const TEST_IDENTITIES = {
   work: {
-    id: 'work',
-    name: 'Work User',
-    email: 'work@example.com',
+    id: "work",
+    name: "Work User",
+    email: "work@example.com",
   },
   personal: {
-    id: 'personal',
-    name: 'Personal User',
-    email: 'personal@example.com',
-    icon: '🏠',
-    service: 'GitHub',
-    description: 'Personal projects',
+    id: "personal",
+    name: "Personal User",
+    email: "personal@example.com",
+    icon: "🏠",
+    service: "GitHub",
+    description: "Personal projects",
   },
 };
 
 /** Symbol for Back button */
-const BACK_BUTTON = Symbol('QuickInputButtons.Back');
+const BACK_BUTTON = Symbol("QuickInputButtons.Back");
 
 /**
  * Mock ThemeIcon class for testing
@@ -74,19 +85,19 @@ class MockThemeIcon {
 }
 
 /** Special symbol to represent back button trigger in inputBox tests */
-const INPUT_BOX_BACK = Symbol('InputBox.Back');
+const INPUT_BOX_BACK = Symbol("InputBox.Back");
 
 /** Special symbol to represent file picker button click */
-const FILE_PICKER_CLICK = Symbol('InputBox.FilePicker');
+const FILE_PICKER_CLICK = Symbol("InputBox.FilePicker");
 
 /**
  * Check if buttons array contains a file picker button (folder-opened icon)
  */
 function hasFilePickerButtonInArray(buttons: unknown[]): boolean {
   return buttons.some((btn: unknown) => {
-    if (typeof btn === 'object' && btn !== null && 'iconPath' in btn) {
+    if (typeof btn === "object" && btn !== null && "iconPath" in btn) {
       const iconPath = (btn as { iconPath: { id?: string } }).iconPath;
-      return iconPath?.id === 'folder-opened';
+      return iconPath?.id === "folder-opened";
     }
     return false;
   });
@@ -102,11 +113,18 @@ function hasFilePickerButtonInArray(buttons: unknown[]): boolean {
  */
 function createMockVSCode(options: {
   identities?: Identity[];
-  showQuickPickResult?: { identity?: Identity; field?: keyof Identity } | undefined;
+  showQuickPickResult?:
+    | { identity?: Identity; field?: keyof Identity }
+    | undefined;
   showInputBoxResults?: (string | undefined)[];
   configUpdateError?: Error;
   quickPickSelections?: unknown[];
-  inputBoxSelections?: (string | typeof INPUT_BOX_BACK | typeof FILE_PICKER_CLICK | undefined)[];
+  inputBoxSelections?: (
+    | string
+    | typeof INPUT_BOX_BACK
+    | typeof FILE_PICKER_CLICK
+    | undefined
+  )[];
   showOpenDialogResult?: string | undefined;
   onShowOpenDialog?: (dialogOptions: {
     canSelectFiles?: boolean;
@@ -142,7 +160,7 @@ function createMockVSCode(options: {
       isTrusted: true,
       getConfiguration: () => ({
         get: (key: string) => {
-          if (key === 'identities') {
+          if (key === "identities") {
             return options.identities ?? [];
           }
           return undefined;
@@ -175,10 +193,23 @@ function createMockVSCode(options: {
         }
         // Find matching item
         return items.find((item: unknown) => {
-          if ('identity' in result && typeof item === 'object' && item !== null && 'identity' in item) {
-            return (item as { identity: Identity }).identity.id === result.identity?.id;
+          if (
+            "identity" in result &&
+            typeof item === "object" &&
+            item !== null &&
+            "identity" in item
+          ) {
+            return (
+              (item as { identity: Identity }).identity.id ===
+              result.identity?.id
+            );
           }
-          if ('field' in result && typeof item === 'object' && item !== null && 'field' in item) {
+          if (
+            "field" in result &&
+            typeof item === "object" &&
+            item !== null &&
+            "field" in item
+          ) {
             return (item as { field: keyof Identity }).field === result.field;
           }
           return false;
@@ -203,27 +234,45 @@ function createMockVSCode(options: {
         let hideCallback: (() => void) | undefined;
         let buttonCallback: ((button: unknown) => void) | undefined;
         let changeCallback: ((value: string) => void) | undefined;
-        let _value = '';
+        let _value = "";
         let _validationMessage: string | undefined;
         let _buttons: unknown[] = [];
-        let _title = '';
-        let _placeholder = '';
+        let _title = "";
+        let _placeholder = "";
 
         const inputBox = {
-          get value() { return _value; },
+          get value() {
+            return _value;
+          },
           set value(v: string) {
             _value = v;
             if (changeCallback) changeCallback(v);
           },
-          get validationMessage() { return _validationMessage; },
-          set validationMessage(v: string | undefined) { _validationMessage = v; },
-          get placeholder() { return _placeholder; },
-          set placeholder(v: string) { _placeholder = v; },
-          prompt: '',
-          get title() { return _title; },
-          set title(v: string) { _title = v; },
-          get buttons() { return _buttons; },
-          set buttons(value: unknown[]) { _buttons = value; },
+          get validationMessage() {
+            return _validationMessage;
+          },
+          set validationMessage(v: string | undefined) {
+            _validationMessage = v;
+          },
+          get placeholder() {
+            return _placeholder;
+          },
+          set placeholder(v: string) {
+            _placeholder = v;
+          },
+          prompt: "",
+          get title() {
+            return _title;
+          },
+          set title(v: string) {
+            _title = v;
+          },
+          get buttons() {
+            return _buttons;
+          },
+          set buttons(value: unknown[]) {
+            _buttons = value;
+          },
           show: () => {
             // Notify test callback with InputBox state
             if (options.onInputBoxCreated) {
@@ -234,7 +283,8 @@ function createMockVSCode(options: {
               });
             }
             // Auto-trigger based on test configuration
-            const selections = options.inputBoxSelections ?? options.showInputBoxResults ?? [];
+            const selections =
+              options.inputBoxSelections ?? options.showInputBoxResults ?? [];
             const selection = selections[inputBoxSelectionIndex];
             inputBoxSelectionIndex++;
             setTimeout(async () => {
@@ -243,7 +293,10 @@ function createMockVSCode(options: {
               } else if (selection === FILE_PICKER_CLICK && buttonCallback) {
                 // Simulate file picker button click (non-back button)
                 // The button callback is async, so we need to wait for showOpenDialog to complete
-                const filePickerButton = { iconPath: { id: 'folder-opened' }, tooltip: 'Browse for SSH key path...' };
+                const filePickerButton = {
+                  iconPath: { id: "folder-opened" },
+                  tooltip: "Browse for SSH key path...",
+                };
                 await Promise.resolve(buttonCallback(filePickerButton));
                 // After file picker completes, cancel the InputBox (test only needs to verify dialog options)
                 setTimeout(() => {
@@ -251,7 +304,7 @@ function createMockVSCode(options: {
                 }, 10);
               } else if (selection === undefined && hideCallback) {
                 hideCallback();
-              } else if (typeof selection === 'string' && acceptCallback) {
+              } else if (typeof selection === "string" && acceptCallback) {
                 _value = selection;
                 // Trigger onDidChangeValue callback (this sets validationMessage via real implementation)
                 if (changeCallback) {
@@ -315,25 +368,51 @@ function createMockVSCode(options: {
         let _items: T[] = [];
         let _selectedItems: T[] = [];
         let _activeItems: T[] = [];
-        let _title = '';
-        let _placeholder = '';
+        let _title = "";
+        let _placeholder = "";
         let _buttons: unknown[] = [];
         let _ignoreFocusOut = false;
 
         const quickPick = {
-          get title() { return _title; },
-          set title(value: string) { _title = value; },
-          get placeholder() { return _placeholder; },
-          set placeholder(value: string) { _placeholder = value; },
-          get buttons() { return _buttons; },
-          set buttons(value: unknown[]) { _buttons = value; },
-          get ignoreFocusOut() { return _ignoreFocusOut; },
-          set ignoreFocusOut(value: boolean) { _ignoreFocusOut = value; },
-          get items() { return _items; },
-          set items(value: T[]) { _items = value; },
-          get selectedItems() { return _selectedItems; },
-          get activeItems() { return _activeItems; },
-          set activeItems(value: T[]) { _activeItems = value; },
+          get title() {
+            return _title;
+          },
+          set title(value: string) {
+            _title = value;
+          },
+          get placeholder() {
+            return _placeholder;
+          },
+          set placeholder(value: string) {
+            _placeholder = value;
+          },
+          get buttons() {
+            return _buttons;
+          },
+          set buttons(value: unknown[]) {
+            _buttons = value;
+          },
+          get ignoreFocusOut() {
+            return _ignoreFocusOut;
+          },
+          set ignoreFocusOut(value: boolean) {
+            _ignoreFocusOut = value;
+          },
+          get items() {
+            return _items;
+          },
+          set items(value: T[]) {
+            _items = value;
+          },
+          get selectedItems() {
+            return _selectedItems;
+          },
+          get activeItems() {
+            return _activeItems;
+          },
+          set activeItems(value: T[]) {
+            _activeItems = value;
+          },
           show: () => {
             // Notify test callback with QuickPick state
             if (options.onQuickPickCreated) {
@@ -350,19 +429,35 @@ function createMockVSCode(options: {
             const selection = selections[quickPickSelectionIndex];
             quickPickSelectionIndex++;
             setTimeout(() => {
-              if (selection === 'back' && buttonCallback) {
+              if (selection === "back" && buttonCallback) {
                 buttonCallback(BACK_BUTTON);
               } else if (selection === undefined && hideCallback) {
                 hideCallback();
               } else if (acceptCallback) {
                 // Find matching item from _items
                 const matchedItem = _items.find((item: unknown) => {
-                  if (typeof selection === 'object' && selection !== null) {
-                    if ('field' in selection && typeof item === 'object' && item !== null && 'field' in item) {
-                      return (item as { field: string }).field === (selection as { field: string }).field;
+                  if (typeof selection === "object" && selection !== null) {
+                    if (
+                      "field" in selection &&
+                      typeof item === "object" &&
+                      item !== null &&
+                      "field" in item
+                    ) {
+                      return (
+                        (item as { field: string }).field ===
+                        (selection as { field: string }).field
+                      );
                     }
-                    if ('_isSaveButton' in selection && typeof item === 'object' && item !== null && '_isSaveButton' in item) {
-                      return (item as { _isSaveButton: boolean })._isSaveButton === (selection as { _isSaveButton: boolean })._isSaveButton;
+                    if (
+                      "_isSaveButton" in selection &&
+                      typeof item === "object" &&
+                      item !== null &&
+                      "_isSaveButton" in item
+                    ) {
+                      return (
+                        (item as { _isSaveButton: boolean })._isSaveButton ===
+                        (selection as { _isSaveButton: boolean })._isSaveButton
+                      );
                     }
                   }
                   return false;
@@ -420,12 +515,14 @@ function createMockVSCode(options: {
     _getConfigUpdateCalls: () => configUpdateCalls,
     _getLastValidateInput: () => lastValidateInput,
     _getAllValidateInputs: () => allValidateInputs,
-    _resetInputBoxCallIndex: () => { inputBoxCallIndex = 0; },
+    _resetInputBoxCallIndex: () => {
+      inputBoxCallIndex = 0;
+    },
     _getInputBoxCallIndex: () => inputBoxCallIndex,
   };
 }
 
-describe('identityManager E2E Test Suite', function () {
+describe("identityManager E2E Test Suite", function () {
   // Set suite-level timeout for all tests
   this.timeout(10_000);
 
@@ -443,31 +540,35 @@ describe('identityManager E2E Test Suite', function () {
   // Add Form Flow Tests (with Esc-back navigation)
   // ===========================================================================
 
-  describe('Add Form: Normal Flow', () => {
-    it('should return Identity when all required fields completed', async () => {
+  describe("Add Form: Normal Flow", () => {
+    it("should return Identity when all required fields completed", async () => {
       // showAddIdentityForm returns Identity | undefined
       // User flow: QuickPick shows fields → select id → enter value → select name → enter value → ...
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },     // Select id field
-          { field: 'name' },   // Select name field
-          { field: 'email' },  // Select email field
+          { field: "id" }, // Select id field
+          { field: "name" }, // Select name field
+          { field: "email" }, // Select email field
           { _isSaveButton: true }, // Click save
         ],
-        inputBoxSelections: ['test-id', 'Test User', 'test@example.com'],
+        inputBoxSelections: ["test-id", "Test User", "test@example.com"],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.ok(result !== undefined, 'Should return Identity on success');
-      assert.strictEqual(result?.id, 'test-id', 'Should return created Identity with correct id');
+      assert.ok(result !== undefined, "Should return Identity on success");
+      assert.strictEqual(
+        result?.id,
+        "test-id",
+        "Should return created Identity with correct id",
+      );
       const infoCalls = mockVSCode._getShowInformationMessageCalls();
-      assert.ok(infoCalls.length > 0, 'Should show success message');
+      assert.ok(infoCalls.length > 0, "Should show success message");
     });
 
-    it('should return undefined when cancelled (Esc)', async () => {
+    it("should return undefined when cancelled (Esc)", async () => {
       // Cancel at QuickPick (property list)
       const mockVSCode = createMockVSCode({
         identities: [],
@@ -477,64 +578,74 @@ describe('identityManager E2E Test Suite', function () {
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'Should return undefined when cancelled at QuickPick');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Should return undefined when cancelled at QuickPick",
+      );
     });
   });
 
-  describe('Add Form: Esc-back Navigation', () => {
-    it('should go back to field list when back pressed at InputBox, preserving ID value', async () => {
+  describe("Add Form: Esc-back Navigation", () => {
+    it("should go back to field list when back pressed at InputBox, preserving ID value", async () => {
       // In property list style: select id → enter value → select name → back → select name again
       // Note: INPUT_BOX_BACK in inputBoxSelections triggers back button, returns to QuickPick
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },     // Select id field
-          { field: 'name' },   // Select name field
+          { field: "id" }, // Select id field
+          { field: "name" }, // Select name field
           // After back from InputBox, QuickPick shows again
-          { field: 'name' },   // Select name field again
-          { field: 'email' },  // Select email field
+          { field: "name" }, // Select name field again
+          { field: "email" }, // Select email field
           { _isSaveButton: true }, // Click save
         ],
         inputBoxSelections: [
-          'my-id',        // Enter id value
+          "my-id", // Enter id value
           INPUT_BOX_BACK, // Press back at name input
-          'My Name',      // Enter name value (after back)
-          'my@test.com',  // Enter email value
+          "My Name", // Enter name value (after back)
+          "my@test.com", // Enter email value
         ],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.ok(result !== undefined, 'Should complete successfully after back-navigation');
-      assert.strictEqual(result?.id, 'my-id', 'Should preserve ID value');
+      assert.ok(
+        result !== undefined,
+        "Should complete successfully after back-navigation",
+      );
+      assert.strictEqual(result?.id, "my-id", "Should preserve ID value");
     });
 
-    it('should go back to field list when back pressed at email, preserving Name value', async () => {
+    it("should go back to field list when back pressed at email, preserving Name value", async () => {
       // In property list style: complete id/name, then back at email input
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },
-          { field: 'email' },
+          { field: "id" },
+          { field: "name" },
+          { field: "email" },
           // After back from InputBox, QuickPick shows again
-          { field: 'email' }, // Select email again
+          { field: "email" }, // Select email again
           { _isSaveButton: true },
         ],
         inputBoxSelections: [
-          'my-id',
-          'My Name',
+          "my-id",
+          "My Name",
           INPUT_BOX_BACK, // Press back at email input
-          'my@test.com',  // Enter email (after back)
+          "my@test.com", // Enter email (after back)
         ],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.ok(result !== undefined, 'Should complete successfully after back-navigation');
-      assert.strictEqual(result?.name, 'My Name', 'Should preserve Name value');
+      assert.ok(
+        result !== undefined,
+        "Should complete successfully after back-navigation",
+      );
+      assert.strictEqual(result?.name, "My Name", "Should preserve Name value");
     });
 
     it('should NOT set "back" as field value when back button pressed (required and optional fields)', async () => {
@@ -544,29 +655,37 @@ describe('identityManager E2E Test Suite', function () {
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },      // Select required name field
-          { field: 'name' },      // Re-select after back
-          { field: 'email' },
-          { field: 'service' },   // Select optional service field
+          { field: "id" },
+          { field: "name" }, // Select required name field
+          { field: "name" }, // Re-select after back
+          { field: "email" },
+          { field: "service" }, // Select optional service field
           { _isSaveButton: true },
         ],
         inputBoxSelections: [
-          'test-id',
-          INPUT_BOX_BACK,         // Press back at required name field
-          'Valid Name',           // Enter name value after back
-          'test@test.com',
-          INPUT_BOX_BACK,         // Press back at optional service field
+          "test-id",
+          INPUT_BOX_BACK, // Press back at required name field
+          "Valid Name", // Enter name value after back
+          "test@test.com",
+          INPUT_BOX_BACK, // Press back at optional service field
         ],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.ok(result !== undefined, 'Should complete successfully');
-      assert.strictEqual(result?.id, 'test-id', 'ID should be preserved');
-      assert.strictEqual(result?.name, 'Valid Name', 'Required field should have entered value, not "back"');
-      assert.strictEqual(result?.service, undefined, 'Optional field should remain undefined after back');
+      assert.ok(result !== undefined, "Should complete successfully");
+      assert.strictEqual(result?.id, "test-id", "ID should be preserved");
+      assert.strictEqual(
+        result?.name,
+        "Valid Name",
+        'Required field should have entered value, not "back"',
+      );
+      assert.strictEqual(
+        result?.service,
+        undefined,
+        "Optional field should remain undefined after back",
+      );
     });
   });
 
@@ -574,44 +693,47 @@ describe('identityManager E2E Test Suite', function () {
   // Edit Profile Flow Tests
   // ===========================================================================
 
-  describe('Edit Profile: targetIdentity Support', () => {
-    it('should skip identity selection when targetIdentity is provided', async () => {
+  describe("Edit Profile: targetIdentity Support", () => {
+    it("should skip identity selection when targetIdentity is provided", async () => {
       // Edit wizard now uses createQuickPick for field selection
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work, TEST_IDENTITIES.personal],
         quickPickSelections: [
-          { field: 'name' },  // Select name field
-          undefined,          // Cancel after saving (exit loop)
+          { field: "name" }, // Select name field
+          undefined, // Cancel after saving (exit loop)
         ],
-        inputBoxSelections: ['Updated Name'],
+        inputBoxSelections: ["Updated Name"],
       });
       _setMockVSCode(mockVSCode as never);
 
       // Pass targetIdentity to skip selection
       const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-      assert.strictEqual(result, true, 'Should return true on success');
+      assert.strictEqual(result, true, "Should return true on success");
       const infoCalls = mockVSCode._getShowInformationMessageCalls();
-      assert.ok(infoCalls.some(msg => msg.includes('updated')), 'Should show update message');
+      assert.ok(
+        infoCalls.some((msg) => msg.includes("updated")),
+        "Should show update message",
+      );
     });
 
-    it('should return true when edit completes successfully', async () => {
+    it("should return true when edit completes successfully", async () => {
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work],
         quickPickSelections: [
-          { field: 'email' }, // Select email field
-          undefined,          // Cancel after saving (exit loop)
+          { field: "email" }, // Select email field
+          undefined, // Cancel after saving (exit loop)
         ],
-        inputBoxSelections: ['new@example.com'],
+        inputBoxSelections: ["new@example.com"],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-      assert.strictEqual(result, true, 'Should return true (boolean)');
+      assert.strictEqual(result, true, "Should return true (boolean)");
     });
 
-    it('should return false when field selection cancelled (Esc)', async () => {
+    it("should return false when field selection cancelled (Esc)", async () => {
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work],
         quickPickSelections: [undefined], // Cancel field selection
@@ -620,25 +742,25 @@ describe('identityManager E2E Test Suite', function () {
 
       const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-      assert.strictEqual(result, false, 'Should return false when cancelled');
+      assert.strictEqual(result, false, "Should return false when cancelled");
     });
   });
 
-  describe('Edit Profile: Esc-back Navigation', () => {
-    it('should go back to field selection when Esc pressed at value input', async () => {
+  describe("Edit Profile: Esc-back Navigation", () => {
+    it("should go back to field selection when Esc pressed at value input", async () => {
       // First attempt: select field, press back at InputBox
       // Second attempt: select field again, enter value
       let quickPickShowCount = 0;
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work],
         quickPickSelections: [
-          { field: 'name' },  // Select name field (first attempt)
-          { field: 'name' },  // Select name field again (after back)
-          undefined,          // Cancel after saving
+          { field: "name" }, // Select name field (first attempt)
+          { field: "name" }, // Select name field again (after back)
+          undefined, // Cancel after saving
         ],
         inputBoxSelections: [
-          INPUT_BOX_BACK,   // First: press back button
-          'Updated Name',   // Second: enter value
+          INPUT_BOX_BACK, // First: press back button
+          "Updated Name", // Second: enter value
         ],
         onQuickPickCreated: () => {
           quickPickShowCount++;
@@ -648,49 +770,72 @@ describe('identityManager E2E Test Suite', function () {
 
       const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-      assert.strictEqual(result, true, 'Should complete after back-navigation');
-      assert.ok(quickPickShowCount >= 2, `Should show QuickPick multiple times due to back-navigation, got ${quickPickShowCount}`);
+      assert.strictEqual(result, true, "Should complete after back-navigation");
+      assert.ok(
+        quickPickShowCount >= 2,
+        `Should show QuickPick multiple times due to back-navigation, got ${quickPickShowCount}`,
+      );
     });
   });
 
-  describe('Edit Profile: Success Path', () => {
-    it('should return true when a field is successfully edited', async () => {
+  describe("Edit Profile: Success Path", () => {
+    it("should return true when a field is successfully edited", async () => {
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work],
-        quickPickSelections: [
-          { field: 'name' },
-          undefined,
-        ],
-        inputBoxSelections: ['New Name'],
+        quickPickSelections: [{ field: "name" }, undefined],
+        inputBoxSelections: ["New Name"],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-      assert.strictEqual(result, true, 'Should return true after successful edit');
+      assert.strictEqual(
+        result,
+        true,
+        "Should return true after successful edit",
+      );
     });
   });
 
-  describe('Add Form: Success Path', () => {
-    it('should return Identity with correct id/name/email after completing all fields', async () => {
+  describe("Add Form: Success Path", () => {
+    it("should return Identity with correct id/name/email after completing all fields", async () => {
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },
-          { field: 'email' },
+          { field: "id" },
+          { field: "name" },
+          { field: "email" },
           { _isSaveButton: true },
         ],
-        inputBoxSelections: ['return-type-id', 'Return Type Name', 'email@test.com'],
+        inputBoxSelections: [
+          "return-type-id",
+          "Return Type Name",
+          "email@test.com",
+        ],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.ok(result !== undefined, 'Should return Identity object on success');
-      assert.strictEqual(result?.id, 'return-type-id', 'Should have correct id');
-      assert.strictEqual(result?.name, 'Return Type Name', 'Should have correct name');
-      assert.strictEqual(result?.email, 'email@test.com', 'Should have correct email');
+      assert.ok(
+        result !== undefined,
+        "Should return Identity object on success",
+      );
+      assert.strictEqual(
+        result?.id,
+        "return-type-id",
+        "Should have correct id",
+      );
+      assert.strictEqual(
+        result?.name,
+        "Return Type Name",
+        "Should have correct name",
+      );
+      assert.strictEqual(
+        result?.email,
+        "email@test.com",
+        "Should have correct email",
+      );
     });
   });
 
@@ -700,140 +845,167 @@ describe('identityManager E2E Test Suite', function () {
   // Invalid input triggers validation error, causing the flow to cancel.
   // ===========================================================================
 
-  describe('Security: ID Input Validation', () => {
-    it('should reject ID with invalid characters (validation causes cancel)', async () => {
+  describe("Security: ID Input Validation", () => {
+    it("should reject ID with invalid characters (validation causes cancel)", async () => {
       // Invalid ID with symbols - validation will fail, causing cancel
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },  // Select id field
-          undefined,        // Cancel after validation failure
+          { field: "id" }, // Select id field
+          undefined, // Cancel after validation failure
         ],
-        inputBoxSelections: ['id@with#symbols!'], // Invalid ID
+        inputBoxSelections: ["id@with#symbols!"], // Invalid ID
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
       // Validation error causes hide (cancel), so result is undefined
-      assert.strictEqual(result, undefined, 'Invalid ID should cause validation failure');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Invalid ID should cause validation failure",
+      );
     });
 
     // Duplicate ID validation is covered by 'Duplicate ID Check' tests in Add Identity Form section
   });
 
-  describe('Security: Name Input Validation', () => {
-    it('should reject name with dangerous characters ($, backtick)', async () => {
+  describe("Security: Name Input Validation", () => {
+    it("should reject name with dangerous characters ($, backtick)", async () => {
       // Name with dangerous characters - validation will fail
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },  // Select name field
-          undefined,          // Cancel after validation failure
+          { field: "id" },
+          { field: "name" }, // Select name field
+          undefined, // Cancel after validation failure
         ],
-        inputBoxSelections: ['valid-id', 'User $HOME'], // Valid ID, Invalid name
+        inputBoxSelections: ["valid-id", "User $HOME"], // Valid ID, Invalid name
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'Name with dangerous characters should cause validation failure');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Name with dangerous characters should cause validation failure",
+      );
     });
 
-    it('should reject name exceeding MAX_NAME_LENGTH', async () => {
-      const longName = 'a'.repeat(MAX_NAME_LENGTH + 1);
+    it("should reject name exceeding MAX_NAME_LENGTH", async () => {
+      const longName = "a".repeat(MAX_NAME_LENGTH + 1);
       const mockVSCode = createMockVSCode({
         identities: [],
-        quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },
-          undefined,
-        ],
-        inputBoxSelections: ['valid-id', longName],
+        quickPickSelections: [{ field: "id" }, { field: "name" }, undefined],
+        inputBoxSelections: ["valid-id", longName],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'Name exceeding max length should cause validation failure');
-    });
-  });
-
-  describe('Security: Email Input Validation', () => {
-    it('should reject invalid email format', async () => {
-      const mockVSCode = createMockVSCode({
-        identities: [],
-        quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },
-          { field: 'email' },
-          undefined,
-        ],
-        inputBoxSelections: ['valid-id', 'Valid Name', 'notanemail'], // Invalid email
-      });
-      _setMockVSCode(mockVSCode as never);
-
-      const result = await showAddIdentityForm();
-
-      assert.strictEqual(result, undefined, 'Invalid email format should cause validation failure');
-    });
-
-    it('should reject email exceeding MAX_EMAIL_LENGTH', async () => {
-      const longEmail = 'a'.repeat(MAX_EMAIL_LENGTH) + '@example.com';
-      const mockVSCode = createMockVSCode({
-        identities: [],
-        quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },
-          { field: 'email' },
-          undefined,
-        ],
-        inputBoxSelections: ['valid-id', 'Valid Name', longEmail],
-      });
-      _setMockVSCode(mockVSCode as never);
-
-      const result = await showAddIdentityForm();
-
-      assert.strictEqual(result, undefined, 'Email exceeding max length should cause validation failure');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Name exceeding max length should cause validation failure",
+      );
     });
   });
 
-  describe('Security: validateInput - Valid Values', () => {
-    it('should accept valid input values and complete successfully', async () => {
+  describe("Security: Email Input Validation", () => {
+    it("should reject invalid email format", async () => {
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },
-          { field: 'email' },
+          { field: "id" },
+          { field: "name" },
+          { field: "email" },
+          undefined,
+        ],
+        inputBoxSelections: ["valid-id", "Valid Name", "notanemail"], // Invalid email
+      });
+      _setMockVSCode(mockVSCode as never);
+
+      const result = await showAddIdentityForm();
+
+      assert.strictEqual(
+        result,
+        undefined,
+        "Invalid email format should cause validation failure",
+      );
+    });
+
+    it("should reject email exceeding MAX_EMAIL_LENGTH", async () => {
+      const longEmail = "a".repeat(MAX_EMAIL_LENGTH) + "@example.com";
+      const mockVSCode = createMockVSCode({
+        identities: [],
+        quickPickSelections: [
+          { field: "id" },
+          { field: "name" },
+          { field: "email" },
+          undefined,
+        ],
+        inputBoxSelections: ["valid-id", "Valid Name", longEmail],
+      });
+      _setMockVSCode(mockVSCode as never);
+
+      const result = await showAddIdentityForm();
+
+      assert.strictEqual(
+        result,
+        undefined,
+        "Email exceeding max length should cause validation failure",
+      );
+    });
+  });
+
+  describe("Security: validateInput - Valid Values", () => {
+    it("should accept valid input values and complete successfully", async () => {
+      const mockVSCode = createMockVSCode({
+        identities: [],
+        quickPickSelections: [
+          { field: "id" },
+          { field: "name" },
+          { field: "email" },
           { _isSaveButton: true },
         ],
-        inputBoxSelections: ['valid-id', 'Valid Name', 'valid@example.com'],
+        inputBoxSelections: ["valid-id", "Valid Name", "valid@example.com"],
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.ok(result !== undefined, 'Valid values should complete successfully');
-      assert.strictEqual(result?.id, 'valid-id', 'Should return Identity with correct id');
+      assert.ok(
+        result !== undefined,
+        "Valid values should complete successfully",
+      );
+      assert.strictEqual(
+        result?.id,
+        "valid-id",
+        "Should return Identity with correct id",
+      );
     });
 
-    it('should reject empty string inputs', async () => {
+    it("should reject empty string inputs", async () => {
       // Empty string for required field should fail validation
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },  // Select id field
-          undefined,        // Cancel after validation failure
+          { field: "id" }, // Select id field
+          undefined, // Cancel after validation failure
         ],
-        inputBoxSelections: [''], // Empty ID
+        inputBoxSelections: [""], // Empty ID
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'Empty string should cause validation failure');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Empty string should cause validation failure",
+      );
     });
   });
 
@@ -841,8 +1013,8 @@ describe('identityManager E2E Test Suite', function () {
   // MAX_IDENTITIES Limit Tests
   // ===========================================================================
 
-  describe('MAX_IDENTITIES Limit', () => {
-    it('should show warning when MAX_IDENTITIES reached', async () => {
+  describe("MAX_IDENTITIES Limit", () => {
+    it("should show warning when MAX_IDENTITIES reached", async () => {
       // Create array with MAX_IDENTITIES identities
       const maxIdentities: Identity[] = [];
       for (let i = 0; i < MAX_IDENTITIES; i++) {
@@ -860,12 +1032,16 @@ describe('identityManager E2E Test Suite', function () {
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'Should return undefined when limit reached');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Should return undefined when limit reached",
+      );
       const warnings = mockVSCode._getShowWarningMessageCalls();
-      assert.strictEqual(warnings.length, 1, 'Should show warning');
+      assert.strictEqual(warnings.length, 1, "Should show warning");
       assert.ok(
         warnings[0].includes(String(MAX_IDENTITIES)),
-        'Warning should mention max limit'
+        "Warning should mention max limit",
       );
     });
   });
@@ -874,9 +1050,9 @@ describe('identityManager E2E Test Suite', function () {
   // Add Identity Form (Property List Style) Tests
   // ===========================================================================
 
-  describe('Add Identity Form: Property List Style', () => {
-    describe('Property List Display', () => {
-      it('should show QuickPick with all 9 FIELD_METADATA fields', async () => {
+  describe("Add Identity Form: Property List Style", () => {
+    describe("Property List Display", () => {
+      it("should show QuickPick with all 9 FIELD_METADATA fields", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -891,33 +1067,42 @@ describe('identityManager E2E Test Suite', function () {
         await showAddIdentityForm();
 
         // 9 fields + 1 separator + 1 save button = 11 items
-        assert.ok(capturedItems.length >= 10, `Should have at least 10 items, got ${capturedItems.length}`);
+        assert.ok(
+          capturedItems.length >= 10,
+          `Should have at least 10 items, got ${capturedItems.length}`,
+        );
 
         // Verify all 9 fields are present with correct icons
         const expectedFields = [
-          { field: 'id', icon: 'lock' },
-          { field: 'name', icon: 'person' },
-          { field: 'email', icon: 'mail' },
-          { field: 'service', icon: 'server' },
-          { field: 'icon', icon: 'symbol-color' },
-          { field: 'description', icon: 'note' },
-          { field: 'sshKeyPath', icon: 'key' },
-          { field: 'sshHost', icon: 'globe' },
-          { field: 'gpgKeyId', icon: 'key' },
+          { field: "id", icon: "lock" },
+          { field: "name", icon: "person" },
+          { field: "email", icon: "mail" },
+          { field: "service", icon: "server" },
+          { field: "icon", icon: "symbol-color" },
+          { field: "description", icon: "note" },
+          { field: "sshKeyPath", icon: "key" },
+          { field: "sshHost", icon: "globe" },
+          { field: "gpgKeyId", icon: "key" },
         ];
 
         for (const { field, icon } of expectedFields) {
-          const item = capturedItems.find((i: unknown) =>
-            typeof i === 'object' && i !== null && 'field' in i &&
-            (i as { field: string }).field === field
+          const item = capturedItems.find(
+            (i: unknown) =>
+              typeof i === "object" &&
+              i !== null &&
+              "field" in i &&
+              (i as { field: string }).field === field,
           );
           assert.ok(item, `Field '${field}' should be present`);
           const label = (item as { label: string }).label;
-          assert.ok(label.includes(`$(${icon})`), `Field '${field}' should have $(${icon}) icon, got: ${label}`);
+          assert.ok(
+            label.includes(`$(${icon})`),
+            `Field '${field}' should have $(${icon}) icon, got: ${label}`,
+          );
         }
       });
 
-      it('should set ignoreFocusOut to prevent data loss on focus change', async () => {
+      it("should set ignoreFocusOut to prevent data loss on focus change", async () => {
         let capturedIgnoreFocusOut = false;
 
         const mockVSCode = createMockVSCode({
@@ -931,10 +1116,14 @@ describe('identityManager E2E Test Suite', function () {
 
         await showAddIdentityForm();
 
-        assert.strictEqual(capturedIgnoreFocusOut, true, 'Add form QuickPick should have ignoreFocusOut=true');
+        assert.strictEqual(
+          capturedIgnoreFocusOut,
+          true,
+          "Add form QuickPick should have ignoreFocusOut=true",
+        );
       });
 
-      it('should mark required fields (id, name, email) with asterisk', async () => {
+      it("should mark required fields (id, name, email) with asterisk", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -948,31 +1137,50 @@ describe('identityManager E2E Test Suite', function () {
 
         await showAddIdentityForm();
 
-        const requiredFields = ['id', 'name', 'email'];
+        const requiredFields = ["id", "name", "email"];
         for (const field of requiredFields) {
-          const item = capturedItems.find((i: unknown) =>
-            typeof i === 'object' && i !== null && 'field' in i &&
-            (i as { field: string }).field === field
+          const item = capturedItems.find(
+            (i: unknown) =>
+              typeof i === "object" &&
+              i !== null &&
+              "field" in i &&
+              (i as { field: string }).field === field,
           );
           assert.ok(item, `Field '${field}' should be present`);
           const label = (item as { label: string }).label;
-          assert.ok(label.endsWith('*'), `Required field '${field}' should have * mark, got: ${label}`);
+          assert.ok(
+            label.endsWith("*"),
+            `Required field '${field}' should have * mark, got: ${label}`,
+          );
         }
 
-        const optionalFields = ['service', 'icon', 'description', 'sshKeyPath', 'sshHost', 'gpgKeyId'];
+        const optionalFields = [
+          "service",
+          "icon",
+          "description",
+          "sshKeyPath",
+          "sshHost",
+          "gpgKeyId",
+        ];
         for (const field of optionalFields) {
-          const item = capturedItems.find((i: unknown) =>
-            typeof i === 'object' && i !== null && 'field' in i &&
-            (i as { field: string }).field === field
+          const item = capturedItems.find(
+            (i: unknown) =>
+              typeof i === "object" &&
+              i !== null &&
+              "field" in i &&
+              (i as { field: string }).field === field,
           );
           if (item) {
             const label = (item as { label: string }).label;
-            assert.ok(!label.endsWith('*'), `Optional field '${field}' should NOT have * mark, got: ${label}`);
+            assert.ok(
+              !label.endsWith("*"),
+              `Optional field '${field}' should NOT have * mark, got: ${label}`,
+            );
           }
         }
       });
 
-      it('should show separator line', async () => {
+      it("should show separator line", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -986,15 +1194,22 @@ describe('identityManager E2E Test Suite', function () {
 
         await showAddIdentityForm();
 
-        const separator = capturedItems.find((i: unknown) =>
-          typeof i === 'object' && i !== null && 'label' in i &&
-          (i as { label: string }).label.includes('─────────────')
+        const separator = capturedItems.find(
+          (i: unknown) =>
+            typeof i === "object" &&
+            i !== null &&
+            "label" in i &&
+            (i as { label: string }).label.includes("─────────────"),
         );
-        assert.ok(separator, 'Separator should be present');
-        assert.strictEqual((separator as { _isDisabled?: boolean })._isDisabled, true, 'Separator should be disabled');
+        assert.ok(separator, "Separator should be present");
+        assert.strictEqual(
+          (separator as { _isDisabled?: boolean })._isDisabled,
+          true,
+          "Separator should be disabled",
+        );
       });
 
-      it('should show save button at bottom', async () => {
+      it("should show save button at bottom", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1008,21 +1223,32 @@ describe('identityManager E2E Test Suite', function () {
 
         await showAddIdentityForm();
 
-        const saveButton = capturedItems.find((i: unknown) =>
-          typeof i === 'object' && i !== null && 'field' in i &&
-          (i as { field: string }).field === 'save'
+        const saveButton = capturedItems.find(
+          (i: unknown) =>
+            typeof i === "object" &&
+            i !== null &&
+            "field" in i &&
+            (i as { field: string }).field === "save",
         );
-        assert.ok(saveButton, 'Save button should be present');
-        assert.strictEqual((saveButton as { _isSaveButton?: boolean })._isSaveButton, true, 'Save button should have _isSaveButton flag');
+        assert.ok(saveButton, "Save button should be present");
+        assert.strictEqual(
+          (saveButton as { _isSaveButton?: boolean })._isSaveButton,
+          true,
+          "Save button should have _isSaveButton flag",
+        );
 
         // Save button should be at the end
         const lastItem = capturedItems.at(-1);
-        assert.strictEqual((lastItem as { field: string }).field, 'save', 'Save button should be the last item');
+        assert.strictEqual(
+          (lastItem as { field: string }).field,
+          "save",
+          "Save button should be the last item",
+        );
       });
     });
 
-    describe('Required Field Validation for Save Button', () => {
-      it('should disable save button when id is empty', async () => {
+    describe("Required Field Validation for Save Button", () => {
+      it("should disable save button when id is empty", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1036,28 +1262,38 @@ describe('identityManager E2E Test Suite', function () {
 
         await showAddIdentityForm();
 
-        const saveButton = capturedItems.find((i: unknown) =>
-          typeof i === 'object' && i !== null && 'field' in i &&
-          (i as { field: string }).field === 'save'
+        const saveButton = capturedItems.find(
+          (i: unknown) =>
+            typeof i === "object" &&
+            i !== null &&
+            "field" in i &&
+            (i as { field: string }).field === "save",
         );
-        assert.ok(saveButton, 'Save button should be present');
+        assert.ok(saveButton, "Save button should be present");
         const label = (saveButton as { label: string }).label;
-        assert.ok(label.includes('$(session-in-progress)'), `Save button should show $(session-in-progress) when disabled, got: ${label}`);
-        assert.strictEqual((saveButton as { _isDisabled?: boolean })._isDisabled, true, 'Save button should be disabled');
+        assert.ok(
+          label.includes("$(session-in-progress)"),
+          `Save button should show $(session-in-progress) when disabled, got: ${label}`,
+        );
+        assert.strictEqual(
+          (saveButton as { _isDisabled?: boolean })._isDisabled,
+          true,
+          "Save button should be disabled",
+        );
       });
 
-      it('should enable save button when all required fields are filled', async () => {
+      it("should enable save button when all required fields are filled", async () => {
         const capturedItemsHistory: unknown[][] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [],
           quickPickSelections: [
-            { field: 'id' },     // Select id field
-            { field: 'name' },   // Select name field
-            { field: 'email' },  // Select email field
+            { field: "id" }, // Select id field
+            { field: "name" }, // Select name field
+            { field: "email" }, // Select email field
             { _isSaveButton: true }, // Click save
           ],
-          inputBoxSelections: ['test-id', 'Test User', 'test@example.com'],
+          inputBoxSelections: ["test-id", "Test User", "test@example.com"],
           onQuickPickCreated: (quickPick) => {
             capturedItemsHistory.push([...quickPick.items]);
           },
@@ -1067,29 +1303,42 @@ describe('identityManager E2E Test Suite', function () {
         await showAddIdentityForm();
 
         // After all fields filled, save button should be enabled
-        assert.ok(capturedItemsHistory.length >= 4, `Expected at least 4 QuickPick displays, got ${capturedItemsHistory.length}`);
-        const lastItems = capturedItemsHistory.at(-1);
-        assert.ok(lastItems, 'Last items should exist');
-        const saveButton = lastItems.find((i: unknown) =>
-          typeof i === 'object' && i !== null && 'field' in i &&
-          (i as { field: string }).field === 'save'
+        assert.ok(
+          capturedItemsHistory.length >= 4,
+          `Expected at least 4 QuickPick displays, got ${capturedItemsHistory.length}`,
         );
-        assert.ok(saveButton, 'Save button should exist');
+        const lastItems = capturedItemsHistory.at(-1);
+        assert.ok(lastItems, "Last items should exist");
+        const saveButton = lastItems.find(
+          (i: unknown) =>
+            typeof i === "object" &&
+            i !== null &&
+            "field" in i &&
+            (i as { field: string }).field === "save",
+        );
+        assert.ok(saveButton, "Save button should exist");
         const label = (saveButton as { label: string }).label;
-        assert.ok(label.includes('$(check)'), `Save button should show $(check) when enabled, got: ${label}`);
-        assert.strictEqual((saveButton as { _isDisabled?: boolean })._isDisabled, false, 'Save button should be enabled');
+        assert.ok(
+          label.includes("$(check)"),
+          `Save button should show $(check) when enabled, got: ${label}`,
+        );
+        assert.strictEqual(
+          (saveButton as { _isDisabled?: boolean })._isDisabled,
+          false,
+          "Save button should be enabled",
+        );
       });
 
-      it('should disable save button when only id is filled', async () => {
+      it("should disable save button when only id is filled", async () => {
         const capturedItemsHistory: unknown[][] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [],
           quickPickSelections: [
-            { field: 'id' },  // Select id field
-            undefined,       // Cancel after
+            { field: "id" }, // Select id field
+            undefined, // Cancel after
           ],
-          inputBoxSelections: ['test-id'],
+          inputBoxSelections: ["test-id"],
           onQuickPickCreated: (quickPick) => {
             capturedItemsHistory.push([...quickPick.items]);
           },
@@ -1099,29 +1348,38 @@ describe('identityManager E2E Test Suite', function () {
         await showAddIdentityForm();
 
         // After id filled but name/email empty, save should still be disabled
-        assert.ok(capturedItemsHistory.length >= 2, `Expected at least 2 QuickPick displays, got ${capturedItemsHistory.length}`);
-        const lastItems = capturedItemsHistory.at(-1);
-        assert.ok(lastItems, 'Last items should exist');
-        const saveButton = lastItems.find((i: unknown) =>
-          typeof i === 'object' && i !== null && 'field' in i &&
-          (i as { field: string }).field === 'save'
+        assert.ok(
+          capturedItemsHistory.length >= 2,
+          `Expected at least 2 QuickPick displays, got ${capturedItemsHistory.length}`,
         );
-        assert.ok(saveButton, 'Save button should exist');
-        assert.strictEqual((saveButton as { _isDisabled?: boolean })._isDisabled, true,
-          'Save button should be disabled when only id is filled');
+        const lastItems = capturedItemsHistory.at(-1);
+        assert.ok(lastItems, "Last items should exist");
+        const saveButton = lastItems.find(
+          (i: unknown) =>
+            typeof i === "object" &&
+            i !== null &&
+            "field" in i &&
+            (i as { field: string }).field === "save",
+        );
+        assert.ok(saveButton, "Save button should exist");
+        assert.strictEqual(
+          (saveButton as { _isDisabled?: boolean })._isDisabled,
+          true,
+          "Save button should be disabled when only id is filled",
+        );
       });
 
-      it('should disable save button when id and name filled but email empty', async () => {
+      it("should disable save button when id and name filled but email empty", async () => {
         const capturedItemsHistory: unknown[][] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [],
           quickPickSelections: [
-            { field: 'id' },    // Select id field
-            { field: 'name' }, // Select name field
-            undefined,         // Cancel after
+            { field: "id" }, // Select id field
+            { field: "name" }, // Select name field
+            undefined, // Cancel after
           ],
-          inputBoxSelections: ['test-id', 'Test User'],
+          inputBoxSelections: ["test-id", "Test User"],
           onQuickPickCreated: (quickPick) => {
             capturedItemsHistory.push([...quickPick.items]);
           },
@@ -1131,21 +1389,30 @@ describe('identityManager E2E Test Suite', function () {
         await showAddIdentityForm();
 
         // After id and name filled but email empty, save should still be disabled
-        assert.ok(capturedItemsHistory.length >= 3, `Expected at least 3 QuickPick displays, got ${capturedItemsHistory.length}`);
-        const lastItems = capturedItemsHistory.at(-1);
-        assert.ok(lastItems, 'Last items should exist');
-        const saveButton = lastItems.find((i: unknown) =>
-          typeof i === 'object' && i !== null && 'field' in i &&
-          (i as { field: string }).field === 'save'
+        assert.ok(
+          capturedItemsHistory.length >= 3,
+          `Expected at least 3 QuickPick displays, got ${capturedItemsHistory.length}`,
         );
-        assert.ok(saveButton, 'Save button should exist');
-        assert.strictEqual((saveButton as { _isDisabled?: boolean })._isDisabled, true,
-          'Save button should be disabled when email is empty');
+        const lastItems = capturedItemsHistory.at(-1);
+        assert.ok(lastItems, "Last items should exist");
+        const saveButton = lastItems.find(
+          (i: unknown) =>
+            typeof i === "object" &&
+            i !== null &&
+            "field" in i &&
+            (i as { field: string }).field === "save",
+        );
+        assert.ok(saveButton, "Save button should exist");
+        assert.strictEqual(
+          (saveButton as { _isDisabled?: boolean })._isDisabled,
+          true,
+          "Save button should be disabled when email is empty",
+        );
       });
     });
 
-    describe('Duplicate ID Check', () => {
-      it('should show ID already exists detail when duplicate ID entered', async () => {
+    describe("Duplicate ID Check", () => {
+      it("should show ID already exists detail when duplicate ID entered", async () => {
         // Note: Duplicate ID detection happens at two levels:
         // 1. InputBox validation (validateIdInput) - prevents accepting duplicate ID
         // 2. buildAddFormItems - shows "ID already exists" detail when state has duplicate ID
@@ -1156,31 +1423,35 @@ describe('identityManager E2E Test Suite', function () {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work], // Existing identity with id 'work'
           quickPickSelections: [
-            { field: 'id' },   // Select id field
-            undefined,        // Cancel after validation failure
+            { field: "id" }, // Select id field
+            undefined, // Cancel after validation failure
           ],
-          inputBoxSelections: ['work'], // Enter duplicate ID (will be rejected by validation)
+          inputBoxSelections: ["work"], // Enter duplicate ID (will be rejected by validation)
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showAddIdentityForm();
 
         // Duplicate ID is rejected at InputBox validation level, causing cancel
-        assert.strictEqual(result, undefined, 'Should return undefined when duplicate ID validation fails');
+        assert.strictEqual(
+          result,
+          undefined,
+          "Should return undefined when duplicate ID validation fails",
+        );
       });
 
-      it('should keep save button disabled when ID is duplicate', async () => {
+      it("should keep save button disabled when ID is duplicate", async () => {
         const capturedItemsHistory: unknown[][] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
           quickPickSelections: [
-            { field: 'id' },
-            { field: 'name' },
-            { field: 'email' },
+            { field: "id" },
+            { field: "name" },
+            { field: "email" },
             undefined,
           ],
-          inputBoxSelections: ['work', 'Test Name', 'test@example.com'], // Duplicate ID
+          inputBoxSelections: ["work", "Test Name", "test@example.com"], // Duplicate ID
           onQuickPickCreated: (quickPick) => {
             capturedItemsHistory.push([...quickPick.items]);
           },
@@ -1190,21 +1461,30 @@ describe('identityManager E2E Test Suite', function () {
         await showAddIdentityForm();
 
         // Even with all fields filled, save should be disabled due to duplicate ID
-        assert.ok(capturedItemsHistory.length >= 4, `Expected at least 4 QuickPick displays, got ${capturedItemsHistory.length}`);
-        const lastItems = capturedItemsHistory.at(-1);
-        assert.ok(lastItems, 'Last items should exist');
-        const saveButton = lastItems.find((i: unknown) =>
-          typeof i === 'object' && i !== null && 'field' in i &&
-          (i as { field: string }).field === 'save'
+        assert.ok(
+          capturedItemsHistory.length >= 4,
+          `Expected at least 4 QuickPick displays, got ${capturedItemsHistory.length}`,
         );
-        assert.ok(saveButton, 'Save button should exist');
-        assert.strictEqual((saveButton as { _isDisabled?: boolean })._isDisabled, true,
-          'Save button should remain disabled with duplicate ID');
+        const lastItems = capturedItemsHistory.at(-1);
+        assert.ok(lastItems, "Last items should exist");
+        const saveButton = lastItems.find(
+          (i: unknown) =>
+            typeof i === "object" &&
+            i !== null &&
+            "field" in i &&
+            (i as { field: string }).field === "save",
+        );
+        assert.ok(saveButton, "Save button should exist");
+        assert.strictEqual(
+          (saveButton as { _isDisabled?: boolean })._isDisabled,
+          true,
+          "Save button should remain disabled with duplicate ID",
+        );
       });
     });
 
-    describe('Back Button (Add Form)', () => {
-      it('should have QuickInputButtons.Back in buttons array', async () => {
+    describe("Back Button (Add Form)", () => {
+      it("should have QuickInputButtons.Back in buttons array", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1218,19 +1498,26 @@ describe('identityManager E2E Test Suite', function () {
 
         await showAddIdentityForm();
 
-        assert.ok(capturedButtons.includes(BACK_BUTTON), 'QuickPick should have Back button');
+        assert.ok(
+          capturedButtons.includes(BACK_BUTTON),
+          "QuickPick should have Back button",
+        );
       });
 
-      it('should return undefined when back button clicked', async () => {
+      it("should return undefined when back button clicked", async () => {
         const mockVSCode = createMockVSCode({
           identities: [],
-          quickPickSelections: ['back'], // Trigger back button
+          quickPickSelections: ["back"], // Trigger back button
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showAddIdentityForm();
 
-        assert.strictEqual(result, undefined, 'Should return undefined when back pressed');
+        assert.strictEqual(
+          result,
+          undefined,
+          "Should return undefined when back pressed",
+        );
       });
     });
   });
@@ -1239,9 +1526,9 @@ describe('identityManager E2E Test Suite', function () {
   // Edit Identity Form Tests
   // ===========================================================================
 
-  describe('Edit Identity Form', () => {
-    describe('Focus Retention', () => {
-      it('should set ignoreFocusOut to prevent data loss on focus change', async () => {
+  describe("Edit Identity Form", () => {
+    describe("Focus Retention", () => {
+      it("should set ignoreFocusOut to prevent data loss on focus change", async () => {
         let capturedIgnoreFocusOut = false;
 
         const mockVSCode = createMockVSCode({
@@ -1255,12 +1542,16 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(capturedIgnoreFocusOut, true, 'Edit form QuickPick should have ignoreFocusOut=true');
+        assert.strictEqual(
+          capturedIgnoreFocusOut,
+          true,
+          "Edit form QuickPick should have ignoreFocusOut=true",
+        );
       });
     });
 
-    describe('Back Button (Field Selection)', () => {
-      it('should have QuickInputButtons.Back in field selection', async () => {
+    describe("Back Button (Field Selection)", () => {
+      it("should have QuickInputButtons.Back in field selection", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1274,24 +1565,31 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.ok(capturedButtons.includes(BACK_BUTTON), 'Field selection QuickPick should have Back button');
+        assert.ok(
+          capturedButtons.includes(BACK_BUTTON),
+          "Field selection QuickPick should have Back button",
+        );
       });
 
-      it('should return false when back button clicked at field selection', async () => {
+      it("should return false when back button clicked at field selection", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: ['back'], // Trigger back button
+          quickPickSelections: ["back"], // Trigger back button
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Should return false when back pressed at field selection');
+        assert.strictEqual(
+          result,
+          false,
+          "Should return false when back pressed at field selection",
+        );
       });
     });
 
-    describe('ID Field Non-Editable (Multiple Profiles)', () => {
-      it('should have ID field with field: null when 2+ profiles exist', async () => {
+    describe("ID Field Non-Editable (Multiple Profiles)", () => {
+      it("should have ID field with field: null when 2+ profiles exist", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1307,15 +1605,19 @@ describe('identityManager E2E Test Suite', function () {
 
         // Find ID item - it should have field: null
         const idItem = capturedItems.find((i: unknown) => {
-          if (typeof i !== 'object' || i === null) return false;
+          if (typeof i !== "object" || i === null) return false;
           const item = i as { label?: string };
-          return item.label?.includes('$(lock)');
+          return item.label?.includes("$(lock)");
         });
-        assert.ok(idItem, 'ID item should be present');
-        assert.strictEqual((idItem as { field: unknown }).field, null, 'ID field should be null');
+        assert.ok(idItem, "ID item should be present");
+        assert.strictEqual(
+          (idItem as { field: unknown }).field,
+          null,
+          "ID field should be null",
+        );
       });
 
-      it('should have ID field with _isDisabled: true when 2+ profiles exist', async () => {
+      it("should have ID field with _isDisabled: true when 2+ profiles exist", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1330,15 +1632,19 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         const idItem = capturedItems.find((i: unknown) => {
-          if (typeof i !== 'object' || i === null) return false;
+          if (typeof i !== "object" || i === null) return false;
           const item = i as { label?: string };
-          return item.label?.includes('$(lock)');
+          return item.label?.includes("$(lock)");
         });
-        assert.ok(idItem, 'ID item should be present');
-        assert.strictEqual((idItem as { _isDisabled?: boolean })._isDisabled, true, 'ID field should be disabled');
+        assert.ok(idItem, "ID item should be present");
+        assert.strictEqual(
+          (idItem as { _isDisabled?: boolean })._isDisabled,
+          true,
+          "ID field should be disabled",
+        );
       });
 
-      it('should have ID field with $(lock) icon when 2+ profiles exist', async () => {
+      it("should have ID field with $(lock) icon when 2+ profiles exist", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1353,21 +1659,21 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         const idItem = capturedItems.find((i: unknown) => {
-          if (typeof i !== 'object' || i === null) return false;
+          if (typeof i !== "object" || i === null) return false;
           const item = i as { label?: string };
-          return item.label?.includes('$(lock)');
+          return item.label?.includes("$(lock)");
         });
-        assert.ok(idItem, 'ID item with $(lock) icon should be present');
+        assert.ok(idItem, "ID item with $(lock) icon should be present");
       });
 
-      it('should not close QuickPick when ID field is clicked (returns undefined for loop continuation)', async () => {
+      it("should not close QuickPick when ID field is clicked (returns undefined for loop continuation)", async () => {
         let quickPickShowCount = 0;
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work, TEST_IDENTITIES.personal],
           quickPickSelections: [
             { field: null }, // Click ID field (disabled)
-            undefined,       // Cancel after
+            undefined, // Cancel after
           ],
           onQuickPickCreated: () => {
             quickPickShowCount++;
@@ -1379,13 +1685,13 @@ describe('identityManager E2E Test Suite', function () {
 
         // When disabled item is clicked, it should return undefined and loop continues
         // The wizard should still be able to exit normally
-        assert.strictEqual(result, false, 'Should return false when cancelled');
+        assert.strictEqual(result, false, "Should return false when cancelled");
         // QuickPick should be shown at least once
-        assert.ok(quickPickShowCount >= 1, 'QuickPick should be shown');
+        assert.ok(quickPickShowCount >= 1, "QuickPick should be shown");
       });
     });
 
-    describe('ID Field Editable (Single Profile)', () => {
+    describe("ID Field Editable (Single Profile)", () => {
       it('should have ID field with field: "id" when only 1 profile exists', async () => {
         let capturedItems: unknown[] = [];
 
@@ -1401,15 +1707,19 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         const idItem = capturedItems.find((i: unknown) => {
-          if (typeof i !== 'object' || i === null) return false;
+          if (typeof i !== "object" || i === null) return false;
           const item = i as { field?: string | null };
-          return item.field === 'id';
+          return item.field === "id";
         });
         assert.ok(idItem, 'ID item with field: "id" should be present');
-        assert.strictEqual((idItem as { _isDisabled?: boolean })._isDisabled, undefined, 'ID field should not be disabled');
+        assert.strictEqual(
+          (idItem as { _isDisabled?: boolean })._isDisabled,
+          undefined,
+          "ID field should not be disabled",
+        );
       });
 
-      it('should have ID field with $(pencil) icon when only 1 profile exists', async () => {
+      it("should have ID field with $(pencil) icon when only 1 profile exists", async () => {
         let capturedItems: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
@@ -1424,23 +1734,26 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         const idItem = capturedItems.find((i: unknown) => {
-          if (typeof i !== 'object' || i === null) return false;
+          if (typeof i !== "object" || i === null) return false;
           const item = i as { label?: string };
-          return item.label?.includes('$(pencil)');
+          return item.label?.includes("$(pencil)");
         });
-        assert.ok(idItem, 'ID item with $(pencil) icon should be present when single profile');
+        assert.ok(
+          idItem,
+          "ID item with $(pencil) icon should be present when single profile",
+        );
       });
 
-      it('should show $(check) Saved for ID field after saving', async () => {
+      it("should show $(check) Saved for ID field after saving", async () => {
         const capturedItemsHistory: unknown[][] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
           quickPickSelections: [
-            { field: 'id' },  // Select ID field
-            undefined,        // Cancel after returning
+            { field: "id" }, // Select ID field
+            undefined, // Cancel after returning
           ],
-          inputBoxSelections: ['new-id'],
+          inputBoxSelections: ["new-id"],
           onQuickPickCreated: (quickPick) => {
             capturedItemsHistory.push([...quickPick.items]);
           },
@@ -1450,99 +1763,106 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // After saving, the ID field should show "Saved" feedback
-        assert.ok(capturedItemsHistory.length >= 2, `Should capture items at least twice (initial + after save), got ${capturedItemsHistory.length}`);
+        assert.ok(
+          capturedItemsHistory.length >= 2,
+          `Should capture items at least twice (initial + after save), got ${capturedItemsHistory.length}`,
+        );
         const itemsAfterSave = capturedItemsHistory[1];
         const idItem = itemsAfterSave.find((i: unknown) => {
-          if (typeof i !== 'object' || i === null) return false;
-          return (i as { field?: string | null }).field === 'id';
+          if (typeof i !== "object" || i === null) return false;
+          return (i as { field?: string | null }).field === "id";
         });
-        assert.ok(idItem, 'Should find ID field item after save');
+        assert.ok(idItem, "Should find ID field item after save");
         const description = (idItem as { description?: string }).description;
-        assert.ok(description?.includes('Saved'), `ID field should show 'Saved' feedback, got: ${description}`);
+        assert.ok(
+          description?.includes("Saved"),
+          `ID field should show 'Saved' feedback, got: ${description}`,
+        );
       });
 
-      it('should accept valid new ID and save successfully', async () => {
+      it("should accept valid new ID and save successfully", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'id' },
-            undefined,
-          ],
-          inputBoxSelections: ['my-new-id'],
+          quickPickSelections: [{ field: "id" }, undefined],
+          inputBoxSelections: ["my-new-id"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, true, 'Editing ID with valid value should succeed');
+        assert.strictEqual(
+          result,
+          true,
+          "Editing ID with valid value should succeed",
+        );
         const configUpdates = mockVSCode._getConfigUpdateCalls();
-        assert.ok(configUpdates.length > 0, 'Config should be updated');
+        assert.ok(configUpdates.length > 0, "Config should be updated");
       });
 
-      it('should reject empty ID input', async () => {
+      it("should reject empty ID input", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'id' },
-            undefined,
-          ],
-          inputBoxSelections: [''], // Empty input
+          quickPickSelections: [{ field: "id" }, undefined],
+          inputBoxSelections: [""], // Empty input
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Empty ID should be rejected');
+        assert.strictEqual(result, false, "Empty ID should be rejected");
       });
 
-      it('should reject ID with invalid characters (@#$)', async () => {
+      it("should reject ID with invalid characters (@#$)", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'id' },
-            undefined,
-          ],
-          inputBoxSelections: ['invalid@#$'],
+          quickPickSelections: [{ field: "id" }, undefined],
+          inputBoxSelections: ["invalid@#$"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'ID with invalid characters should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "ID with invalid characters should be rejected",
+        );
       });
 
-      it('should reject ID exceeding max length (65 chars)', async () => {
-        const tooLong = 'a'.repeat(MAX_ID_LENGTH + 1); // 65 chars
+      it("should reject ID exceeding max length (65 chars)", async () => {
+        const tooLong = "a".repeat(MAX_ID_LENGTH + 1); // 65 chars
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'id' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "id" }, undefined],
           inputBoxSelections: [tooLong],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'ID exceeding max length should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "ID exceeding max length should be rejected",
+        );
       });
 
-      it('should allow current ID value (self-exclusion in duplicate check)', async () => {
+      it("should allow current ID value (self-exclusion in duplicate check)", async () => {
         // When editing ID, entering the same ID as current should be allowed
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'id' },
-            undefined,
-          ],
-          inputBoxSelections: ['work'], // Same as current ID
+          quickPickSelections: [{ field: "id" }, undefined],
+          inputBoxSelections: ["work"], // Same as current ID
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, true, 'Current ID value should be allowed (self-exclusion)');
+        assert.strictEqual(
+          result,
+          true,
+          "Current ID value should be allowed (self-exclusion)",
+        );
       });
 
       // Note: QuickPick title update after ID change cannot be tested with current mock
@@ -1551,17 +1871,17 @@ describe('identityManager E2E Test Suite', function () {
       // correctly finds the identity with the new ID. This is verified by manual testing.
     });
 
-    describe('Edit Loop Continuation', () => {
-      it('should return to field selection after editing a field', async () => {
+    describe("Edit Loop Continuation", () => {
+      it("should return to field selection after editing a field", async () => {
         let quickPickShowCount = 0;
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
           quickPickSelections: [
-            { field: 'name' },  // Select name field
-            undefined,         // Cancel after returning
+            { field: "name" }, // Select name field
+            undefined, // Cancel after returning
           ],
-          inputBoxSelections: ['Updated Name'],
+          inputBoxSelections: ["Updated Name"],
           onQuickPickCreated: () => {
             quickPickShowCount++;
           },
@@ -1571,19 +1891,22 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // QuickPick should be shown at least twice (initial + after edit)
-        assert.ok(quickPickShowCount >= 2, `QuickPick should be shown at least twice, got ${quickPickShowCount}`);
+        assert.ok(
+          quickPickShowCount >= 2,
+          `QuickPick should be shown at least twice, got ${quickPickShowCount}`,
+        );
       });
 
-      it('should show $(check) Saved for just-saved field', async () => {
+      it("should show $(check) Saved for just-saved field", async () => {
         const capturedItemsHistory: unknown[][] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
           quickPickSelections: [
-            { field: 'name' },  // Select name field
-            undefined,         // Cancel after returning
+            { field: "name" }, // Select name field
+            undefined, // Cancel after returning
           ],
-          inputBoxSelections: ['Updated Name'],
+          inputBoxSelections: ["Updated Name"],
           onQuickPickCreated: (quickPick) => {
             capturedItemsHistory.push([...quickPick.items]);
           },
@@ -1593,28 +1916,34 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // After saving, the name field should show "Saved" feedback
-        assert.ok(capturedItemsHistory.length >= 2, `Should capture items at least twice (initial + after save), got ${capturedItemsHistory.length}`);
+        assert.ok(
+          capturedItemsHistory.length >= 2,
+          `Should capture items at least twice (initial + after save), got ${capturedItemsHistory.length}`,
+        );
         const itemsAfterSave = capturedItemsHistory[1];
         const nameItem = itemsAfterSave.find((i: unknown) => {
-          if (typeof i !== 'object' || i === null) return false;
-          return (i as { field?: string }).field === 'name';
+          if (typeof i !== "object" || i === null) return false;
+          return (i as { field?: string }).field === "name";
         });
-        assert.ok(nameItem, 'Should find name field item after save');
+        assert.ok(nameItem, "Should find name field item after save");
         const description = (nameItem as { description?: string }).description;
-        assert.ok(description?.includes('Saved'), `Name field should show 'Saved' feedback, got: ${description}`);
+        assert.ok(
+          description?.includes("Saved"),
+          `Name field should show 'Saved' feedback, got: ${description}`,
+        );
       });
 
-      it('should allow re-selecting the same field after saving', async () => {
+      it("should allow re-selecting the same field after saving", async () => {
         let quickPickShowCount = 0;
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
           quickPickSelections: [
-            { field: 'name' },  // Select name field first time
-            { field: 'name' },  // Select name field again
-            undefined,         // Cancel
+            { field: "name" }, // Select name field first time
+            { field: "name" }, // Select name field again
+            undefined, // Cancel
           ],
-          inputBoxSelections: ['Updated Name', 'Updated Name Again'],
+          inputBoxSelections: ["Updated Name", "Updated Name Again"],
           onQuickPickCreated: () => {
             quickPickShowCount++;
           },
@@ -1624,13 +1953,16 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // QuickPick should be shown at least 3 times
-        assert.ok(quickPickShowCount >= 3, `QuickPick should be shown at least 3 times for re-selection, got ${quickPickShowCount}`);
+        assert.ok(
+          quickPickShowCount >= 3,
+          `QuickPick should be shown at least 3 times for re-selection, got ${quickPickShowCount}`,
+        );
       });
     });
 
-    describe('Placeholder', () => {
-      it('should have Filter... placeholder in field selection', async () => {
-        let capturedPlaceholder = '';
+    describe("Placeholder", () => {
+      it("should have Filter... placeholder in field selection", async () => {
+        let capturedPlaceholder = "";
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
@@ -1643,7 +1975,11 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(capturedPlaceholder, 'Filter...', 'Placeholder should be "Filter..."');
+        assert.strictEqual(
+          capturedPlaceholder,
+          "Filter...",
+          'Placeholder should be "Filter..."',
+        );
       });
     });
   });
@@ -1659,215 +1995,229 @@ describe('identityManager E2E Test Suite', function () {
   // - File picker button ($(folder-opened)) and showOpenDialog integration
   // ===========================================================================
 
-  describe('SSH/GPG Field Editing', () => {
+  describe("SSH/GPG Field Editing", () => {
     /**
      * Test identity fixture with SSH/GPG fields
      */
     const TEST_IDENTITY_WITH_SSH: Identity = {
-      id: 'ssh-test',
-      name: 'SSH Test User',
-      email: 'ssh@example.com',
-      sshKeyPath: '~/.ssh/id_rsa',
-      sshHost: 'github-work',
-      gpgKeyId: 'ABCD1234',
+      id: "ssh-test",
+      name: "SSH Test User",
+      email: "ssh@example.com",
+      sshKeyPath: "~/.ssh/id_rsa",
+      sshHost: "github-work",
+      gpgKeyId: "ABCD1234",
     };
 
     // =========================================================================
     // sshKeyPath Field Editing Tests
     // =========================================================================
 
-    describe('sshKeyPath Field Editing', () => {
-      describe('Validation', () => {
-        it('should accept valid SSH key path (~/.ssh/id_rsa)', async () => {
+    describe("sshKeyPath Field Editing", () => {
+      describe("Validation", () => {
+        it("should accept valid SSH key path (~/.ssh/id_rsa)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
             quickPickSelections: [
-              { field: 'sshKeyPath' },
+              { field: "sshKeyPath" },
               undefined, // Cancel after save
             ],
-            inputBoxSelections: ['~/.ssh/id_rsa'],
+            inputBoxSelections: ["~/.ssh/id_rsa"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'Valid SSH key path should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "Valid SSH key path should be accepted",
+          );
         });
 
-        it('should accept SSH key path in subdirectory (~/.ssh/keys/work_key)', async () => {
+        it("should accept SSH key path in subdirectory (~/.ssh/keys/work_key)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/.ssh/keys/work_key'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/.ssh/keys/work_key"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'SSH key path in subdirectory should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "SSH key path in subdirectory should be accepted",
+          );
         });
 
         // SSH directory restriction tests (isUnderSshDirectory)
-        it('should reject path outside .ssh directory (~/documents/key)', async () => {
+        it("should reject path outside .ssh directory (~/documents/key)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/documents/key'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/documents/key"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'Path outside .ssh directory should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "Path outside .ssh directory should be rejected",
+          );
         });
 
-        it('should reject path in .ssh_backup directory (~/.ssh_backup/key)', async () => {
+        it("should reject path in .ssh_backup directory (~/.ssh_backup/key)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/.ssh_backup/key'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/.ssh_backup/key"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'Path in .ssh_backup (not .ssh) should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "Path in .ssh_backup (not .ssh) should be rejected",
+          );
         });
 
-        it('should reject path with traversal (~/.ssh/../../../etc/passwd)', async () => {
+        it("should reject path with traversal (~/.ssh/../../../etc/passwd)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
             quickPickSelections: [
-              { field: 'sshKeyPath' },
+              { field: "sshKeyPath" },
               undefined, // Cancel after validation failure
             ],
-            inputBoxSelections: ['~/.ssh/../../../etc/passwd'],
+            inputBoxSelections: ["~/.ssh/../../../etc/passwd"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
           // Validation error causes flow to cancel
-          assert.strictEqual(result, false, 'Path traversal should cause validation failure');
+          assert.strictEqual(
+            result,
+            false,
+            "Path traversal should cause validation failure",
+          );
         });
 
-        it('should allow single dot in path (~/.ssh/./id_rsa)', async () => {
+        it("should allow single dot in path (~/.ssh/./id_rsa)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/.ssh/./id_rsa'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/.ssh/./id_rsa"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
           // Single dot is harmless, should be accepted
-          assert.strictEqual(result, true, 'Single dot in path should be allowed');
+          assert.strictEqual(
+            result,
+            true,
+            "Single dot in path should be allowed",
+          );
         });
 
-        it('should reject backtick command substitution (`whoami`)', async () => {
+        it("should reject backtick command substitution (`whoami`)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/.ssh/`whoami`'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/.ssh/`whoami`"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'Backtick command should cause validation failure');
+          assert.strictEqual(
+            result,
+            false,
+            "Backtick command should cause validation failure",
+          );
         });
 
-        it('should reject dollar command substitution ($(command))', async () => {
+        it("should reject dollar command substitution ($(command))", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/.ssh/$(whoami)'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/.ssh/$(whoami)"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'Dollar command substitution should cause validation failure');
+          assert.strictEqual(
+            result,
+            false,
+            "Dollar command substitution should cause validation failure",
+          );
         });
 
-        it('should reject semicolon in path (key;rm -rf /)', async () => {
+        it("should reject semicolon in path (key;rm -rf /)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/.ssh/key;rm -rf /'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/.ssh/key;rm -rf /"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'Semicolon in path should cause validation failure');
+          assert.strictEqual(
+            result,
+            false,
+            "Semicolon in path should cause validation failure",
+          );
         });
 
-        it('should reject path not starting with / or ~', async () => {
+        it("should reject path not starting with / or ~", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['relative/path/key'],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["relative/path/key"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'Relative path should cause validation failure');
+          assert.strictEqual(
+            result,
+            false,
+            "Relative path should cause validation failure",
+          );
         });
 
-        it('should allow clearing sshKeyPath (empty string for optional field)', async () => {
+        it("should allow clearing sshKeyPath (empty string for optional field)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITY_WITH_SSH],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: [''], // Clear the field
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: [""], // Clear the field
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITY_WITH_SSH);
 
-          assert.strictEqual(result, true, 'Clearing optional sshKeyPath should be allowed');
+          assert.strictEqual(
+            result,
+            true,
+            "Clearing optional sshKeyPath should be allowed",
+          );
         });
       });
 
-      describe('File Picker Button', () => {
-        it('should show file picker button ($(folder-opened)) in InputBox', async () => {
+      describe("File Picker Button", () => {
+        it("should show file picker button ($(folder-opened)) in InputBox", async () => {
           let capturedButtons: unknown[] = [];
 
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
             inputBoxSelections: [undefined], // Cancel at InputBox
             onInputBoxCreated: (inputBox) => {
               capturedButtons = inputBox.buttons;
@@ -1878,28 +2228,31 @@ describe('identityManager E2E Test Suite', function () {
           await showEditProfileFlow(TEST_IDENTITIES.work);
 
           // Should have Back button and file picker button
-          assert.ok(capturedButtons.length >= 2, `Should have at least 2 buttons, got ${capturedButtons.length}`);
+          assert.ok(
+            capturedButtons.length >= 2,
+            `Should have at least 2 buttons, got ${capturedButtons.length}`,
+          );
 
           // Find file picker button (has ThemeIcon with 'folder-opened')
           const hasFilePickerButton = capturedButtons.some((btn: unknown) => {
-            if (typeof btn === 'object' && btn !== null && 'iconPath' in btn) {
+            if (typeof btn === "object" && btn !== null && "iconPath" in btn) {
               const iconPath = (btn as { iconPath: { id?: string } }).iconPath;
-              return iconPath?.id === 'folder-opened';
+              return iconPath?.id === "folder-opened";
             }
             return false;
           });
-          assert.ok(hasFilePickerButton, 'Should have file picker button with $(folder-opened) icon');
+          assert.ok(
+            hasFilePickerButton,
+            "Should have file picker button with $(folder-opened) icon",
+          );
         });
 
-        it('should have showOpenDialog available for file picker', async () => {
+        it("should have showOpenDialog available for file picker", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
-            inputBoxSelections: ['~/.ssh/selected_key'],
-            showOpenDialogResult: '/home/user/.ssh/selected_key',
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+            inputBoxSelections: ["~/.ssh/selected_key"],
+            showOpenDialogResult: "/home/user/.ssh/selected_key",
           });
 
           _setMockVSCode(mockVSCode as never);
@@ -1908,8 +2261,11 @@ describe('identityManager E2E Test Suite', function () {
 
           // Verify showOpenDialog is available in the mock
           // The actual file picker button click is handled by the mock infrastructure
-          assert.strictEqual(typeof mockVSCode.window.showOpenDialog, 'function',
-            'showOpenDialog should be available');
+          assert.strictEqual(
+            typeof mockVSCode.window.showOpenDialog,
+            "function",
+            "showOpenDialog should be available",
+          );
         });
 
         it('should have file picker button tooltip "Browse for SSH key path..."', async () => {
@@ -1917,10 +2273,7 @@ describe('identityManager E2E Test Suite', function () {
 
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
             inputBoxSelections: [undefined],
             onInputBoxCreated: (inputBox) => {
               capturedButtons = inputBox.buttons;
@@ -1932,40 +2285,44 @@ describe('identityManager E2E Test Suite', function () {
 
           // Find file picker button and verify tooltip
           const filePickerButton = capturedButtons.find((btn: unknown) => {
-            if (typeof btn === 'object' && btn !== null && 'iconPath' in btn) {
+            if (typeof btn === "object" && btn !== null && "iconPath" in btn) {
               const iconPath = (btn as { iconPath: { id?: string } }).iconPath;
-              return iconPath?.id === 'folder-opened';
+              return iconPath?.id === "folder-opened";
             }
             return false;
           });
 
-          if (filePickerButton && typeof filePickerButton === 'object' && 'tooltip' in filePickerButton) {
+          if (
+            filePickerButton &&
+            typeof filePickerButton === "object" &&
+            "tooltip" in filePickerButton
+          ) {
             const tooltip = (filePickerButton as { tooltip?: string }).tooltip;
-            assert.ok(tooltip?.includes('Browse for SSH key path'), `File picker button should have 'Browse for SSH key path' tooltip, got: ${tooltip}`);
+            assert.ok(
+              tooltip?.includes("Browse for SSH key path"),
+              `File picker button should have 'Browse for SSH key path' tooltip, got: ${tooltip}`,
+            );
           }
         });
       });
 
-      describe('showOpenDialog default path', () => {
-        it('should use HOME/.ssh as defaultUri on Unix', async () => {
+      describe("showOpenDialog default path", () => {
+        it("should use HOME/.ssh as defaultUri on Unix", async () => {
           // Save original env
           const originalHome = process.env.HOME;
           const originalUserProfile = process.env.USERPROFILE;
 
           // Set up Unix environment
-          process.env.HOME = '/home/testuser';
+          process.env.HOME = "/home/testuser";
           delete process.env.USERPROFILE;
 
           let capturedDefaultUri: { fsPath: string } | undefined;
 
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
             inputBoxSelections: [FILE_PICKER_CLICK, undefined],
-            showOpenDialogResult: '/home/testuser/.ssh/id_rsa',
+            showOpenDialogResult: "/home/testuser/.ssh/id_rsa",
             onShowOpenDialog: (dialogOptions) => {
               capturedDefaultUri = dialogOptions.defaultUri;
             },
@@ -1974,9 +2331,15 @@ describe('identityManager E2E Test Suite', function () {
 
           try {
             await showEditProfileFlow(TEST_IDENTITIES.work);
-            assert.ok(capturedDefaultUri, 'showOpenDialog should have been called');
-            assert.strictEqual(capturedDefaultUri?.fsPath, '/home/testuser/.ssh',
-              'defaultUri should be HOME/.ssh');
+            assert.ok(
+              capturedDefaultUri,
+              "showOpenDialog should have been called",
+            );
+            assert.strictEqual(
+              capturedDefaultUri?.fsPath,
+              "/home/testuser/.ssh",
+              "defaultUri should be HOME/.ssh",
+            );
           } finally {
             // Restore original env
             process.env.HOME = originalHome;
@@ -1986,7 +2349,7 @@ describe('identityManager E2E Test Suite', function () {
           }
         });
 
-        it('should use USERPROFILE/.ssh as defaultUri on Windows', async () => {
+        it("should use USERPROFILE/.ssh as defaultUri on Windows", async () => {
           // Save original env
           const originalHome = process.env.HOME;
           const originalUserProfile = process.env.USERPROFILE;
@@ -1999,10 +2362,7 @@ describe('identityManager E2E Test Suite', function () {
 
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
             inputBoxSelections: [FILE_PICKER_CLICK, undefined],
             showOpenDialogResult: String.raw`C:\Users\testuser\.ssh\id_rsa`,
             onShowOpenDialog: (dialogOptions) => {
@@ -2013,9 +2373,15 @@ describe('identityManager E2E Test Suite', function () {
 
           try {
             await showEditProfileFlow(TEST_IDENTITIES.work);
-            assert.ok(capturedDefaultUri, 'showOpenDialog should have been called');
-            assert.strictEqual(capturedDefaultUri?.fsPath, String.raw`C:\Users\testuser/.ssh`,
-              'defaultUri should be USERPROFILE/.ssh');
+            assert.ok(
+              capturedDefaultUri,
+              "showOpenDialog should have been called",
+            );
+            assert.strictEqual(
+              capturedDefaultUri?.fsPath,
+              String.raw`C:\Users\testuser/.ssh`,
+              "defaultUri should be USERPROFILE/.ssh",
+            );
           } finally {
             // Restore original env
             if (originalHome !== undefined) {
@@ -2025,7 +2391,7 @@ describe('identityManager E2E Test Suite', function () {
           }
         });
 
-        it('should use undefined defaultUri when both HOME and USERPROFILE are undefined', async () => {
+        it("should use undefined defaultUri when both HOME and USERPROFILE are undefined", async () => {
           // Save original env
           const originalHome = process.env.HOME;
           const originalUserProfile = process.env.USERPROFILE;
@@ -2034,15 +2400,14 @@ describe('identityManager E2E Test Suite', function () {
           delete process.env.HOME;
           delete process.env.USERPROFILE;
 
-          let capturedDefaultUri: { fsPath: string } | undefined = { fsPath: 'sentinel' };
+          let capturedDefaultUri: { fsPath: string } | undefined = {
+            fsPath: "sentinel",
+          };
           let dialogWasCalled = false;
 
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
             inputBoxSelections: [FILE_PICKER_CLICK, undefined],
             showOpenDialogResult: undefined,
             onShowOpenDialog: (dialogOptions) => {
@@ -2054,9 +2419,15 @@ describe('identityManager E2E Test Suite', function () {
 
           try {
             await showEditProfileFlow(TEST_IDENTITIES.work);
-            assert.ok(dialogWasCalled, 'showOpenDialog should have been called');
-            assert.strictEqual(capturedDefaultUri, undefined,
-              'defaultUri should be undefined when HOME and USERPROFILE are both undefined');
+            assert.ok(
+              dialogWasCalled,
+              "showOpenDialog should have been called",
+            );
+            assert.strictEqual(
+              capturedDefaultUri,
+              undefined,
+              "defaultUri should be undefined when HOME and USERPROFILE are both undefined",
+            );
           } finally {
             // Restore original env
             if (originalHome !== undefined) {
@@ -2074,135 +2445,139 @@ describe('identityManager E2E Test Suite', function () {
     // sshHost Field Editing Tests
     // =========================================================================
 
-    describe('sshHost Field Editing', () => {
-      describe('Validation with SSH_HOST_REGEX', () => {
-        it('should accept valid hostname (github-work)', async () => {
+    describe("sshHost Field Editing", () => {
+      describe("Validation with SSH_HOST_REGEX", () => {
+        it("should accept valid hostname (github-work)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
-            inputBoxSelections: ['github-work'],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
+            inputBoxSelections: ["github-work"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'Valid SSH host should be accepted');
+          assert.strictEqual(result, true, "Valid SSH host should be accepted");
         });
 
-        it('should accept hostname with dot (gitlab.personal)', async () => {
+        it("should accept hostname with dot (gitlab.personal)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
-            inputBoxSelections: ['gitlab.personal'],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
+            inputBoxSelections: ["gitlab.personal"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'SSH host with dot should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "SSH host with dot should be accepted",
+          );
         });
 
-        it('should accept hostname with underscore (my_server)', async () => {
+        it("should accept hostname with underscore (my_server)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
-            inputBoxSelections: ['my_server'],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
+            inputBoxSelections: ["my_server"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'SSH host with underscore should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "SSH host with underscore should be accepted",
+          );
         });
 
-        it('should reject hostname with space', async () => {
+        it("should reject hostname with space", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
-            inputBoxSelections: ['invalid host'],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
+            inputBoxSelections: ["invalid host"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'SSH host with space should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "SSH host with space should be rejected",
+          );
         });
 
-        it('should reject hostname with special characters (!@#)', async () => {
+        it("should reject hostname with special characters (!@#)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
-            inputBoxSelections: ['invalid!@#host'],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
+            inputBoxSelections: ["invalid!@#host"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'SSH host with special characters should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "SSH host with special characters should be rejected",
+          );
         });
 
-        it('should reject hostname starting with hyphen', async () => {
+        it("should reject hostname starting with hyphen", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
-            inputBoxSelections: ['-invalid-start'],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
+            inputBoxSelections: ["-invalid-start"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'SSH host starting with hyphen should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "SSH host starting with hyphen should be rejected",
+          );
         });
 
-        it('should reject hostname exceeding MAX_SSH_HOST_LENGTH', async () => {
-          const longHost = 'a'.repeat(MAX_SSH_HOST_LENGTH + 1);
+        it("should reject hostname exceeding MAX_SSH_HOST_LENGTH", async () => {
+          const longHost = "a".repeat(MAX_SSH_HOST_LENGTH + 1);
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
             inputBoxSelections: [longHost],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'SSH host exceeding max length should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "SSH host exceeding max length should be rejected",
+          );
         });
 
-        it('should allow clearing sshHost (empty string for optional field)', async () => {
+        it("should allow clearing sshHost (empty string for optional field)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITY_WITH_SSH],
-            quickPickSelections: [
-              { field: 'sshHost' },
-              undefined,
-            ],
-            inputBoxSelections: [''],
+            quickPickSelections: [{ field: "sshHost" }, undefined],
+            inputBoxSelections: [""],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITY_WITH_SSH);
 
-          assert.strictEqual(result, true, 'Clearing optional sshHost should be allowed');
+          assert.strictEqual(
+            result,
+            true,
+            "Clearing optional sshHost should be allowed",
+          );
         });
       });
     });
@@ -2211,152 +2586,161 @@ describe('identityManager E2E Test Suite', function () {
     // gpgKeyId Field Editing Tests
     // =========================================================================
 
-    describe('gpgKeyId Field Editing', () => {
-      describe('Validation with GPG_KEY_REGEX', () => {
-        it('should accept valid 8-character hex key ID (ABCD1234)', async () => {
+    describe("gpgKeyId Field Editing", () => {
+      describe("Validation with GPG_KEY_REGEX", () => {
+        it("should accept valid 8-character hex key ID (ABCD1234)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
-            inputBoxSelections: ['ABCD1234'],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
+            inputBoxSelections: ["ABCD1234"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'Valid 8-char GPG key ID should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "Valid 8-char GPG key ID should be accepted",
+          );
         });
 
-        it('should accept valid 16-character hex key ID', async () => {
+        it("should accept valid 16-character hex key ID", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
-            inputBoxSelections: ['ABCD1234ABCD1234'],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
+            inputBoxSelections: ["ABCD1234ABCD1234"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'Valid 16-char GPG key ID should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "Valid 16-char GPG key ID should be accepted",
+          );
         });
 
-        it('should accept valid 40-character hex fingerprint', async () => {
-          const fullFingerprint = 'ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234';
+        it("should accept valid 40-character hex fingerprint", async () => {
+          const fullFingerprint = "ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234";
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
             inputBoxSelections: [fullFingerprint],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'Valid 40-char GPG fingerprint should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "Valid 40-char GPG fingerprint should be accepted",
+          );
         });
 
-        it('should accept lowercase hex characters', async () => {
+        it("should accept lowercase hex characters", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
-            inputBoxSelections: ['abcdef12'],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
+            inputBoxSelections: ["abcdef12"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, true, 'Lowercase hex GPG key ID should be accepted');
+          assert.strictEqual(
+            result,
+            true,
+            "Lowercase hex GPG key ID should be accepted",
+          );
         });
 
-        it('should reject key ID with less than 8 characters (7 chars)', async () => {
+        it("should reject key ID with less than 8 characters (7 chars)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
-            inputBoxSelections: ['ABCD123'], // 7 characters
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
+            inputBoxSelections: ["ABCD123"], // 7 characters
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'GPG key ID with 7 chars should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "GPG key ID with 7 chars should be rejected",
+          );
         });
 
-        it('should reject key ID with more than 40 characters (41 chars)', async () => {
-          const tooLong = 'A'.repeat(41);
+        it("should reject key ID with more than 40 characters (41 chars)", async () => {
+          const tooLong = "A".repeat(41);
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
             inputBoxSelections: [tooLong],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'GPG key ID with 41 chars should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "GPG key ID with 41 chars should be rejected",
+          );
         });
 
-        it('should reject non-hex characters (GHIJKLMN)', async () => {
+        it("should reject non-hex characters (GHIJKLMN)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
-            inputBoxSelections: ['GHIJKLMN'],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
+            inputBoxSelections: ["GHIJKLMN"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'GPG key ID with non-hex chars should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "GPG key ID with non-hex chars should be rejected",
+          );
         });
 
-        it('should reject key ID with spaces', async () => {
+        it("should reject key ID with spaces", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
-            inputBoxSelections: ['ABCD 1234'],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
+            inputBoxSelections: ["ABCD 1234"],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, 'GPG key ID with spaces should be rejected');
+          assert.strictEqual(
+            result,
+            false,
+            "GPG key ID with spaces should be rejected",
+          );
         });
 
-        it('should allow clearing gpgKeyId (empty string for optional field)', async () => {
+        it("should allow clearing gpgKeyId (empty string for optional field)", async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITY_WITH_SSH],
-            quickPickSelections: [
-              { field: 'gpgKeyId' },
-              undefined,
-            ],
-            inputBoxSelections: [''],
+            quickPickSelections: [{ field: "gpgKeyId" }, undefined],
+            inputBoxSelections: [""],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITY_WITH_SSH);
 
-          assert.strictEqual(result, true, 'Clearing optional gpgKeyId should be allowed');
+          assert.strictEqual(
+            result,
+            true,
+            "Clearing optional gpgKeyId should be allowed",
+          );
         });
       });
     });
@@ -2366,17 +2750,14 @@ describe('identityManager E2E Test Suite', function () {
   // InputBox Back Button, File Picker, onDidChangeValue Tests
   // ===========================================================================
 
-  describe('InputBox Back Button Tests', () => {
-    describe('QuickInputButtons.Back in InputBox', () => {
-      it('should have QuickInputButtons.Back set in showFieldInputBox() for name field', async () => {
+  describe("InputBox Back Button Tests", () => {
+    describe("QuickInputButtons.Back in InputBox", () => {
+      it("should have QuickInputButtons.Back set in showFieldInputBox() for name field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "name" }, undefined],
           inputBoxSelections: [undefined], // Cancel InputBox
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2387,19 +2768,22 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // Should have Back button
-        assert.ok(capturedButtons.length > 0, `Should have at least 1 button, got ${capturedButtons.length}`);
-        assert.ok(capturedButtons.includes(BACK_BUTTON), 'InputBox should have Back button');
+        assert.ok(
+          capturedButtons.length > 0,
+          `Should have at least 1 button, got ${capturedButtons.length}`,
+        );
+        assert.ok(
+          capturedButtons.includes(BACK_BUTTON),
+          "InputBox should have Back button",
+        );
       });
 
-      it('should have QuickInputButtons.Back set in showFieldInputBox() for email field', async () => {
+      it("should have QuickInputButtons.Back set in showFieldInputBox() for email field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'email' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "email" }, undefined],
           inputBoxSelections: [undefined],
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2409,7 +2793,10 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.ok(capturedButtons.includes(BACK_BUTTON), 'InputBox for email should have Back button');
+        assert.ok(
+          capturedButtons.includes(BACK_BUTTON),
+          "InputBox for email should have Back button",
+        );
       });
 
       it('should return "back" when back button clicked in InputBox', async () => {
@@ -2419,8 +2806,8 @@ describe('identityManager E2E Test Suite', function () {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
           quickPickSelections: [
-            { field: 'name' },  // Select name field
-            undefined,          // Cancel at field selection (after back)
+            { field: "name" }, // Select name field
+            undefined, // Cancel at field selection (after back)
           ],
           inputBoxSelections: [INPUT_BOX_BACK], // Trigger back button
           onQuickPickCreated: () => {
@@ -2432,16 +2819,16 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // QuickPick should be shown at least twice (initial + after back)
-        assert.ok(quickPickShowCount >= 2, `QuickPick should show at least twice due to back navigation, got ${quickPickShowCount}`);
+        assert.ok(
+          quickPickShowCount >= 2,
+          `QuickPick should show at least twice due to back navigation, got ${quickPickShowCount}`,
+        );
       });
 
-      it('should discard value when back button pressed (value not saved)', async () => {
+      it("should discard value when back button pressed (value not saved)", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "name" }, undefined],
           inputBoxSelections: [INPUT_BOX_BACK], // Press back - value discarded
         });
         _setMockVSCode(mockVSCode as never);
@@ -2449,25 +2836,30 @@ describe('identityManager E2E Test Suite', function () {
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // Result should be false (cancelled without saving)
-        assert.strictEqual(result, false, 'Should return false when back pressed without saving');
+        assert.strictEqual(
+          result,
+          false,
+          "Should return false when back pressed without saving",
+        );
         // No config update should have occurred
         const configUpdates = mockVSCode._getConfigUpdateCalls();
-        assert.strictEqual(configUpdates.length, 0, 'No config update should occur when back pressed');
+        assert.strictEqual(
+          configUpdates.length,
+          0,
+          "No config update should occur when back pressed",
+        );
       });
     });
   });
 
-  describe('File Picker Button Tests (sshKeyPath only)', () => {
-    describe('File picker button visibility', () => {
-      it('should NOT show file picker button for name field', async () => {
+  describe("File Picker Button Tests (sshKeyPath only)", () => {
+    describe("File picker button visibility", () => {
+      it("should NOT show file picker button for name field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "name" }, undefined],
           inputBoxSelections: [undefined],
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2478,19 +2870,19 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // Should only have Back button, no file picker
-        assert.strictEqual(hasFilePickerButtonInArray(capturedButtons), false,
-          'Name field should NOT have file picker button');
+        assert.strictEqual(
+          hasFilePickerButtonInArray(capturedButtons),
+          false,
+          "Name field should NOT have file picker button",
+        );
       });
 
-      it('should NOT show file picker button for email field', async () => {
+      it("should NOT show file picker button for email field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'email' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "email" }, undefined],
           inputBoxSelections: [undefined],
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2500,19 +2892,19 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(hasFilePickerButtonInArray(capturedButtons), false,
-          'Email field should NOT have file picker button');
+        assert.strictEqual(
+          hasFilePickerButtonInArray(capturedButtons),
+          false,
+          "Email field should NOT have file picker button",
+        );
       });
 
-      it('should NOT show file picker button for service field', async () => {
+      it("should NOT show file picker button for service field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'service' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "service" }, undefined],
           inputBoxSelections: [undefined],
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2522,19 +2914,19 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(hasFilePickerButtonInArray(capturedButtons), false,
-          'Service field should NOT have file picker button');
+        assert.strictEqual(
+          hasFilePickerButtonInArray(capturedButtons),
+          false,
+          "Service field should NOT have file picker button",
+        );
       });
 
-      it('should NOT show file picker button for gpgKeyId field', async () => {
+      it("should NOT show file picker button for gpgKeyId field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'gpgKeyId' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "gpgKeyId" }, undefined],
           inputBoxSelections: [undefined],
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2544,19 +2936,19 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(hasFilePickerButtonInArray(capturedButtons), false,
-          'GPG Key ID field should NOT have file picker button');
+        assert.strictEqual(
+          hasFilePickerButtonInArray(capturedButtons),
+          false,
+          "GPG Key ID field should NOT have file picker button",
+        );
       });
 
-      it('should NOT show file picker button for sshHost field', async () => {
+      it("should NOT show file picker button for sshHost field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshHost' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "sshHost" }, undefined],
           inputBoxSelections: [undefined],
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2566,19 +2958,19 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(hasFilePickerButtonInArray(capturedButtons), false,
-          'SSH Host field should NOT have file picker button');
+        assert.strictEqual(
+          hasFilePickerButtonInArray(capturedButtons),
+          false,
+          "SSH Host field should NOT have file picker button",
+        );
       });
 
-      it('should show file picker button ONLY for sshKeyPath field', async () => {
+      it("should show file picker button ONLY for sshKeyPath field", async () => {
         let capturedButtons: unknown[] = [];
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
           inputBoxSelections: [undefined],
           onInputBoxCreated: (inputBox) => {
             capturedButtons = inputBox.buttons;
@@ -2588,38 +2980,40 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.ok(hasFilePickerButtonInArray(capturedButtons),
-          'sshKeyPath field SHOULD have file picker button');
+        assert.ok(
+          hasFilePickerButtonInArray(capturedButtons),
+          "sshKeyPath field SHOULD have file picker button",
+        );
       });
     });
 
-    describe('File selection updates InputBox value', () => {
-      it('should update InputBox value after file selection (Unix)', async () => {
+    describe("File selection updates InputBox value", () => {
+      it("should update InputBox value after file selection (Unix)", async () => {
         // Save original env
         const originalHome = process.env.HOME;
-        process.env.HOME = '/home/testuser';
+        process.env.HOME = "/home/testuser";
 
         let inputBoxValueAfterFilePick: string | undefined;
 
         // Custom mock to capture the InputBox value after file pick
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
           inputBoxSelections: [FILE_PICKER_CLICK, undefined], // Click file picker, then cancel
-          showOpenDialogResult: '/home/testuser/.ssh/selected_key',
+          showOpenDialogResult: "/home/testuser/.ssh/selected_key",
         });
 
         // Intercept the createInputBox to track value changes
         const originalCreateInputBox = mockVSCode.window.createInputBox;
         mockVSCode.window.createInputBox = () => {
           const inputBox = originalCreateInputBox();
-          const originalValueSetter = Object.getOwnPropertyDescriptor(inputBox, 'value')?.set;
-          let internalValue = '';
+          const originalValueSetter = Object.getOwnPropertyDescriptor(
+            inputBox,
+            "value",
+          )?.set;
+          let internalValue = "";
 
-          Object.defineProperty(inputBox, 'value', {
+          Object.defineProperty(inputBox, "value", {
             get: () => internalValue,
             set: (v: string) => {
               internalValue = v;
@@ -2636,14 +3030,17 @@ describe('identityManager E2E Test Suite', function () {
 
         try {
           await showEditProfileFlow(TEST_IDENTITIES.work);
-          assert.strictEqual(inputBoxValueAfterFilePick, '~/.ssh/selected_key',
-            'InputBox value should be updated to selected file path with ~ prefix');
+          assert.strictEqual(
+            inputBoxValueAfterFilePick,
+            "~/.ssh/selected_key",
+            "InputBox value should be updated to selected file path with ~ prefix",
+          );
         } finally {
           process.env.HOME = originalHome;
         }
       });
 
-      it('should normalize Windows backslashes to forward slashes after tilde compression', async () => {
+      it("should normalize Windows backslashes to forward slashes after tilde compression", async () => {
         // Save original env
         const originalHome = process.env.HOME;
         const originalUserProfile = process.env.USERPROFILE;
@@ -2656,10 +3053,7 @@ describe('identityManager E2E Test Suite', function () {
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
           inputBoxSelections: [FILE_PICKER_CLICK, undefined],
           showOpenDialogResult: String.raw`C:\Users\testuser\.ssh\selected_key`,
         });
@@ -2667,10 +3061,13 @@ describe('identityManager E2E Test Suite', function () {
         const originalCreateInputBox = mockVSCode.window.createInputBox;
         mockVSCode.window.createInputBox = () => {
           const inputBox = originalCreateInputBox();
-          const originalValueSetter = Object.getOwnPropertyDescriptor(inputBox, 'value')?.set;
-          let internalValue = '';
+          const originalValueSetter = Object.getOwnPropertyDescriptor(
+            inputBox,
+            "value",
+          )?.set;
+          let internalValue = "";
 
-          Object.defineProperty(inputBox, 'value', {
+          Object.defineProperty(inputBox, "value", {
             get: () => internalValue,
             set: (v: string) => {
               internalValue = v;
@@ -2687,8 +3084,11 @@ describe('identityManager E2E Test Suite', function () {
 
         try {
           await showEditProfileFlow(TEST_IDENTITIES.work);
-          assert.strictEqual(inputBoxValueAfterFilePick, '~/.ssh/selected_key',
-            'Windows backslashes should be normalized to forward slashes after ~ compression');
+          assert.strictEqual(
+            inputBoxValueAfterFilePick,
+            "~/.ssh/selected_key",
+            "Windows backslashes should be normalized to forward slashes after ~ compression",
+          );
         } finally {
           if (originalHome !== undefined) {
             process.env.HOME = originalHome;
@@ -2700,30 +3100,30 @@ describe('identityManager E2E Test Suite', function () {
       });
     });
 
-    describe('Validation after file selection', () => {
-      it('should run validation after file selection (valid path)', async () => {
+    describe("Validation after file selection", () => {
+      it("should run validation after file selection (valid path)", async () => {
         const originalHome = process.env.HOME;
-        process.env.HOME = '/home/testuser';
+        process.env.HOME = "/home/testuser";
 
-        let validationMessageAfterFilePick: string | undefined = 'not_set';
+        let validationMessageAfterFilePick: string | undefined = "not_set";
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
           inputBoxSelections: [FILE_PICKER_CLICK, undefined],
-          showOpenDialogResult: '/home/testuser/.ssh/valid_key', // Valid path under .ssh
+          showOpenDialogResult: "/home/testuser/.ssh/valid_key", // Valid path under .ssh
         });
 
         const originalCreateInputBox = mockVSCode.window.createInputBox;
         mockVSCode.window.createInputBox = () => {
           const inputBox = originalCreateInputBox();
-          const originalValidationSetter = Object.getOwnPropertyDescriptor(inputBox, 'validationMessage')?.set;
+          const originalValidationSetter = Object.getOwnPropertyDescriptor(
+            inputBox,
+            "validationMessage",
+          )?.set;
           let internalValidation: string | undefined;
 
-          Object.defineProperty(inputBox, 'validationMessage', {
+          Object.defineProperty(inputBox, "validationMessage", {
             get: () => internalValidation,
             set: (v: string | undefined) => {
               internalValidation = v;
@@ -2741,8 +3141,11 @@ describe('identityManager E2E Test Suite', function () {
         try {
           await showEditProfileFlow(TEST_IDENTITIES.work);
           // For a valid path, validationMessage should be undefined (no error)
-          assert.strictEqual(validationMessageAfterFilePick, undefined,
-            'Validation should pass for valid path (validationMessage should be undefined)');
+          assert.strictEqual(
+            validationMessageAfterFilePick,
+            undefined,
+            "Validation should pass for valid path (validationMessage should be undefined)",
+          );
         } finally {
           process.env.HOME = originalHome;
         }
@@ -2754,7 +3157,7 @@ describe('identityManager E2E Test Suite', function () {
   // Security Tests (ARCHITECTURE.md Compliance)
   // ===========================================================================
 
-  describe('Security: Multi-Layer Validation (Defense-in-Depth)', () => {
+  describe("Security: Multi-Layer Validation (Defense-in-Depth)", () => {
     /**
      * Tests for ARCHITECTURE.md Defense-in-Depth compliance
      *
@@ -2764,362 +3167,373 @@ describe('identityManager E2E Test Suite', function () {
      * - Layer 3: isUnderSshDirectory() - SSH directory restriction (includes path normalization)
      */
 
-    describe('Layer 1: hasDangerousCharsForPath() for sshKeyPath', () => {
-      const dangerousChars = ['$', '`', '|', ';', '&', '<', '>'];
+    describe("Layer 1: hasDangerousCharsForPath() for sshKeyPath", () => {
+      const dangerousChars = ["$", "`", "|", ";", "&", "<", ">"];
 
       for (const char of dangerousChars) {
         it(`should reject sshKeyPath containing "${char}" character`, async () => {
           const mockVSCode = createMockVSCode({
             identities: [TEST_IDENTITIES.work],
-            quickPickSelections: [
-              { field: 'sshKeyPath' },
-              undefined,
-            ],
+            quickPickSelections: [{ field: "sshKeyPath" }, undefined],
             inputBoxSelections: [`~/.ssh/key${char}file`],
           });
           _setMockVSCode(mockVSCode as never);
 
           const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-          assert.strictEqual(result, false, `sshKeyPath with "${char}" should be rejected`);
+          assert.strictEqual(
+            result,
+            false,
+            `sshKeyPath with "${char}" should be rejected`,
+          );
         });
       }
     });
 
-    describe('Layer 2: hasPathTraversal() for sshKeyPath', () => {
-      it('should reject path with .. traversal', async () => {
+    describe("Layer 2: hasPathTraversal() for sshKeyPath", () => {
+      it("should reject path with .. traversal", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['~/.ssh/../etc/passwd'],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["~/.ssh/../etc/passwd"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Path traversal should be rejected');
+        assert.strictEqual(result, false, "Path traversal should be rejected");
       });
 
-      it('should reject deep path traversal (~/.ssh/../../../../etc/passwd)', async () => {
+      it("should reject deep path traversal (~/.ssh/../../../../etc/passwd)", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['~/.ssh/../../../../etc/passwd'],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["~/.ssh/../../../../etc/passwd"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Deep path traversal should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Deep path traversal should be rejected",
+        );
       });
     });
 
-    describe('Layer 3: isUnderSshDirectory() restriction', () => {
-      it('should accept path under ~/.ssh/', async () => {
+    describe("Layer 3: isUnderSshDirectory() restriction", () => {
+      it("should accept path under ~/.ssh/", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['~/.ssh/id_ed25519'],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["~/.ssh/id_ed25519"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, true, 'Path under ~/.ssh/ should be accepted');
+        assert.strictEqual(
+          result,
+          true,
+          "Path under ~/.ssh/ should be accepted",
+        );
       });
 
-      it('should accept absolute path under user home .ssh/', async () => {
-        // Use actual home directory for cross-platform compatibility
-        // Use path.join to ensure correct path separators on Windows
-        const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '';
-        const absoluteSshPath = homeDir ? path.join(homeDir, '.ssh', 'id_rsa') : '~/.ssh/id_rsa';
+      it("should accept tilde path under .ssh/", async () => {
+        // Use ~/.ssh/ format for cross-platform compatibility
+        // Windows drive letter paths (C:\...) are rejected — use ~/.ssh/ instead
+        const tildeSshPath = "~/.ssh/id_rsa";
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: [absoluteSshPath],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: [tildeSshPath],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, true, 'Absolute path under .ssh/ should be accepted');
+        assert.strictEqual(
+          result,
+          true,
+          "Tilde path under .ssh/ should be accepted on all platforms",
+        );
       });
 
-      it('should reject path in home directory but not under .ssh', async () => {
+      it("should reject path in home directory but not under .ssh", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['~/my_keys/id_rsa'],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["~/my_keys/id_rsa"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Path not under ~/.ssh/ should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Path not under ~/.ssh/ should be rejected",
+        );
       });
 
-      it('should reject absolute path not under .ssh (/etc/ssh/key)', async () => {
+      it("should reject absolute path not under .ssh (/etc/ssh/key)", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['/etc/ssh/key'],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["/etc/ssh/key"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Absolute path /etc/ssh/ should be rejected (not user .ssh)');
+        assert.strictEqual(
+          result,
+          false,
+          "Absolute path /etc/ssh/ should be rejected (not user .ssh)",
+        );
       });
 
-      it('should reject path with similar name (~/.ssh_backup/key)', async () => {
+      it("should reject path with similar name (~/.ssh_backup/key)", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['~/.ssh_backup/key'],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["~/.ssh_backup/key"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Path in .ssh_backup (not .ssh) should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Path in .ssh_backup (not .ssh) should be rejected",
+        );
       });
     });
 
-    describe('Validation layers are independently testable', () => {
-      it('should reject at Layer 1 before reaching Layer 2 or 3', async () => {
+    describe("Validation layers are independently testable", () => {
+      it("should reject at Layer 1 before reaching Layer 2 or 3", async () => {
         // A path with dangerous char should fail immediately at Layer 1
         // without needing Layer 2 (traversal) or Layer 3 (directory) checks
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['~/.ssh/key`whoami`'], // Dangerous char
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["~/.ssh/key`whoami`"], // Dangerous char
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Should fail at Layer 1 (dangerous char)');
+        assert.strictEqual(
+          result,
+          false,
+          "Should fail at Layer 1 (dangerous char)",
+        );
       });
     });
   });
 
-  describe('Security: Field-specific Dangerous Character Detection', () => {
-    describe('name field: hasDangerousCharsForText() allows semicolon', () => {
-      it('should accept name with semicolon (Null;Variant)', async () => {
+  describe("Security: Field-specific Dangerous Character Detection", () => {
+    describe("name field: hasDangerousCharsForText() allows semicolon", () => {
+      it("should accept name with semicolon (Null;Variant)", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
-          inputBoxSelections: ['Null;Variant'],
+          quickPickSelections: [{ field: "name" }, undefined],
+          inputBoxSelections: ["Null;Variant"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, true, 'Name with semicolon should be accepted');
+        assert.strictEqual(
+          result,
+          true,
+          "Name with semicolon should be accepted",
+        );
       });
 
-      it('should reject name with backtick', async () => {
+      it("should reject name with backtick", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
-          inputBoxSelections: ['User `whoami`'],
+          quickPickSelections: [{ field: "name" }, undefined],
+          inputBoxSelections: ["User `whoami`"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Name with backtick should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Name with backtick should be rejected",
+        );
       });
 
-      it('should reject name with dollar sign', async () => {
+      it("should reject name with dollar sign", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
-          inputBoxSelections: ['User $HOME'],
+          quickPickSelections: [{ field: "name" }, undefined],
+          inputBoxSelections: ["User $HOME"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Name with dollar sign should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Name with dollar sign should be rejected",
+        );
       });
     });
 
-    describe('service field: validateFieldForDangerousPatterns()', () => {
-      it('should reject service with ampersand', async () => {
+    describe("service field: validateFieldForDangerousPatterns()", () => {
+      it("should reject service with ampersand", async () => {
         // ampersand is a shell metacharacter blocked by SAFE_TEXT_REGEX
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'service' },
-            undefined,
-          ],
-          inputBoxSelections: ['AT&T GitHub'],
+          quickPickSelections: [{ field: "service" }, undefined],
+          inputBoxSelections: ["AT&T GitHub"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Service with ampersand should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Service with ampersand should be rejected",
+        );
       });
 
-      it('should reject service with backtick', async () => {
+      it("should reject service with backtick", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'service' },
-            undefined,
-          ],
-          inputBoxSelections: ['`whoami`'],
+          quickPickSelections: [{ field: "service" }, undefined],
+          inputBoxSelections: ["`whoami`"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Service with backtick should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Service with backtick should be rejected",
+        );
       });
 
-      it('should reject service with dollar sign', async () => {
+      it("should reject service with dollar sign", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'service' },
-            undefined,
-          ],
-          inputBoxSelections: ['GitHub$Enterprise'],
+          quickPickSelections: [{ field: "service" }, undefined],
+          inputBoxSelections: ["GitHub$Enterprise"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Service with dollar sign should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Service with dollar sign should be rejected",
+        );
       });
     });
 
-    describe('description field: validateFieldForDangerousPatterns()', () => {
-      it('should reject description with angle brackets', async () => {
+    describe("description field: validateFieldForDangerousPatterns()", () => {
+      it("should reject description with angle brackets", async () => {
         // angle brackets are shell metacharacters blocked by SAFE_TEXT_REGEX
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'description' },
-            undefined,
-          ],
-          inputBoxSelections: ['Primary account <main>'],
+          quickPickSelections: [{ field: "description" }, undefined],
+          inputBoxSelections: ["Primary account <main>"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Description with angle brackets should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Description with angle brackets should be rejected",
+        );
       });
 
-      it('should reject description with backtick', async () => {
+      it("should reject description with backtick", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'description' },
-            undefined,
-          ],
-          inputBoxSelections: ['Run `rm -rf /`'],
+          quickPickSelections: [{ field: "description" }, undefined],
+          inputBoxSelections: ["Run `rm -rf /`"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'Description with backtick should be rejected');
-      });
-    });
-
-    describe('icon field: hasDangerousCharsForText()', () => {
-      it('should accept valid emoji icon', async () => {
-        const mockVSCode = createMockVSCode({
-          identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'icon' },
-            undefined,
-          ],
-          inputBoxSelections: ['🏠'],
-        });
-        _setMockVSCode(mockVSCode as never);
-
-        const result = await showEditProfileFlow(TEST_IDENTITIES.work);
-
-        assert.strictEqual(result, true, 'Emoji icon should be accepted');
-      });
-
-      it('should reject icon with backtick', async () => {
-        const mockVSCode = createMockVSCode({
-          identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'icon' },
-            undefined,
-          ],
-          inputBoxSelections: ['`'],
-        });
-        _setMockVSCode(mockVSCode as never);
-
-        const result = await showEditProfileFlow(TEST_IDENTITIES.work);
-
-        assert.strictEqual(result, false, 'Icon with backtick should be rejected');
+        assert.strictEqual(
+          result,
+          false,
+          "Description with backtick should be rejected",
+        );
       });
     });
 
-    describe('sshKeyPath field: hasDangerousCharsForPath() (stricter)', () => {
-      it('should reject sshKeyPath with semicolon (unlike name field)', async () => {
+    describe("icon field: hasDangerousCharsForText()", () => {
+      it("should accept valid emoji icon", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'sshKeyPath' },
-            undefined,
-          ],
-          inputBoxSelections: ['~/.ssh/key;rm'],
+          quickPickSelections: [{ field: "icon" }, undefined],
+          inputBoxSelections: ["🏠"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, false, 'sshKeyPath with semicolon should be rejected (stricter than text fields)');
+        assert.strictEqual(result, true, "Emoji icon should be accepted");
+      });
+
+      it("should reject icon with backtick", async () => {
+        const mockVSCode = createMockVSCode({
+          identities: [TEST_IDENTITIES.work],
+          quickPickSelections: [{ field: "icon" }, undefined],
+          inputBoxSelections: ["`"],
+        });
+        _setMockVSCode(mockVSCode as never);
+
+        const result = await showEditProfileFlow(TEST_IDENTITIES.work);
+
+        assert.strictEqual(
+          result,
+          false,
+          "Icon with backtick should be rejected",
+        );
+      });
+    });
+
+    describe("sshKeyPath field: hasDangerousCharsForPath() (stricter)", () => {
+      it("should reject sshKeyPath with semicolon (unlike name field)", async () => {
+        const mockVSCode = createMockVSCode({
+          identities: [TEST_IDENTITIES.work],
+          quickPickSelections: [{ field: "sshKeyPath" }, undefined],
+          inputBoxSelections: ["~/.ssh/key;rm"],
+        });
+        _setMockVSCode(mockVSCode as never);
+
+        const result = await showEditProfileFlow(TEST_IDENTITIES.work);
+
+        assert.strictEqual(
+          result,
+          false,
+          "sshKeyPath with semicolon should be rejected (stricter than text fields)",
+        );
       });
     });
   });
 
-  describe('Security: MAX_IDENTITIES Limit Tests', () => {
-    it('should show warning message when MAX_IDENTITIES reached', async () => {
+  describe("Security: MAX_IDENTITIES Limit Tests", () => {
+    it("should show warning message when MAX_IDENTITIES reached", async () => {
       const maxIdentities: Identity[] = [];
       for (let i = 0; i < MAX_IDENTITIES; i++) {
         maxIdentities.push({
@@ -3136,16 +3550,20 @@ describe('identityManager E2E Test Suite', function () {
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'Should return undefined when limit reached');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Should return undefined when limit reached",
+      );
       const warnings = mockVSCode._getShowWarningMessageCalls();
-      assert.strictEqual(warnings.length, 1, 'Should show warning');
+      assert.strictEqual(warnings.length, 1, "Should show warning");
       assert.ok(
         warnings[0].includes(String(MAX_IDENTITIES)),
-        `Warning should mention max limit (${MAX_IDENTITIES})`
+        `Warning should mention max limit (${MAX_IDENTITIES})`,
       );
     });
 
-    it('should return undefined from showAddIdentityForm() when MAX_IDENTITIES reached', async () => {
+    it("should return undefined from showAddIdentityForm() when MAX_IDENTITIES reached", async () => {
       const maxIdentities: Identity[] = [];
       for (let i = 0; i < MAX_IDENTITIES; i++) {
         maxIdentities.push({
@@ -3162,11 +3580,15 @@ describe('identityManager E2E Test Suite', function () {
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'showAddIdentityForm() should return undefined at MAX_IDENTITIES');
+      assert.strictEqual(
+        result,
+        undefined,
+        "showAddIdentityForm() should return undefined at MAX_IDENTITIES",
+      );
     });
   });
 
-  describe('Security: Audit Log Tests (securityLogger.logConfigChange)', () => {
+  describe("Security: Audit Log Tests (securityLogger.logConfigChange)", () => {
     /**
      * Tests verify that securityLogger.logConfigChange('identities') is called
      * when identities are added, edited, or deleted.
@@ -3175,113 +3597,137 @@ describe('identityManager E2E Test Suite', function () {
      * These tests verify that identityManager.ts calls the logging function.
      */
 
-    describe('Add identity: logConfigChange called on success', () => {
-      it('should call logConfigChange after successful identity creation', async () => {
+    describe("Add identity: logConfigChange called on success", () => {
+      it("should call logConfigChange after successful identity creation", async () => {
         // saveNewIdentity calls securityLogger.logConfigChange('identities')
         // We verify indirectly by checking successful completion and info message
         const mockVSCode = createMockVSCode({
           identities: [],
           quickPickSelections: [
-            { field: 'id' },
-            { field: 'name' },
-            { field: 'email' },
-            { field: 'save' }, // Save button in property list form
+            { field: "id" },
+            { field: "name" },
+            { field: "email" },
+            { field: "save" }, // Save button in property list form
           ],
-          inputBoxSelections: ['new-id', 'New User', 'new@example.com'],
+          inputBoxSelections: ["new-id", "New User", "new@example.com"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showAddIdentityForm();
 
-        assert.ok(result !== undefined, 'Should return new identity on success');
+        assert.ok(
+          result !== undefined,
+          "Should return new identity on success",
+        );
         const infoCalls = mockVSCode._getShowInformationMessageCalls();
-        assert.ok(infoCalls.length > 0, 'Should show success message (indicates logConfigChange path was executed)');
-        assert.ok(infoCalls[0].includes('created'), 'Success message should mention creation');
+        assert.ok(
+          infoCalls.length > 0,
+          "Should show success message (indicates logConfigChange path was executed)",
+        );
+        assert.ok(
+          infoCalls[0].includes("created"),
+          "Success message should mention creation",
+        );
       });
     });
 
-    describe('Edit identity: logConfigChange called on success', () => {
-      it('should call logConfigChange after successful identity update', async () => {
+    describe("Edit identity: logConfigChange called on success", () => {
+      it("should call logConfigChange after successful identity update", async () => {
         // saveEditedField calls securityLogger.logConfigChange('identities')
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
-          inputBoxSelections: ['Updated Name'],
+          quickPickSelections: [{ field: "name" }, undefined],
+          inputBoxSelections: ["Updated Name"],
         });
         _setMockVSCode(mockVSCode as never);
 
         const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.strictEqual(result, true, 'Should return true on success');
+        assert.strictEqual(result, true, "Should return true on success");
         const infoCalls = mockVSCode._getShowInformationMessageCalls();
-        assert.ok(infoCalls.length > 0, 'Should show success message (indicates logConfigChange path was executed)');
-        assert.ok(infoCalls[0].includes('updated'), 'Success message should mention update');
+        assert.ok(
+          infoCalls.length > 0,
+          "Should show success message (indicates logConfigChange path was executed)",
+        );
+        assert.ok(
+          infoCalls[0].includes("updated"),
+          "Success message should mention update",
+        );
       });
     });
 
     // Delete identity audit logging is covered by deleteIdentityPicker.test.ts
   });
 
-  describe('Config Update Error: saveNewIdentity/saveEditedField error paths', () => {
-    it('should return undefined and show error message when saveNewIdentity fails due to config update error', async () => {
+  describe("Config Update Error: saveNewIdentity/saveEditedField error paths", () => {
+    it("should return undefined and show error message when saveNewIdentity fails due to config update error", async () => {
       const mockVSCode = createMockVSCode({
         identities: [],
         quickPickSelections: [
-          { field: 'id' },
-          { field: 'name' },
-          { field: 'email' },
+          { field: "id" },
+          { field: "name" },
+          { field: "email" },
           { _isSaveButton: true },
         ],
-        inputBoxSelections: ['error-test-id', 'Error Test Name', 'error@test.com'],
-        configUpdateError: new Error('Permission denied'),
+        inputBoxSelections: [
+          "error-test-id",
+          "Error Test Name",
+          "error@test.com",
+        ],
+        configUpdateError: new Error("Permission denied"),
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showAddIdentityForm();
 
-      assert.strictEqual(result, undefined, 'Should return undefined when config update fails');
+      assert.strictEqual(
+        result,
+        undefined,
+        "Should return undefined when config update fails",
+      );
       const errorCalls = mockVSCode._getShowErrorMessageCalls();
-      assert.ok(errorCalls.length > 0, 'Should show error notification to user');
+      assert.ok(
+        errorCalls.length > 0,
+        "Should show error notification to user",
+      );
     });
 
-    it('should show error message and return false when saveEditedField fails and user cancels', async () => {
+    it("should show error message and return false when saveEditedField fails and user cancels", async () => {
       const mockVSCode = createMockVSCode({
         identities: [TEST_IDENTITIES.work],
-        quickPickSelections: [
-          { field: 'name' },
-          undefined,
-        ],
-        inputBoxSelections: ['Updated Name'],
-        configUpdateError: new Error('Permission denied'),
+        quickPickSelections: [{ field: "name" }, undefined],
+        inputBoxSelections: ["Updated Name"],
+        configUpdateError: new Error("Permission denied"),
       });
       _setMockVSCode(mockVSCode as never);
 
       const result = await showEditProfileFlow(TEST_IDENTITIES.work);
 
       const errorCalls = mockVSCode._getShowErrorMessageCalls();
-      assert.ok(errorCalls.length > 0, 'Should show error notification to user');
+      assert.ok(
+        errorCalls.length > 0,
+        "Should show error notification to user",
+      );
       // saveEditedField failure does not set hasUpdated=true, so cancelling returns false
-      assert.strictEqual(result, false, 'Edit flow should return false when save failed and user cancelled');
+      assert.strictEqual(
+        result,
+        false,
+        "Edit flow should return false when save failed and user cancelled",
+      );
     });
   });
 
-  describe('onDidChangeValue Tests', () => {
-    describe('Real-time validation on input change', () => {
-      it('should trigger validation when input value changes', async () => {
+  describe("onDidChangeValue Tests", () => {
+    describe("Real-time validation on input change", () => {
+      it("should trigger validation when input value changes", async () => {
         // This test verifies that onDidChangeValue is properly wired up
         // The mock's createInputBox simulates value change and validation
         let validationWasCalled = false;
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
-          inputBoxSelections: ['New Name'], // Entering a value triggers onDidChangeValue
+          quickPickSelections: [{ field: "name" }, undefined],
+          inputBoxSelections: ["New Name"], // Entering a value triggers onDidChangeValue
         });
 
         const originalCreateInputBox = mockVSCode.window.createInputBox;
@@ -3301,30 +3747,36 @@ describe('identityManager E2E Test Suite', function () {
 
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
-        assert.ok(validationWasCalled, 'onDidChangeValue should be registered for validation');
+        assert.ok(
+          validationWasCalled,
+          "onDidChangeValue should be registered for validation",
+        );
       });
 
-      it('should set validationMessage when validation error occurs', async () => {
+      it("should set validationMessage when validation error occurs", async () => {
         // Test with invalid input that triggers validation error
         // Using a name with dangerous characters ($ or backtick)
-        let capturedValidationMessage: string | undefined = 'not_set';
+        let capturedValidationMessage: string | undefined = "not_set";
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
           quickPickSelections: [
-            { field: 'name' },
+            { field: "name" },
             undefined, // Cancel after validation failure
           ],
-          inputBoxSelections: ['User $HOME'], // Invalid name (contains $)
+          inputBoxSelections: ["User $HOME"], // Invalid name (contains $)
         });
 
         const originalCreateInputBox = mockVSCode.window.createInputBox;
         mockVSCode.window.createInputBox = () => {
           const inputBox = originalCreateInputBox();
-          const originalValidationSetter = Object.getOwnPropertyDescriptor(inputBox, 'validationMessage')?.set;
+          const originalValidationSetter = Object.getOwnPropertyDescriptor(
+            inputBox,
+            "validationMessage",
+          )?.set;
           let internalValidation: string | undefined;
 
-          Object.defineProperty(inputBox, 'validationMessage', {
+          Object.defineProperty(inputBox, "validationMessage", {
             get: () => internalValidation,
             set: (v: string | undefined) => {
               internalValidation = v;
@@ -3344,32 +3796,37 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // validationMessage should be set (not 'not_set' and not undefined)
-        assert.notStrictEqual(capturedValidationMessage, 'not_set',
-          'validationMessage should be set when validation error occurs');
-        assert.ok(capturedValidationMessage !== undefined,
-          'validationMessage should not be undefined for invalid input');
+        assert.notStrictEqual(
+          capturedValidationMessage,
+          "not_set",
+          "validationMessage should be set when validation error occurs",
+        );
+        assert.ok(
+          capturedValidationMessage !== undefined,
+          "validationMessage should not be undefined for invalid input",
+        );
       });
 
-      it('should set validationMessage to undefined when validation succeeds', async () => {
+      it("should set validationMessage to undefined when validation succeeds", async () => {
         // Test with valid input
-        let lastValidationMessage: string | undefined = 'initial';
+        let lastValidationMessage: string | undefined = "initial";
 
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],
-          quickPickSelections: [
-            { field: 'name' },
-            undefined,
-          ],
-          inputBoxSelections: ['Valid Name'], // Valid name
+          quickPickSelections: [{ field: "name" }, undefined],
+          inputBoxSelections: ["Valid Name"], // Valid name
         });
 
         const originalCreateInputBox = mockVSCode.window.createInputBox;
         mockVSCode.window.createInputBox = () => {
           const inputBox = originalCreateInputBox();
-          const originalValidationSetter = Object.getOwnPropertyDescriptor(inputBox, 'validationMessage')?.set;
+          const originalValidationSetter = Object.getOwnPropertyDescriptor(
+            inputBox,
+            "validationMessage",
+          )?.set;
           let internalValidation: string | undefined;
 
-          Object.defineProperty(inputBox, 'validationMessage', {
+          Object.defineProperty(inputBox, "validationMessage", {
             get: () => internalValidation,
             set: (v: string | undefined) => {
               internalValidation = v;
@@ -3387,8 +3844,11 @@ describe('identityManager E2E Test Suite', function () {
         await showEditProfileFlow(TEST_IDENTITIES.work);
 
         // For valid input, validationMessage should be undefined
-        assert.strictEqual(lastValidationMessage, undefined,
-          'validationMessage should be undefined for valid input');
+        assert.strictEqual(
+          lastValidationMessage,
+          undefined,
+          "validationMessage should be undefined for valid input",
+        );
       });
     });
   });

--- a/extensions/git-id-switcher/src/test/validation.test.ts
+++ b/extensions/git-id-switcher/src/test/validation.test.ts
@@ -4,377 +4,545 @@
  * Tests that malicious input is properly rejected.
  */
 
-import * as assert from 'node:assert';
-import { validateIdentity, validateIdentities, isShellSafePath, validateFieldForDangerousPatterns } from '../identity/inputValidator';
-import { hasDangerousChars } from '../validators/common';
-import { Identity } from '../identity/identity';
+import * as assert from "node:assert";
+import {
+  validateIdentity,
+  validateIdentities,
+  isShellSafePath,
+  validateFieldForDangerousPatterns,
+} from "../identity/inputValidator";
+import { hasDangerousChars } from "../validators/common";
+import { Identity } from "../identity/identity";
 
 /**
  * Test suite for validateIdentity
  */
 function testValidateIdentity(): void {
-  console.log('Testing validateIdentity...');
+  console.log("Testing validateIdentity...");
 
   // Test 1: Valid identity should pass
   {
     const validIdentity: Identity = {
-      id: 'personal',
-      name: 'John Doe',
-      email: 'john@example.com',
+      id: "personal",
+      name: "John Doe",
+      email: "john@example.com",
     };
     const result = validateIdentity(validIdentity);
-    assert.strictEqual(result.valid, true, 'Valid identity should pass');
-    assert.strictEqual(result.errors.length, 0, 'No errors for valid identity');
+    assert.strictEqual(result.valid, true, "Valid identity should pass");
+    assert.strictEqual(result.errors.length, 0, "No errors for valid identity");
   }
 
   // Test 2: Identity with all optional fields should pass
   {
     const fullIdentity: Identity = {
-      id: 'work',
-      icon: '👔',
-      name: 'John Doe',
-      email: 'john.doe@company.com',
-      description: 'Work account',
-      sshKeyPath: '~/.ssh/id_work',
-      sshHost: 'github.com-work',
-      gpgKeyId: 'ABCD1234',
+      id: "work",
+      icon: "👔",
+      name: "John Doe",
+      email: "john.doe@company.com",
+      description: "Work account",
+      sshKeyPath: "~/.ssh/id_work",
+      sshHost: "github.com-work",
+      gpgKeyId: "ABCD1234",
     };
     const result = validateIdentity(fullIdentity);
-    assert.strictEqual(result.valid, true, 'Full valid identity should pass');
+    assert.strictEqual(result.valid, true, "Full valid identity should pass");
   }
 
   // Test 2b: Identity with semicolon in name should pass (e.g., "Null;Variant")
   {
     const semicolonName: Identity = {
-      id: 'nullvariant',
-      icon: '🎭',
-      name: 'Null;Variant',
-      email: 'dev@nullvariant.com',
+      id: "nullvariant",
+      icon: "🎭",
+      name: "Null;Variant",
+      email: "dev@nullvariant.com",
     };
     const result = validateIdentity(semicolonName);
-    assert.strictEqual(result.valid, true, 'Semicolon in name should be allowed');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Semicolon in name should be allowed",
+    );
   }
 
   // Test 3: Command injection in name should fail
   // Note: semicolon is intentionally allowed (e.g., "Null;Variant")
   {
     const maliciousName: Identity = {
-      id: 'malicious',
-      name: 'test$(rm -rf ~)',
-      email: 'test@example.com',
+      id: "malicious",
+      name: "test$(rm -rf ~)",
+      email: "test@example.com",
     };
     const result = validateIdentity(maliciousName);
-    assert.strictEqual(result.valid, false, 'Command injection in name should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Command injection in name should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('name')),
-      'Error should mention name field'
+      result.errors.some((e) => e.includes("name")),
+      "Error should mention name field",
     );
   }
 
   // Test 4: Command substitution in email should fail
   {
     const maliciousEmail: Identity = {
-      id: 'malicious',
-      name: 'Test User',
-      email: '$(whoami)@evil.com',
+      id: "malicious",
+      name: "Test User",
+      email: "$(whoami)@evil.com",
     };
     const result = validateIdentity(maliciousEmail);
-    assert.strictEqual(result.valid, false, 'Command substitution in email should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Command substitution in email should fail",
+    );
   }
 
   // Test 5: Shell metacharacters should fail
   {
     const shellChars: Identity = {
-      id: 'test',
-      name: 'Test | cat /etc/passwd',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test | cat /etc/passwd",
+      email: "test@example.com",
     };
     const result = validateIdentity(shellChars);
-    assert.strictEqual(result.valid, false, 'Shell metacharacters should fail');
+    assert.strictEqual(result.valid, false, "Shell metacharacters should fail");
   }
 
   // Test 6: Backtick injection should fail
   {
     const backtickInjection: Identity = {
-      id: 'test',
-      name: 'Test `id`',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test `id`",
+      email: "test@example.com",
     };
     const result = validateIdentity(backtickInjection);
-    assert.strictEqual(result.valid, false, 'Backtick injection should fail');
+    assert.strictEqual(result.valid, false, "Backtick injection should fail");
   }
 
   // Test 7: Newline injection should fail
   {
     const newlineInjection: Identity = {
-      id: 'test',
-      name: 'Test\nmalicious',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test\nmalicious",
+      email: "test@example.com",
     };
     const result = validateIdentity(newlineInjection);
-    assert.strictEqual(result.valid, false, 'Newline injection should fail');
+    assert.strictEqual(result.valid, false, "Newline injection should fail");
   }
 
   // Test 8: Invalid email format should fail
   {
     const invalidEmail: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'not-an-email',
+      id: "test",
+      name: "Test User",
+      email: "not-an-email",
     };
     const result = validateIdentity(invalidEmail);
-    assert.strictEqual(result.valid, false, 'Invalid email format should fail');
+    assert.strictEqual(result.valid, false, "Invalid email format should fail");
   }
 
   // Test 9: Path traversal in sshKeyPath should fail
   {
     const pathTraversal: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshKeyPath: '/home/../etc/passwd',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "/home/../etc/passwd",
     };
     const result = validateIdentity(pathTraversal);
-    assert.strictEqual(result.valid, false, 'Path traversal should fail');
+    assert.strictEqual(result.valid, false, "Path traversal should fail");
   }
 
   // Test 10: Non-absolute sshKeyPath should fail
   {
     const relativePath: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshKeyPath: 'relative/path/key',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "relative/path/key",
     };
     const result = validateIdentity(relativePath);
-    assert.strictEqual(result.valid, false, 'Relative SSH key path should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Relative SSH key path should fail",
+    );
+  }
+
+  // Test 10a: Windows drive letter sshKeyPath should fail with ~/.ssh/ guidance
+  {
+    const windowsPath: Identity = {
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "C:/Users/user/.ssh/id_ed25519",
+    };
+    const result = validateIdentity(windowsPath);
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Windows drive letter SSH key path should fail",
+    );
+    assert.ok(
+      result.errors.some(
+        (e) => e.includes("sshKeyPath") && e.includes("~/.ssh/"),
+      ),
+      "Error should mention field name and guide to ~/.ssh/ format",
+    );
+  }
+
+  // Test 10b: Windows drive letter with backslashes should fail with ~/.ssh/ guidance
+  {
+    const windowsBackslashPath: Identity = {
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: String.raw`C:\Users\user\.ssh\id_ed25519`,
+    };
+    const result = validateIdentity(windowsBackslashPath);
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Windows backslash SSH key path should fail",
+    );
+    assert.ok(
+      result.errors.some(
+        (e) => e.includes("sshKeyPath") && e.includes("~/.ssh/"),
+      ),
+      "Error should mention field name and guide to ~/.ssh/ format",
+    );
+  }
+
+  // Test 10c: Lowercase drive letter should also fail
+  {
+    const lowercaseWindowsPath: Identity = {
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshKeyPath: "c:/users/user/.ssh/id_ed25519",
+    };
+    const result = validateIdentity(lowercaseWindowsPath);
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Lowercase drive letter path should fail",
+    );
+    assert.ok(
+      result.errors.some(
+        (e) => e.includes("sshKeyPath") && e.includes("~/.ssh/"),
+      ),
+      "Error should mention field name and guide to ~/.ssh/ format",
+    );
   }
 
   // Test 11: Invalid GPG key ID should fail
   {
     const invalidGpg: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'invalid-gpg-key',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "invalid-gpg-key",
     };
     const result = validateIdentity(invalidGpg);
-    assert.strictEqual(result.valid, false, 'Invalid GPG key ID should fail');
+    assert.strictEqual(result.valid, false, "Invalid GPG key ID should fail");
   }
 
   // Test 12: Valid GPG key ID should pass
   {
     const validGpg: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      gpgKeyId: 'ABCDEF12',
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      gpgKeyId: "ABCDEF12",
     };
     const result = validateIdentity(validGpg);
-    assert.strictEqual(result.valid, true, 'Valid GPG key ID should pass');
+    assert.strictEqual(result.valid, true, "Valid GPG key ID should pass");
   }
 
   // Test 13: Missing required fields should fail
   {
     const missingFields = {
-      id: 'test',
+      id: "test",
     } as Identity;
     const result = validateIdentity(missingFields);
-    assert.strictEqual(result.valid, false, 'Missing required fields should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Missing required fields should fail",
+    );
   }
 
   // Test 14: Unicode name should pass (legitimate international names)
   {
     const unicodeName: Identity = {
-      id: 'test',
-      name: '田中太郎',
-      email: 'tanaka@example.com',
+      id: "test",
+      name: "田中太郎",
+      email: "tanaka@example.com",
     };
     const result = validateIdentity(unicodeName);
-    assert.strictEqual(result.valid, true, 'Unicode name should pass');
+    assert.strictEqual(result.valid, true, "Unicode name should pass");
   }
 
   // Test 15: Hex escape sequence should fail
   {
     const hexEscape: Identity = {
-      id: 'test',
+      id: "test",
       name: String.raw`Test\x00User`,
-      email: 'test@example.com',
+      email: "test@example.com",
     };
     const result = validateIdentity(hexEscape);
-    assert.strictEqual(result.valid, false, 'Hex escape sequence should fail');
+    assert.strictEqual(result.valid, false, "Hex escape sequence should fail");
   }
 
   // Test 16: Email exceeding max length (320) should fail
   {
     const longEmail: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'a'.repeat(310) + '@example.com', // 322 chars > 320
+      id: "test",
+      name: "Test User",
+      email: "a".repeat(310) + "@example.com", // 322 chars > 320
     };
     const result = validateIdentity(longEmail);
-    assert.strictEqual(result.valid, false, 'Email exceeding max length should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Email exceeding max length should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('email') && e.includes('320')),
-      'Error should mention email max length 320'
+      result.errors.some((e) => e.includes("email") && e.includes("320")),
+      "Error should mention email max length 320",
     );
   }
 
   // Test 17: sshHost exceeding max length (253) should fail
   {
     const longSshHost: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      sshHost: 'a'.repeat(254), // > 253 chars
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      sshHost: "a".repeat(254), // > 253 chars
     };
     const result = validateIdentity(longSshHost);
-    assert.strictEqual(result.valid, false, 'sshHost exceeding max length should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "sshHost exceeding max length should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('sshHost') && e.includes('253')),
-      'Error should mention sshHost max length 253'
+      result.errors.some((e) => e.includes("sshHost") && e.includes("253")),
+      "Error should mention sshHost max length 253",
     );
   }
 
   // Test 18: Service exceeding max length (64) should fail
   {
     const longService: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      service: 'a'.repeat(65), // > 64 chars
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      service: "a".repeat(65), // > 64 chars
     };
     const result = validateIdentity(longService);
-    assert.strictEqual(result.valid, false, 'Service exceeding max length should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Service exceeding max length should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('service') && e.includes('64')),
-      'Error should mention service max length 64'
+      result.errors.some((e) => e.includes("service") && e.includes("64")),
+      "Error should mention service max length 64",
     );
   }
 
   // Test 19: Description exceeding max length (500) should fail
   {
     const longDescription: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      description: 'a'.repeat(501), // > 500 chars
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      description: "a".repeat(501), // > 500 chars
     };
     const result = validateIdentity(longDescription);
-    assert.strictEqual(result.valid, false, 'Description exceeding max length should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Description exceeding max length should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('description') && e.includes('500')),
-      'Error should mention description max length 500'
+      result.errors.some((e) => e.includes("description") && e.includes("500")),
+      "Error should mention description max length 500",
     );
   }
 
   // Test 20: Icon exceeding max byte length (32) should fail
   {
     const longIcon: Identity = {
-      id: 'test',
-      name: 'Test User',
-      email: 'test@example.com',
-      icon: 'a'.repeat(33), // > 32 bytes
+      id: "test",
+      name: "Test User",
+      email: "test@example.com",
+      icon: "a".repeat(33), // > 32 bytes
     };
     const result = validateIdentity(longIcon);
-    assert.strictEqual(result.valid, false, 'Icon exceeding max byte length should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Icon exceeding max byte length should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('icon') && e.includes('maximum length')),
-      'Error should mention icon max length'
+      result.errors.some(
+        (e) => e.includes("icon") && e.includes("maximum length"),
+      ),
+      "Error should mention icon max length",
     );
   }
 
   // Test 21: Name exceeding max length (256) should fail
   {
     const longName: Identity = {
-      id: 'test',
-      name: 'a'.repeat(257), // > 256 chars
-      email: 'test@example.com',
+      id: "test",
+      name: "a".repeat(257), // > 256 chars
+      email: "test@example.com",
     };
     const result = validateIdentity(longName);
-    assert.strictEqual(result.valid, false, 'Name exceeding max length should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Name exceeding max length should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('name') && e.includes('256')),
-      'Error should mention name max length 256'
+      result.errors.some((e) => e.includes("name") && e.includes("256")),
+      "Error should mention name max length 256",
     );
   }
 
-  console.log('✅ All validateIdentity tests passed!');
+  console.log("✅ All validateIdentity tests passed!");
 }
 
 /**
  * Test suite for validateIdentities
  */
 function testValidateIdentities(): void {
-  console.log('Testing validateIdentities...');
+  console.log("Testing validateIdentities...");
 
   // Test 1: Empty array should pass
   {
     const result = validateIdentities([]);
-    assert.strictEqual(result.valid, true, 'Empty array should pass');
+    assert.strictEqual(result.valid, true, "Empty array should pass");
   }
 
   // Test 2: Array with valid identities should pass
   {
     const identities: Identity[] = [
-      { id: 'personal', name: 'John', email: 'john@example.com' },
-      { id: 'work', name: 'John Work', email: 'john@company.com' },
+      { id: "personal", name: "John", email: "john@example.com" },
+      { id: "work", name: "John Work", email: "john@company.com" },
     ];
     const result = validateIdentities(identities);
-    assert.strictEqual(result.valid, true, 'Valid identities array should pass');
+    assert.strictEqual(
+      result.valid,
+      true,
+      "Valid identities array should pass",
+    );
   }
 
   // Test 3: Duplicate IDs should fail
   {
     const duplicates: Identity[] = [
-      { id: 'same', name: 'John', email: 'john@example.com' },
-      { id: 'same', name: 'Jane', email: 'jane@example.com' },
+      { id: "same", name: "John", email: "john@example.com" },
+      { id: "same", name: "Jane", email: "jane@example.com" },
     ];
     const result = validateIdentities(duplicates);
-    assert.strictEqual(result.valid, false, 'Duplicate IDs should fail');
+    assert.strictEqual(result.valid, false, "Duplicate IDs should fail");
   }
 
   // Test 4: One invalid identity should fail the whole array
   {
     const mixedArray: Identity[] = [
-      { id: 'valid', name: 'John', email: 'john@example.com' },
-      { id: 'invalid', name: 'Test$(rm -rf /)', email: 'test@example.com' },
+      { id: "valid", name: "John", email: "john@example.com" },
+      { id: "invalid", name: "Test$(rm -rf /)", email: "test@example.com" },
     ];
     const result = validateIdentities(mixedArray);
-    assert.strictEqual(result.valid, false, 'Array with invalid identity should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Array with invalid identity should fail",
+    );
   }
 
-  console.log('✅ All validateIdentities tests passed!');
+  console.log("✅ All validateIdentities tests passed!");
 }
 
 /**
  * Test suite for isShellSafePath
  */
 function testIsPathSafe(): void {
-  console.log('Testing isShellSafePath...');
+  console.log("Testing isShellSafePath...");
 
   // Test 1: Normal path should be safe
-  assert.strictEqual(isShellSafePath('/home/user/.ssh/id_rsa'), true, 'Normal path is safe');
+  assert.strictEqual(
+    isShellSafePath("/home/user/.ssh/id_rsa"),
+    true,
+    "Normal path is safe",
+  );
 
   // Test 2: Path with ~ should be safe
-  assert.strictEqual(isShellSafePath('~/.ssh/id_rsa'), true, 'Path with ~ is safe');
+  assert.strictEqual(
+    isShellSafePath("~/.ssh/id_rsa"),
+    true,
+    "Path with ~ is safe",
+  );
 
   // Test 3: Path traversal should be unsafe
-  assert.strictEqual(isShellSafePath('/home/../etc/passwd'), false, 'Path traversal is unsafe');
+  assert.strictEqual(
+    isShellSafePath("/home/../etc/passwd"),
+    false,
+    "Path traversal is unsafe",
+  );
 
   // Test 4: Shell metacharacters should be unsafe
-  assert.strictEqual(isShellSafePath('/home/user/key$(rm -rf /)'), false, 'Shell metachar is unsafe');
+  assert.strictEqual(
+    isShellSafePath("/home/user/key$(rm -rf /)"),
+    false,
+    "Shell metachar is unsafe",
+  );
 
   // Test 5: Command substitution should be unsafe
-  assert.strictEqual(isShellSafePath('/home/$(whoami)/key'), false, 'Command sub is unsafe');
+  assert.strictEqual(
+    isShellSafePath("/home/$(whoami)/key"),
+    false,
+    "Command sub is unsafe",
+  );
 
   // Test 6: Backticks should be unsafe
-  assert.strictEqual(isShellSafePath('/home/`id`/key'), false, 'Backticks are unsafe');
+  assert.strictEqual(
+    isShellSafePath("/home/`id`/key"),
+    false,
+    "Backticks are unsafe",
+  );
 
   // Test 7: Pipe should be unsafe
-  assert.strictEqual(isShellSafePath('/home/user/key|cat'), false, 'Pipe is unsafe');
+  assert.strictEqual(
+    isShellSafePath("/home/user/key|cat"),
+    false,
+    "Pipe is unsafe",
+  );
 
-  console.log('✅ All isShellSafePath tests passed!');
+  // Test 8: Windows forward-slash path is shell-safe (no metacharacters)
+  // isShellSafePath only checks shell injection — Windows rejection is caller's responsibility
+  assert.strictEqual(
+    isShellSafePath("C:/Users/user/.ssh/id_ed25519"),
+    true,
+    "Windows path has no shell metacharacters (rejection is NOT isShellSafePath's responsibility)",
+  );
+
+  // Test 9: Windows backslash path is also shell-safe
+  assert.strictEqual(
+    isShellSafePath(String.raw`C:\Users\user\.ssh\id_ed25519`),
+    true,
+    "Windows backslash path has no shell metacharacters",
+  );
+
+  console.log("✅ All isShellSafePath tests passed!");
 }
 
 /**
@@ -388,115 +556,154 @@ function testIsPathSafe(): void {
  * Issue-00103: Unify validation logic between UI and identity layers.
  */
 function testValidationConsistency(): void {
-  console.log('Testing validation consistency (UI ↔ identity layer)...');
+  console.log("Testing validation consistency (UI ↔ identity layer)...");
 
   // Category 1: Inputs rejected by BOTH hasDangerousChars and validateFieldForDangerousPatterns
   // (actual dangerous bytes: shell metacharacters and control characters)
   const bothReject = [
-    { value: 'test$(cmd)', reason: 'command substitution ($)' },
-    { value: 'test`id`', reason: 'backtick injection' },
-    { value: 'test|cat', reason: 'pipe' },
-    { value: 'test&bg', reason: 'ampersand' },
-    { value: 'test<in', reason: 'angle bracket (<)' },
-    { value: 'test>out', reason: 'angle bracket (>)' },
-    { value: 'test(group)', reason: 'parentheses' },
-    { value: 'test{brace}', reason: 'braces' },
-    { value: 'test\ninjection', reason: 'newline' },
-    { value: 'test\rinjection', reason: 'carriage return' },
-    { value: 'test\0null', reason: 'null byte' },
+    { value: "test$(cmd)", reason: "command substitution ($)" },
+    { value: "test`id`", reason: "backtick injection" },
+    { value: "test|cat", reason: "pipe" },
+    { value: "test&bg", reason: "ampersand" },
+    { value: "test<in", reason: "angle bracket (<)" },
+    { value: "test>out", reason: "angle bracket (>)" },
+    { value: "test(group)", reason: "parentheses" },
+    { value: "test{brace}", reason: "braces" },
+    { value: "test\ninjection", reason: "newline" },
+    { value: "test\rinjection", reason: "carriage return" },
+    { value: "test\0null", reason: "null byte" },
     // Control characters caught by hasDangerousChars (SAFE_TEXT_REGEX)
     // AND now also by validateFieldForDangerousPatterns (Issue-00103 fix)
-    { value: 'test\u0002ctrl', reason: 'STX control character (0x02)' },
-    { value: 'test\u0007bell', reason: 'BEL control character (0x07)' },
-    { value: 'test\u001Bescape', reason: 'ESC control character (0x1B)' },
-    { value: 'test\u007Fdel', reason: 'DEL control character (0x7F)' },
+    { value: "test\u0002ctrl", reason: "STX control character (0x02)" },
+    { value: "test\u0007bell", reason: "BEL control character (0x07)" },
+    { value: "test\u001Bescape", reason: "ESC control character (0x1B)" },
+    { value: "test\u007Fdel", reason: "DEL control character (0x7F)" },
   ];
 
   for (const { value, reason } of bothReject) {
     const uiRejects = hasDangerousChars(value);
     const errors: string[] = [];
-    validateFieldForDangerousPatterns(value, 'test', errors);
+    validateFieldForDangerousPatterns(value, "test", errors);
     const identityRejects = errors.length > 0;
 
-    assert.strictEqual(uiRejects, true, `hasDangerousChars should reject: ${reason}`);
-    assert.strictEqual(identityRejects, true, `validateFieldForDangerousPatterns should reject: ${reason}`);
+    assert.strictEqual(
+      uiRejects,
+      true,
+      `hasDangerousChars should reject: ${reason}`,
+    );
+    assert.strictEqual(
+      identityRejects,
+      true,
+      `validateFieldForDangerousPatterns should reject: ${reason}`,
+    );
   }
 
   // Category 2: Inputs rejected ONLY by validateFieldForDangerousPatterns
   // (literal text patterns like \x00 — safe bytes but dangerous as text)
   const identityOnlyRejects = [
-    { value: String.raw`test\x00user`, reason: String.raw`hex escape \x00 (null)` },
-    { value: String.raw`test\x0auser`, reason: String.raw`hex escape \x0a (LF)` },
-    { value: String.raw`test\x1buser`, reason: String.raw`hex escape \x1b (ESC)` },
+    {
+      value: String.raw`test\x00user`,
+      reason: String.raw`hex escape \x00 (null)`,
+    },
+    {
+      value: String.raw`test\x0auser`,
+      reason: String.raw`hex escape \x0a (LF)`,
+    },
+    {
+      value: String.raw`test\x1buser`,
+      reason: String.raw`hex escape \x1b (ESC)`,
+    },
   ];
 
   for (const { value, reason } of identityOnlyRejects) {
     const uiRejects = hasDangerousChars(value);
     const errors: string[] = [];
-    validateFieldForDangerousPatterns(value, 'test', errors);
+    validateFieldForDangerousPatterns(value, "test", errors);
     const identityRejects = errors.length > 0;
 
     // hasDangerousChars does NOT reject (all bytes are printable)
     assert.strictEqual(uiRejects, false, `hasDangerousChars allows: ${reason}`);
     // validateFieldForDangerousPatterns DOES reject (text-level pattern detection)
-    assert.strictEqual(identityRejects, true, `validateFieldForDangerousPatterns catches: ${reason}`);
+    assert.strictEqual(
+      identityRejects,
+      true,
+      `validateFieldForDangerousPatterns catches: ${reason}`,
+    );
   }
 
   // Category 2b: validateFieldForDangerousPatterns boundary values
   {
     const errors: string[] = [];
-    validateFieldForDangerousPatterns(undefined, 'test', errors);
-    assert.strictEqual(errors.length, 0, 'undefined should produce no errors');
+    validateFieldForDangerousPatterns(undefined, "test", errors);
+    assert.strictEqual(errors.length, 0, "undefined should produce no errors");
   }
   {
     const errors: string[] = [];
-    validateFieldForDangerousPatterns('', 'test', errors);
-    assert.strictEqual(errors.length, 0, 'empty string should produce no errors');
+    validateFieldForDangerousPatterns("", "test", errors);
+    assert.strictEqual(
+      errors.length,
+      0,
+      "empty string should produce no errors",
+    );
   }
 
   // Category 3: Inputs accepted by BOTH layers
   const bothAccept = [
-    { value: 'John Doe', reason: 'simple ASCII name' },
-    { value: '田中太郎', reason: 'Japanese name' },
-    { value: 'Null;Variant', reason: 'semicolon in name' },
-    { value: "O'Brien", reason: 'single quote in name' },
-    { value: 'José García', reason: 'accented characters' },
-    { value: 'Müller', reason: 'umlaut' },
+    { value: "John Doe", reason: "simple ASCII name" },
+    { value: "田中太郎", reason: "Japanese name" },
+    { value: "Null;Variant", reason: "semicolon in name" },
+    { value: "O'Brien", reason: "single quote in name" },
+    { value: "José García", reason: "accented characters" },
+    { value: "Müller", reason: "umlaut" },
   ];
 
   for (const { value, reason } of bothAccept) {
     const uiRejects = hasDangerousChars(value);
     const errors: string[] = [];
-    validateFieldForDangerousPatterns(value, 'test', errors);
+    validateFieldForDangerousPatterns(value, "test", errors);
     const identityRejects = errors.length > 0;
 
-    assert.strictEqual(uiRejects, false, `hasDangerousChars should accept: ${reason}`);
-    assert.strictEqual(identityRejects, false, `validateFieldForDangerousPatterns should accept: ${reason}`);
+    assert.strictEqual(
+      uiRejects,
+      false,
+      `hasDangerousChars should accept: ${reason}`,
+    );
+    assert.strictEqual(
+      identityRejects,
+      false,
+      `validateFieldForDangerousPatterns should accept: ${reason}`,
+    );
   }
 
   // Category 4: validateIdentity integration — control characters in name are now caught
   {
     const controlCharName: Identity = {
-      id: 'test',
-      name: 'Test\u0007User',
-      email: 'test@example.com',
+      id: "test",
+      name: "Test\u0007User",
+      email: "test@example.com",
     };
     const result = validateIdentity(controlCharName);
-    assert.strictEqual(result.valid, false, 'Control character in name should fail');
+    assert.strictEqual(
+      result.valid,
+      false,
+      "Control character in name should fail",
+    );
     assert.ok(
-      result.errors.some(e => e.includes('name') && e.includes('control characters')),
-      'Error should mention control characters'
+      result.errors.some(
+        (e) => e.includes("name") && e.includes("control characters"),
+      ),
+      "Error should mention control characters",
     );
   }
 
-  console.log('✅ All validation consistency tests passed!');
+  console.log("✅ All validation consistency tests passed!");
 }
 
 /**
  * Run all tests
  */
 export function runSecurityTests(): void {
-  console.log('\n=== Security Validation Tests ===\n');
+  console.log("\n=== Security Validation Tests ===\n");
 
   try {
     testValidateIdentity();
@@ -504,9 +711,9 @@ export function runSecurityTests(): void {
     testIsPathSafe();
     testValidationConsistency();
 
-    console.log('\n✅ All security tests passed!\n');
+    console.log("\n✅ All security tests passed!\n");
   } catch (error) {
-    console.error('\n❌ Test failed:', error);
+    console.error("\n❌ Test failed:", error);
     process.exit(1);
   }
 }

--- a/extensions/git-id-switcher/src/ui/documentationInternal.ts
+++ b/extensions/git-id-switcher/src/ui/documentationInternal.ts
@@ -33,7 +33,7 @@ export const DOCUMENT_HASHES: Record<string, string> = {
   'AGENTS.md': 'c4918e12fd7900bfc41e708992ebc4b7326600ce9327e8020a986fe4dd807f8d',
   'CODE_OF_CONDUCT.md': 'a0e9cb2e004663cdedef4e1adc0e429417ccfc479e367cbc17b869f62ae759d2',
   'CONTRIBUTING.md': 'ed4d1f391ffe04e3031dfc9f16fd8fd5dcd54ba23af3b3202c07adac5ba23da7',
-  'extensions/git-id-switcher/CHANGELOG.md': 'df6ccd555473bdab19e6e3b278af41d32f9827ea0284655f2913e4c51d7f87cf',
+  'extensions/git-id-switcher/CHANGELOG.md': 'a3f912342c9ce3685deb38861bed54204d3dc7e533450a9dccde40fcf0f700b8',
   'extensions/git-id-switcher/docs/ARCHITECTURE.md': 'd5d879d988054d208739497962a0f937f2f21bdaab51776c4e8363cba99d634c',
   'extensions/git-id-switcher/docs/CONTRIBUTING.md': '7d6ad2bc4d8c838790754cb9df848cb65f9fdce7e1a13e5c965b83a3d5b6378c',
   'extensions/git-id-switcher/docs/DESIGN_PHILOSOPHY.md': 'f9718b61ac161cb466dbc76845688e7acacf4e5fdc4b8b9553269dba4a094f6b',

--- a/extensions/git-id-switcher/src/ui/identityFormValidation.ts
+++ b/extensions/git-id-switcher/src/ui/identityFormValidation.ts
@@ -8,27 +8,22 @@
  * @module ui/identityFormValidation
  */
 
-import type { VSCodeAPI } from './identityFormUtils';
+import type { VSCodeAPI } from "./identityFormUtils";
 import {
   type Identity,
   getIdentities,
   getFieldMetadata,
-} from '../identity/identity';
-import {
-  MAX_ID_LENGTH,
-  MAX_NAME_LENGTH,
-} from '../core/constants';
-import {
-  isValidIdentityId,
-} from '../validators/common';
+} from "../identity/identity";
+import { MAX_ID_LENGTH, MAX_NAME_LENGTH } from "../core/constants";
+import { isValidIdentityId } from "../validators/common";
 import {
   validateSshKeyPathFormat,
   validateFieldForDangerousPatterns,
   validateEmailField,
   validateGpgKeyId,
   validateSshHost,
-} from '../identity/inputValidator';
-import { isUnderSshDirectory } from '../security/pathUtils';
+} from "../identity/inputValidator";
+import { isUnderSshDirectory } from "../security/pathUtils";
 
 // ============================================================================
 // Constants
@@ -36,8 +31,12 @@ import { isUnderSshDirectory } from '../security/pathUtils';
 
 /** Optional fields that can be cleared */
 export const OPTIONAL_FIELDS: ReadonlySet<keyof Identity> = new Set([
-  'service', 'icon', 'description',
-  'sshKeyPath', 'sshHost', 'gpgKeyId',
+  "service",
+  "icon",
+  "description",
+  "sshKeyPath",
+  "sshHost",
+  "gpgKeyId",
 ]);
 
 // ============================================================================
@@ -72,19 +71,19 @@ export function isOptionalField(field: keyof Identity): boolean {
 export function validateIdInput(
   vs: VSCodeAPI,
   value: string,
-  existingIds: Set<string>
+  existingIds: Set<string>,
 ): string | null {
   if (!value) {
-    return vs.l10n.t('ID cannot be empty');
+    return vs.l10n.t("ID cannot be empty");
   }
   if (!isValidIdentityId(value, MAX_ID_LENGTH)) {
     return vs.l10n.t(
-      'ID must be 1-{0} alphanumeric characters, underscores, or hyphens',
-      MAX_ID_LENGTH
+      "ID must be 1-{0} alphanumeric characters, underscores, or hyphens",
+      MAX_ID_LENGTH,
     );
   }
   if (existingIds.has(value)) {
-    return vs.l10n.t('ID already exists');
+    return vs.l10n.t("ID already exists");
   }
   return null;
 }
@@ -101,16 +100,16 @@ export function validateIdInput(
  */
 function validateNameInput(vs: VSCodeAPI, value: string): string | null {
   if (!value || value.trim().length === 0) {
-    return vs.l10n.t('Name cannot be empty');
+    return vs.l10n.t("Name cannot be empty");
   }
   if (value.length > MAX_NAME_LENGTH) {
-    return vs.l10n.t('Name is too long (max {0} characters)', MAX_NAME_LENGTH);
+    return vs.l10n.t("Name is too long (max {0} characters)", MAX_NAME_LENGTH);
   }
   // SECURITY: Delegate to identity layer (SSoT for dangerous pattern detection)
   const errors: string[] = [];
-  validateFieldForDangerousPatterns(value, 'name', errors);
+  validateFieldForDangerousPatterns(value, "name", errors);
   if (errors.length > 0) {
-    return vs.l10n.t('Name contains invalid characters');
+    return vs.l10n.t("Name contains invalid characters");
   }
   return null;
 }
@@ -127,13 +126,13 @@ function validateNameInput(vs: VSCodeAPI, value: string): string | null {
  */
 function validateEmailInput(vs: VSCodeAPI, value: string): string | null {
   if (!value) {
-    return vs.l10n.t('Email cannot be empty');
+    return vs.l10n.t("Email cannot be empty");
   }
   // Delegate format and length validation to identity layer (SSoT)
   const errors: string[] = [];
   validateEmailField(value, errors);
   if (errors.length > 0) {
-    return vs.l10n.t('Invalid email format');
+    return vs.l10n.t("Invalid email format");
   }
   return null;
 }
@@ -151,14 +150,14 @@ function validateEmailInput(vs: VSCodeAPI, value: string): string | null {
 function validateSshKeyPathInput(vs: VSCodeAPI, value: string): string | null {
   if (!value) return null; // Optional field
   const errors: string[] = [];
-  // Reuse existing validator (Defense-in-depth)
+  // validateSshKeyPathFormat checks format: Windows paths, prefix (/ or ~), traversal, dangerous chars
   validateSshKeyPathFormat(value, errors);
   if (errors.length > 0) {
-    return vs.l10n.t('Invalid SSH key path format');
+    return errors[0];
   }
-  // Safety First: Also check that path is under ~/.ssh directory
+  // isUnderSshDirectory adds path-destination constraint (must be under ~/.ssh/)
   if (!isUnderSshDirectory(value)) {
-    return vs.l10n.t('SSH key path must be under ~/.ssh/ directory');
+    return vs.l10n.t("SSH key path must be under ~/.ssh/ directory");
   }
   return null;
 }
@@ -179,7 +178,7 @@ function validateGpgKeyIdInput(vs: VSCodeAPI, value: string): string | null {
   const errors: string[] = [];
   validateGpgKeyId(value, errors);
   if (errors.length > 0) {
-    return vs.l10n.t('GPG key ID must be 8-40 hexadecimal characters');
+    return vs.l10n.t("GPG key ID must be 8-40 hexadecimal characters");
   }
   return null;
 }
@@ -200,7 +199,7 @@ function validateSshHostInput(vs: VSCodeAPI, value: string): string | null {
   const errors: string[] = [];
   validateSshHost(value, errors);
   if (errors.length > 0) {
-    return vs.l10n.t('SSH host must contain only valid hostname characters');
+    return vs.l10n.t("SSH host must contain only valid hostname characters");
   }
   return null;
 }
@@ -224,36 +223,34 @@ export function validateFieldInput(
   field: keyof Identity,
   value: string,
   isOptional: boolean,
-  currentIdentityId?: string
+  currentIdentityId?: string,
 ): string | null {
   // Optional fields can be empty
-  if (isOptional && value.trim() === '') {
+  if (isOptional && value.trim() === "") {
     return null;
   }
 
   switch (field) {
-    case 'id': {
+    case "id": {
       const identities = getIdentities();
       const existingIds = new Set(
-        identities
-          .filter(i => i.id !== currentIdentityId)
-          .map(i => i.id)
+        identities.filter((i) => i.id !== currentIdentityId).map((i) => i.id),
       );
       return validateIdInput(vs, value, existingIds);
     }
-    case 'name': {
+    case "name": {
       return validateNameInput(vs, value);
     }
-    case 'email': {
+    case "email": {
       return validateEmailInput(vs, value);
     }
-    case 'sshKeyPath': {
+    case "sshKeyPath": {
       return validateSshKeyPathInput(vs, value);
     }
-    case 'gpgKeyId': {
+    case "gpgKeyId": {
       return validateGpgKeyIdInput(vs, value);
     }
-    case 'sshHost': {
+    case "sshHost": {
       return validateSshHostInput(vs, value);
     }
     default: {
@@ -261,12 +258,16 @@ export function validateFieldInput(
       const errors: string[] = [];
       validateFieldForDangerousPatterns(value, field, errors);
       if (errors.length > 0) {
-        return vs.l10n.t('{0} contains invalid characters', field);
+        return vs.l10n.t("{0} contains invalid characters", field);
       }
       // Length validation from FIELD_METADATA
       const meta = getFieldMetadata(field);
       if (meta?.maxLength && value.length > meta.maxLength) {
-        return vs.l10n.t('{0} is too long (max {1} characters)', field, meta.maxLength);
+        return vs.l10n.t(
+          "{0} is too long (max {1} characters)",
+          field,
+          meta.maxLength,
+        );
       }
       return null;
     }


### PR DESCRIPTION
## Summary

- Closes #492: Windows users entering drive letter paths (`C:/...` or `C:\...`) for SSH key paths now receive a clear error message guiding them to the cross-platform `~/.ssh/` format
- All validation layers (configSchema, UI field, settings load, runtime) consistently reject Windows absolute paths with actionable guidance
- Added localized error messages in all 17 supported languages

## Changes

### Bug fix
- `configSchema.ts`: Removed `[A-Za-z]:` from `sshKeyPath` pattern — Windows paths were accepted at schema level but rejected at runtime, causing confusing failures
- `inputValidator.ts`: Early detection of Windows drive letter paths with `~/.ssh/` guidance (previously accepted Windows paths)
- `identity.ts`: Added Layer 0 (Windows path detection) to `validateSshKeyPathForField` with defense-in-depth comment
- `sshAgent.ts`: Added Windows path detection to `expandPath` and `validateKeyPathOrThrow` with actionable error messages
- `identityFormValidation.ts`: Now shows the specific error message from `validateSshKeyPathFormat` instead of a generic "Invalid SSH key path format"

### Tests
- `validation.test.ts`: Added tests for Windows forward-slash (10a), backslash (10b), lowercase drive letter (10c), and `isShellSafePath` Windows path specification (Test 8/9)
- `configSchema.test.ts`: Updated tests 7.1/7.2 from pass→fail, added test 7.3 for forward-slash Windows paths

### Localization
- Added `"Invalid SSH key path: use ~/.ssh/ format (e.g., ~/.ssh/id_ed25519)"` to all 17 l10n bundles

## Test plan

- [x] `tsc --noEmit` passes
- [x] ESLint passes (changed files)
- [x] All tests pass
- [x] Statement coverage 100% maintained
- [x] Windows CI matrix (ubuntu, windows, macos) will validate cross-platform behavior