### PR TITLE
fix(security): align FIELD_METADATA validator strictness with configSchema patterns

### DIFF
--- a/extensions/git-id-switcher/src/identity/configSchema.ts
+++ b/extensions/git-id-switcher/src/identity/configSchema.ts
@@ -62,6 +62,8 @@ export const IDENTITY_SCHEMA: Record<string, PropertySchema> = {
     description: "Display emoji (single emoji character)",
     maxLength: MAX_ICON_BYTE_LENGTH, // Allow for complex composed emoji (byte length)
     format: "single-grapheme", // Validate as single visible character
+    // defense-in-depth: block control chars at schema layer too
+    pattern: "^[^\\x00-\\x1f\\x7f`$]+$",
   },
   name: {
     type: "string",
@@ -127,7 +129,9 @@ for (const schema of Object.values(IDENTITY_SCHEMA)) {
   if (schema.pattern) {
     schema.compiledPattern = new RegExp(schema.pattern);
   }
+  Object.freeze(schema);
 }
+Object.freeze(IDENTITY_SCHEMA);
 
 /**
  * Schema validation result

--- a/extensions/git-id-switcher/src/identity/identity.ts
+++ b/extensions/git-id-switcher/src/identity/identity.ts
@@ -26,6 +26,7 @@ import {
   isValidSshHost,
   isValidGpgKeyId,
   hasPathTraversal,
+  hasDangerousChars,
   hasDangerousCharsForPath,
   hasDangerousCharsForText,
   isWindowsAbsolutePath,
@@ -243,8 +244,9 @@ export const FIELD_METADATA: ReadonlyArray<FieldMetadata> = [
     inputType: "text",
     icon: "person",
     maxLength: MAX_NAME_LENGTH,
+    // strict: configSchema name pattern blocks (){}|&<> unlike service/description
     validator: (value: string) =>
-      hasDangerousCharsForText(value)
+      hasDangerousChars(value)
         ? "Name contains invalid characters"
         : undefined,
   },

--- a/extensions/git-id-switcher/src/identity/inputValidator.ts
+++ b/extensions/git-id-switcher/src/identity/inputValidator.ts
@@ -14,9 +14,11 @@ import {
   hasPathTraversal,
   isValidIdentityId,
   hasDangerousChars,
+  hasDangerousCharsForText,
   GPG_KEY_REGEX,
   SSH_HOST_REGEX,
   DANGEROUS_PATTERNS,
+  DANGEROUS_PATTERNS_FOR_TEXT,
   isWindowsAbsolutePath,
 } from "../validators/common";
 import {
@@ -35,16 +37,15 @@ export interface ValidationResult {
 }
 
 /**
- * Validate a string field for dangerous command injection patterns.
+ * Validate a string field for dangerous command injection patterns (strict).
  *
  * Checks both hasDangerousChars() (SAFE_TEXT_REGEX — catches control characters
  * and shell metacharacters) and DANGEROUS_PATTERNS (catches literal hex escape
- * sequences like `\x00` in text). This ensures consistency with UI-layer
- * validation while retaining detection of text-level injection patterns.
+ * sequences like `\x00` in text).
  *
- * @param value - The field value to validate
- * @param fieldName - The name of the field (for error messages)
- * @param errors - Array to accumulate validation errors
+ * Use for fields where shell metacharacters like |&<>(){} must be blocked
+ * (e.g., name, email). For fields that allow these characters (service,
+ * description, icon), use validateTextFieldForDangerousPatterns instead.
  */
 export function validateFieldForDangerousPatterns(
   value: string | undefined,
@@ -55,8 +56,6 @@ export function validateFieldForDangerousPatterns(
     return;
   }
 
-  // Check DANGEROUS_PATTERNS first for specific error messages
-  // (includes hex escape sequence detection that SAFE_TEXT_REGEX doesn't cover)
   for (const { pattern, description } of DANGEROUS_PATTERNS) {
     if (pattern.test(value)) {
       errors.push(`${fieldName} contains ${description}`);
@@ -64,9 +63,38 @@ export function validateFieldForDangerousPatterns(
     }
   }
 
-  // Also check hasDangerousChars (SAFE_TEXT_REGEX) for control characters
-  // not covered by DANGEROUS_PATTERNS (e.g., 0x02-0x09, 0x7F)
   if (hasDangerousChars(value)) {
+    errors.push(`${fieldName} contains control characters`);
+  }
+}
+
+/**
+ * Validate a text field for dangerous patterns (relaxed).
+ *
+ * Only blocks command substitution characters (backtick, dollar sign),
+ * newlines, hex escapes, null bytes, and control characters.
+ * Allows shell metacharacters like |&<>(){} that may appear in
+ * service names (e.g., "AT&T") or descriptions.
+ *
+ * Aligned with configSchema patterns for service/description fields.
+ */
+export function validateTextFieldForDangerousPatterns(
+  value: string | undefined,
+  fieldName: string,
+  errors: string[],
+): void {
+  if (!value) {
+    return;
+  }
+
+  for (const { pattern, description } of DANGEROUS_PATTERNS_FOR_TEXT) {
+    if (pattern.test(value)) {
+      errors.push(`${fieldName} contains ${description}`);
+      return;
+    }
+  }
+
+  if (hasDangerousCharsForText(value)) {
     errors.push(`${fieldName} contains control characters`);
   }
 }
@@ -231,15 +259,17 @@ export function validateIdentity(identity: Identity): ValidationResult {
   }
 
   // Text field validation (dangerous patterns)
+  // name/email: strict — blocks all shell metacharacters (aligned with configSchema name pattern)
   validateFieldForDangerousPatterns(identity.name, "name", errors);
   validateFieldForDangerousPatterns(identity.email, "email", errors);
-  validateFieldForDangerousPatterns(identity.service, "service", errors);
-  validateFieldForDangerousPatterns(
+  // service/description/icon: relaxed — allows |&<>(){} (aligned with configSchema service/description patterns)
+  validateTextFieldForDangerousPatterns(identity.service, "service", errors);
+  validateTextFieldForDangerousPatterns(
     identity.description,
     "description",
     errors,
   );
-  validateFieldForDangerousPatterns(identity.icon, "icon", errors);
+  validateTextFieldForDangerousPatterns(identity.icon, "icon", errors);
 
   // Format-specific validation
   validateEmailField(identity.email, errors);

--- a/extensions/git-id-switcher/src/ssh/sshAgent.ts
+++ b/extensions/git-id-switcher/src/ssh/sshAgent.ts
@@ -146,7 +146,7 @@ export interface SshKeyInfo {
  * @throws Error if path is invalid or insecure
  */
 function expandPath(keyPath: string): string {
-  // defense-in-depth: called directly by keyFileExists without validateKeyPathOrThrow
+  // defense-in-depth: expandPath retains its own validation as a second layer
   if (isWindowsAbsolutePath(keyPath)) {
     throw createSecurityViolationError(
       vscode.l10n.t(
@@ -472,6 +472,7 @@ export async function getKeyFingerprint(
  * Check if SSH key file exists
  */
 export async function keyFileExists(keyPath: string): Promise<boolean> {
+  validateKeyPathOrThrow(keyPath);
   const expandedPath = expandPath(keyPath);
 
   try {

--- a/extensions/git-id-switcher/src/test/configSchema.test.ts
+++ b/extensions/git-id-switcher/src/test/configSchema.test.ts
@@ -892,6 +892,59 @@ function testIdentitySchemaStructure(): void {
     }
   }
 
+  // Test 6: Expected fields must have pattern defined
+  {
+    const fieldsRequiringPattern = [
+      "id",
+      "name",
+      "service",
+      "description",
+      "sshKeyPath",
+      "sshHost",
+      "icon",
+    ];
+    for (const field of fieldsRequiringPattern) {
+      assert.ok(
+        IDENTITY_SCHEMA[field].pattern,
+        `${field} must have a pattern defined for input validation`,
+      );
+    }
+  }
+
+  // Test 7: Fields without pattern should not accidentally gain one
+  {
+    const fieldsWithoutPattern = ["email", "gpgKeyId"];
+    for (const field of fieldsWithoutPattern) {
+      assert.strictEqual(
+        IDENTITY_SCHEMA[field].pattern,
+        undefined,
+        `${field} should use format-based validation, not pattern`,
+      );
+    }
+  }
+
+  // Test 8: name pattern should allow semicolons (e.g., "Null;Variant")
+  {
+    const namePattern = new RegExp(IDENTITY_SCHEMA["name"].pattern!);
+    assert.ok(
+      namePattern.test("Null;Variant"),
+      "name pattern should allow semicolons for names like Null;Variant",
+    );
+  }
+
+  // Test 9: name pattern should block shell metacharacters
+  {
+    const namePattern = new RegExp(IDENTITY_SCHEMA["name"].pattern!);
+    const blockedChars = ["`", "$", "(", ")", "{", "}", "|", "&", "<", ">"];
+    for (const char of blockedChars) {
+      assert.strictEqual(
+        namePattern.test(`Test${char}Name`),
+        false,
+        `name pattern should block "${char}"`,
+      );
+    }
+  }
+
   console.log("  IDENTITY_SCHEMA structure tests passed!");
 }
 

--- a/extensions/git-id-switcher/src/test/e2e/identityManager.test.ts
+++ b/extensions/git-id-switcher/src/test/e2e/identityManager.test.ts
@@ -3336,7 +3336,7 @@ describe("identityManager E2E Test Suite", function () {
   });
 
   describe("Security: Field-specific Dangerous Character Detection", () => {
-    describe("name field: hasDangerousCharsForText() allows semicolon", () => {
+    describe("name field: hasDangerousChars() allows semicolon", () => {
       it("should accept name with semicolon (Null;Variant)", async () => {
         const mockVSCode = createMockVSCode({
           identities: [TEST_IDENTITIES.work],

--- a/extensions/git-id-switcher/src/test/validation.test.ts
+++ b/extensions/git-id-switcher/src/test/validation.test.ts
@@ -10,6 +10,7 @@ import {
   validateIdentities,
   isShellSafePath,
   validateFieldForDangerousPatterns,
+  validateTextFieldForDangerousPatterns,
 } from "../identity/inputValidator";
 import { hasDangerousChars } from "../validators/common";
 import { Identity } from "../identity/identity";
@@ -416,6 +417,40 @@ function testValidateIdentity(): void {
     );
   }
 
+  // Test 22: ID at exact max length (64) should pass
+  {
+    const maxLengthId: Identity = {
+      id: "a".repeat(64), // exactly 64 chars
+      name: "Test User",
+      email: "test@example.com",
+    };
+    const result = validateIdentity(maxLengthId);
+    assert.strictEqual(
+      result.valid,
+      true,
+      "ID at exact max length (64) should pass",
+    );
+  }
+
+  // Test 23: ID exceeding max length (64) should fail
+  {
+    const longId: Identity = {
+      id: "a".repeat(65), // > 64 chars
+      name: "Test User",
+      email: "test@example.com",
+    };
+    const result = validateIdentity(longId);
+    assert.strictEqual(
+      result.valid,
+      false,
+      "ID exceeding max length should fail",
+    );
+    assert.ok(
+      result.errors.some((e) => e.includes("id") && e.includes("64")),
+      "Error should mention id max length 64",
+    );
+  }
+
   console.log("✅ All validateIdentity tests passed!");
 }
 
@@ -453,6 +488,10 @@ function testValidateIdentities(): void {
     ];
     const result = validateIdentities(duplicates);
     assert.strictEqual(result.valid, false, "Duplicate IDs should fail");
+    assert.ok(
+      result.errors.some((e) => e.includes("Duplicate")),
+      "Error should mention duplicate IDs",
+    );
   }
 
   // Test 4: One invalid identity should fail the whole array
@@ -700,6 +739,113 @@ function testValidationConsistency(): void {
 }
 
 /**
+ * Test suite for validateTextFieldForDangerousPatterns (relaxed mode)
+ */
+function testValidateTextFieldForDangerousPatterns(): void {
+  console.log("Testing validateTextFieldForDangerousPatterns...");
+
+  // Test 1: Command substitution should be rejected
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns("test$(cmd)", "service", errors);
+    assert.ok(errors.length > 0, "Command substitution should be rejected");
+    assert.ok(
+      errors.some((e) => e.includes("command substitution")),
+      "Error should mention command substitution",
+    );
+  }
+
+  // Test 2: Backtick should be rejected
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns("test`id`", "service", errors);
+    assert.ok(errors.length > 0, "Backtick should be rejected");
+    assert.ok(
+      errors.some((e) => e.includes("command substitution")),
+      "Error should mention command substitution",
+    );
+  }
+
+  // Test 3: Shell metacharacters should be allowed (relaxed mode)
+  {
+    const allowedChars = [
+      { value: "AT&T", reason: "ampersand in company name" },
+      { value: "A|B", reason: "pipe in text" },
+      { value: "<main>", reason: "angle brackets in description" },
+      { value: "func()", reason: "parentheses in text" },
+      { value: "{key}", reason: "braces in text" },
+    ];
+    for (const { value, reason } of allowedChars) {
+      const errors: string[] = [];
+      validateTextFieldForDangerousPatterns(value, "service", errors);
+      assert.strictEqual(
+        errors.length,
+        0,
+        `Relaxed mode should allow: ${reason}`,
+      );
+    }
+  }
+
+  // Test 4: Control characters should be rejected via hasDangerousCharsForText
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns("test\u0007bell", "service", errors);
+    assert.ok(errors.length > 0, "Control characters should be rejected");
+    assert.ok(
+      errors.some((e) => e.includes("control characters")),
+      "Error should specifically mention control characters",
+    );
+  }
+
+  // Test 5: Hex escape sequences should be rejected
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns(
+      String.raw`test\x00user`,
+      "service",
+      errors,
+    );
+    assert.ok(errors.length > 0, "Hex escape sequences should be rejected");
+  }
+
+  // Test 6: Newline characters should be rejected
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns("line1\nline2", "service", errors);
+    assert.ok(errors.length > 0, "Newline should be rejected");
+    assert.ok(
+      errors.some((e) => e.includes("newline")),
+      "Error should mention newline characters",
+    );
+  }
+
+  // Test 7: Null byte should be rejected
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns("test\0user", "service", errors);
+    assert.ok(errors.length > 0, "Null byte should be rejected");
+  }
+
+  // Test 8: Boundary values
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns(undefined, "service", errors);
+    assert.strictEqual(errors.length, 0, "undefined should produce no errors");
+  }
+  {
+    const errors: string[] = [];
+    validateTextFieldForDangerousPatterns("", "service", errors);
+    assert.strictEqual(
+      errors.length,
+      0,
+      "empty string should produce no errors",
+    );
+  }
+
+  console.log("✅ All validateTextFieldForDangerousPatterns tests passed!");
+}
+
+/**
  * Run all tests
  */
 export function runSecurityTests(): void {
@@ -710,6 +856,7 @@ export function runSecurityTests(): void {
     testValidateIdentities();
     testIsPathSafe();
     testValidationConsistency();
+    testValidateTextFieldForDangerousPatterns();
 
     console.log("\n✅ All security tests passed!\n");
   } catch (error) {

--- a/extensions/git-id-switcher/src/test/validatorsCommon.test.ts
+++ b/extensions/git-id-switcher/src/test/validatorsCommon.test.ts
@@ -420,6 +420,10 @@ function testHasDangerousCharsForText(): void {
   assert.strictEqual(hasDangerousCharsForText('hello-world_123'), false, 'Alphanumeric with hyphen/underscore should be safe');
   assert.strictEqual(hasDangerousCharsForText('user@example.com'), false, 'Email format should be safe');
 
+  // Control characters should be dangerous (aligned with configSchema service/description patterns)
+  assert.strictEqual(hasDangerousCharsForText('\u0001hello'), true, 'SOH control char should be dangerous');
+  assert.strictEqual(hasDangerousCharsForText('hello\u007F'), true, 'DEL should be dangerous');
+
   // Verify regex constant exists
   assert.ok(DANGEROUS_CHARS_FOR_TEXT_REGEX instanceof RegExp, 'DANGEROUS_CHARS_FOR_TEXT_REGEX should be a RegExp');
 

--- a/extensions/git-id-switcher/src/validators/common.ts
+++ b/extensions/git-id-switcher/src/validators/common.ts
@@ -397,6 +397,26 @@ export const DANGEROUS_PATTERNS: ReadonlyArray<{ pattern: RegExp; description: s
 ] as const;
 
 /**
+ * Dangerous character patterns for text fields (relaxed mode)
+ *
+ * Only blocks command substitution characters (backtick, dollar sign),
+ * newlines, hex escapes, and null bytes. Allows shell metacharacters
+ * like pipe, ampersand, angle brackets that may appear in service names
+ * (e.g., "AT&T") or descriptions.
+ *
+ * Aligned with configSchema patterns for service/description fields.
+ *
+ * Note: For simple boolean check, use hasDangerousCharsForText() instead.
+ * This array is for cases where you need specific error messages.
+ */
+export const DANGEROUS_PATTERNS_FOR_TEXT: ReadonlyArray<{ pattern: RegExp; description: string }> = [
+  { pattern: /[`$]/, description: 'command substitution characters' },
+  { pattern: /[\n\r]/, description: 'newline characters' },
+  { pattern: /\\x[0-9a-f]{2}/i, description: 'hex escape sequences' },
+  { pattern: /\0/, description: 'null bytes' },
+] as const;
+
+/**
  * Check if text contains dangerous characters
  *
  * Uses SAFE_TEXT_REGEX for efficient single-pass validation.
@@ -435,7 +455,8 @@ export const DANGEROUS_CHARS_FOR_PATH_REGEX = /[`$|;&<>]/;
 /**
  * Pattern for dangerous characters in text fields (relaxed mode)
  *
- * Only blocks command substitution characters:
+ * Blocks:
+ * - Control characters: \x00-\x1f, \x7f
  * - Backtick (`): Command substitution
  * - Dollar sign ($): Variable expansion / command substitution
  *
@@ -444,8 +465,11 @@ export const DANGEROUS_CHARS_FOR_PATH_REGEX = /[`$|;&<>]/;
  * - Pipe (|): May appear in descriptions
  * - Ampersand (&): May appear in company names like "AT&T"
  * - Angle brackets (<>): May appear in descriptions
+ *
+ * Aligned with configSchema patterns for service/description fields.
  */
-export const DANGEROUS_CHARS_FOR_TEXT_REGEX = /[`$]/;
+// eslint-disable-next-line no-control-regex
+export const DANGEROUS_CHARS_FOR_TEXT_REGEX = /[\u0000-\u001F\u007F`$]/;
 
 /**
  * Check for dangerous characters in file paths (strict mode)
@@ -463,9 +487,9 @@ export function hasDangerousCharsForPath(value: string): boolean {
 /**
  * Check for dangerous characters in text fields (relaxed mode)
  *
- * Only blocks command substitution characters, allows semicolons and other
- * characters that may legitimately appear in names and descriptions.
- * Use this for name, service, description, and icon fields.
+ * Only blocks command substitution characters and control characters, allows
+ * semicolons and other characters that may legitimately appear in descriptions.
+ * Use this for service, description, and icon fields.
  *
  * @param value - The text string to check
  * @returns true if text contains dangerous characters


### PR DESCRIPTION
## Summary

- Align UI-layer validators (FIELD_METADATA) with configSchema patterns so control characters and shell metacharacters are blocked consistently across all three validation layers (FIELD_METADATA, inputValidator, configSchema)
- Add `validateTextFieldForDangerousPatterns()` relaxed validation for service/description/icon fields that allows `|&<>(){}` while blocking command substitution and control characters
- Add `validateKeyPathOrThrow()` to `keyFileExists()` for defense-in-depth consistency with other public SSH functions
- Freeze `IDENTITY_SCHEMA` after regex pre-compilation to prevent runtime tampering
- Add icon field pattern to configSchema for defense-in-depth control character blocking

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] ESLint passes with zero warnings (`npx eslint --max-warnings=0 src/`)
- [x] All tests pass with 100% statement coverage (`npm run test:coverage`)
- [x] New tests: configSchema field pattern assertions (Test 6-9), id maxLength boundary values (Test 22-23), duplicate ID error message verification, `validateTextFieldForDangerousPatterns` suite (8 tests), control character detection tests