### PR TITLE
perf: pre-compile regex patterns at module load in configSchema

### DIFF
--- a/extensions/git-id-switcher/src/identity/configSchema.ts
+++ b/extensions/git-id-switcher/src/identity/configSchema.ts
@@ -37,6 +37,7 @@ interface PropertySchema {
   maxLength?: number;
   minLength?: number;
   pattern?: string;
+  compiledPattern?: RegExp;
   format?: "email" | "uri" | "date" | "hex" | "single-grapheme";
   minimum?: number;
   maximum?: number;
@@ -119,7 +120,14 @@ export const IDENTITY_SCHEMA: Record<string, PropertySchema> = {
     maxLength: MAX_GPG_KEY_LENGTH, // SHA-1 fingerprint length
     format: "hex",
   },
-} as const;
+};
+
+// Pre-compile all regex patterns at module load to avoid per-validation RegExp instantiation
+for (const schema of Object.values(IDENTITY_SCHEMA)) {
+  if (schema.pattern) {
+    schema.compiledPattern = new RegExp(schema.pattern);
+  }
+}
 
 /**
  * Schema validation result
@@ -165,34 +173,22 @@ function validateStringLength(
 }
 
 /**
- * Validate string pattern constraint.
+ * Validate string pattern constraint using pre-compiled RegExp.
  * @internal
  */
 function validateStringPattern(
   field: string,
   value: string,
-  pattern: string,
+  compiledPattern: RegExp,
   errors: SchemaError[],
 ): void {
-  try {
-    const regex = new RegExp(pattern);
-    if (!regex.test(value)) {
-      errors.push({
-        field,
-        message: `Does not match required pattern`,
-        value,
-      });
-    }
-    /* c8 ignore start: defensive - schema patterns are hardcoded valid */
-  } catch {
-    // SECURITY: Invalid regex pattern in schema is a programming error
+  if (!compiledPattern.test(value)) {
     errors.push({
       field,
-      message: "Invalid validation pattern (internal error)",
-      value: undefined,
+      message: `Does not match required pattern`,
+      value,
     });
   }
-  /* c8 ignore stop */
 }
 
 /**
@@ -231,8 +227,8 @@ function validateStringValue(
   errors: SchemaError[],
 ): void {
   validateStringLength(field, value, schema, errors);
-  if (schema.pattern) {
-    validateStringPattern(field, value, schema.pattern, errors);
+  if (schema.compiledPattern) {
+    validateStringPattern(field, value, schema.compiledPattern, errors);
   }
   if (schema.format) {
     validateStringFormat(field, value, schema.format, errors);

--- a/extensions/git-id-switcher/src/test/configSchema.test.ts
+++ b/extensions/git-id-switcher/src/test/configSchema.test.ts
@@ -875,6 +875,23 @@ function testIdentitySchemaStructure(): void {
     }
   }
 
+  // Test 5: Fields with patterns should have pre-compiled RegExp
+  {
+    for (const [field, schema] of Object.entries(IDENTITY_SCHEMA)) {
+      if (schema.pattern) {
+        assert.ok(
+          schema.compiledPattern instanceof RegExp,
+          `${field} should have compiledPattern as RegExp`,
+        );
+        assert.strictEqual(
+          schema.compiledPattern?.source,
+          new RegExp(schema.pattern).source,
+          `${field} compiledPattern should match pattern source`,
+        );
+      }
+    }
+  }
+
   console.log("  IDENTITY_SCHEMA structure tests passed!");
 }
 


### PR DESCRIPTION
## Summary

- Pre-compile all `IDENTITY_SCHEMA` regex patterns once at module load into a new `compiledPattern` field on `PropertySchema`, eliminating per-call `new RegExp()` instantiation in `validateStringPattern`
- Remove the now-unnecessary try/catch (invalid patterns fail fast at module startup instead of silently at validation time)
- Remove inert `as const` assertion that contradicted immediate mutation of the schema object
- Add direct test verifying `compiledPattern` population matches `pattern` source

## Test plan

- [x] TypeScript compile passes (`npx tsc --noEmit`)
- [x] ESLint passes with `--max-warnings=0`
- [x] All existing tests pass (no regressions in pattern validation behavior)
- [x] Statement coverage 100% maintained (`configSchema.ts` Stmts/Branch/Funcs/Lines all 100%)
- [x] New test verifies `compiledPattern instanceof RegExp` and `source` match for all pattern-bearing fields