### PR TITLE
fix: replace fragile Awaited<ReturnType> type patterns with concrete types

### DIFF
--- a/extensions/git-id-switcher/src/ssh/sshAgent.ts
+++ b/extensions/git-id-switcher/src/ssh/sshAgent.ts
@@ -8,6 +8,8 @@
  * @see https://owasp.org/www-community/attacks/Command_Injection
  */
 
+import type { Stats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as vscode from "vscode";
@@ -505,7 +507,7 @@ export interface KeyFileValidationResult {
  * @returns true if the file has a valid SSH key header
  */
 async function validateSshKeyFormat(filePath: string): Promise<boolean> {
-  let fileHandle: Awaited<ReturnType<typeof fs.open>> | null = null;
+  let fileHandle: FileHandle | null = null;
   try {
     fileHandle = await fs.open(filePath, "r");
     const buffer = Buffer.alloc(FORMAT_CHECK_BYTES);
@@ -591,7 +593,7 @@ function handleFileStatError(error: unknown): KeyFileValidationResult {
  * @internal
  */
 function validateKeyFileType(
-  stats: Awaited<ReturnType<typeof fs.stat>>,
+  stats: Stats,
 ): KeyFileValidationResult | null {
   if (stats.isFile()) {
     return null; // Valid
@@ -698,7 +700,7 @@ async function validateKeyFileBeforeAddToAgent(
 ): Promise<KeyFileValidationResult> {
   try {
     // Get file stats
-    let stats: Awaited<ReturnType<typeof fs.stat>>;
+    let stats: Stats;
     try {
       stats = await fs.stat(expandedPath);
     } catch (error) {

--- a/extensions/git-id-switcher/src/test/sshKeyFormat.test.ts
+++ b/extensions/git-id-switcher/src/test/sshKeyFormat.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as assert from 'node:assert';
+import type { FileHandle } from 'node:fs/promises';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -48,7 +49,7 @@ async function cleanupTempDir(tmpDir: string): Promise<void> {
  * (Test implementation, matching sshAgent.ts logic)
  */
 async function isValidSshKeyFormat(filePath: string): Promise<boolean> {
-  let fileHandle: Awaited<ReturnType<typeof fs.open>> | null = null;
+  let fileHandle: FileHandle | null = null;
   try {
     fileHandle = await fs.open(filePath, 'r');
     const buffer = Buffer.alloc(64);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,9 +1579,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1905,9 +1905,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6937,9 +6937,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Replace `Awaited<ReturnType<typeof fs.stat>>` with concrete `Stats` type from `node:fs` to fix TS18048 compile errors caused by `@types/node` 25.9.0 adding a `throwIfNoEntry: false` overload
- Replace `Awaited<ReturnType<typeof fs.open>>` with concrete `FileHandle` type from `node:fs/promises` to prevent the same fragile pattern from breaking in future `@types/node` updates
- Unblocks PR #505 (dev-dependencies bump including `@types/node` 25.6→25.9)

## Test plan

- [x] `npx tsc --noEmit` passes with both `@types/node` 25.6.2 and 25.9.0
- [x] `npm run lint` passes
- [x] `npm run test:coverage` passes with 100% statement coverage maintained
- [x] Quality review completed (architect + security + test engineer + sergeant) — all clear